### PR TITLE
feature: Persist high score via localStorage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,13 @@ import { createSfxController, type SfxName } from "./audio/sfx";
 import { createInitialGameState, type GameState, type Input } from "./game/state";
 import { step } from "./game/step";
 import { createKeyboardController } from "./input/keyboard";
-import { createCanvasRenderer } from "./render/canvas";
+import { createHighScoreStore } from "./persistence";
+import { createCanvasRenderer, type CanvasRenderer } from "./render/canvas";
 
 const FIXED_TIMESTEP_MS = 1000 / 60;
+type RuntimeRenderFlags = Parameters<CanvasRenderer["render"]>[1] & {
+  highScore: number;
+};
 
 const canvas = document.querySelector<HTMLCanvasElement>("#game");
 
@@ -15,14 +19,16 @@ if (canvas === null) {
 const renderer = createRenderer(canvas);
 const keyboard = createKeyboardController(window);
 const sfx = createSfxController();
+const highScoreStore = createHighScoreStore();
 
 let state = createInitialGameState();
 let previousTimestamp = performance.now();
 let accumulator = 0;
 let bootstrapping = true;
 let audioAttempted = false;
+let highScore = highScoreStore.getHighScore();
 
-renderer.render(state, { bootstrapping, muted: false });
+renderer.render(state, createRenderFlags(false));
 bootstrapping = false;
 
 window.addEventListener("beforeunload", () => {
@@ -50,15 +56,13 @@ function loop(timestamp: number): void {
         };
     const previousState = state;
     state = step(state, FIXED_TIMESTEP_MS, stepInput);
+    highScore = maybeRecordHighScore(previousState, state);
     playDerivedEvents(previousState, state);
     accumulator -= FIXED_TIMESTEP_MS;
     firstStep = false;
   }
 
-  renderer.render(state, {
-    bootstrapping,
-    muted: sfx.getStatus() === "muted"
-  });
+  renderer.render(state, createRenderFlags(sfx.getStatus() === "muted"));
 
   requestAnimationFrame(loop);
 }
@@ -109,6 +113,25 @@ function playDerivedEvents(previousState: GameState, nextState: GameState): void
   for (const event of events) {
     sfx.play(event);
   }
+}
+
+function maybeRecordHighScore(
+  previousState: GameState,
+  nextState: GameState
+): number {
+  if (previousState.phase === "gameOver" || nextState.phase !== "gameOver") {
+    return highScore;
+  }
+
+  return highScoreStore.recordScore(nextState.hud.score);
+}
+
+function createRenderFlags(muted: boolean): RuntimeRenderFlags {
+  return {
+    bootstrapping,
+    muted,
+    highScore
+  };
 }
 
 function renderFallback(title: string, detail: string): void {

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { createHighScoreStore } from "./persistence";
+
+const HIGH_SCORE_STORAGE_KEY = "space-invaders-hd.highScore";
+
+class FakeStorage implements Storage {
+  private readonly entries = new Map<string, string>();
+
+  public throwOnGet = false;
+  public throwOnSet = false;
+
+  get length(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  getItem(key: string): string | null {
+    if (this.throwOnGet) {
+      throw new Error("getItem failed");
+    }
+
+    return this.entries.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.entries.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.entries.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.throwOnSet) {
+      throw new Error("setItem failed");
+    }
+
+    this.entries.set(key, value);
+  }
+
+  seed(key: string, value: string): void {
+    this.entries.set(key, value);
+  }
+}
+
+describe("createHighScoreStore", () => {
+  it("returns 0 when storage is empty", () => {
+    const store = createHighScoreStore(new FakeStorage());
+
+    expect(store.getHighScore()).toBe(0);
+  });
+
+  it("round-trips a recorded score through storage", () => {
+    const storage = new FakeStorage();
+    const firstStore = createHighScoreStore(storage);
+
+    expect(firstStore.recordScore(180)).toBe(180);
+
+    const secondStore = createHighScoreStore(storage);
+
+    expect(secondStore.getHighScore()).toBe(180);
+  });
+
+  it("ignores scores below the stored high score", () => {
+    const storage = new FakeStorage();
+    storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+    const store = createHighScoreStore(storage);
+
+    expect(store.recordScore(100)).toBe(220);
+    expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("220");
+  });
+
+  it("persists scores above the stored high score", () => {
+    const storage = new FakeStorage();
+    storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+    const store = createHighScoreStore(storage);
+
+    expect(store.recordScore(360)).toBe(360);
+    expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("360");
+  });
+
+  it.each(["not-a-number", "-5", "NaN"])(
+    "recovers from malformed stored value %s",
+    (storedValue) => {
+      const storage = new FakeStorage();
+      storage.seed(HIGH_SCORE_STORAGE_KEY, storedValue);
+      const store = createHighScoreStore(storage);
+
+      expect(store.getHighScore()).toBe(0);
+    }
+  );
+
+  it("swallows getItem failures", () => {
+    const storage = new FakeStorage();
+    storage.throwOnGet = true;
+    const store = createHighScoreStore(storage);
+
+    expect(store.getHighScore()).toBe(0);
+  });
+
+  it("swallows setItem failures", () => {
+    const storage = new FakeStorage();
+    storage.throwOnSet = true;
+    const store = createHighScoreStore(storage);
+
+    expect(store.recordScore(400)).toBe(400);
+    expect(store.getHighScore()).toBe(400);
+    expect(storage.key(0)).toBeNull();
+  });
+});

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,0 +1,92 @@
+const HIGH_SCORE_STORAGE_KEY = "space-invaders-hd.highScore";
+
+const fallbackStorage = createMemoryStorage();
+
+export type HighScoreStore = {
+  getHighScore: () => number;
+  recordScore: (score: number) => number;
+};
+
+export function createHighScoreStore(
+  storage: Storage = getDefaultStorage()
+): HighScoreStore {
+  let highScore = readStoredHighScore(storage);
+
+  return {
+    getHighScore: () => highScore,
+    recordScore: (score) => {
+      const nextHighScore = normalizeHighScore(score);
+
+      if (nextHighScore <= highScore) {
+        return highScore;
+      }
+
+      highScore = nextHighScore;
+      writeStoredHighScore(storage, nextHighScore);
+
+      return highScore;
+    }
+  };
+}
+
+function getDefaultStorage(): Storage {
+  try {
+    const storage = globalThis.localStorage;
+    return storage === undefined ? fallbackStorage : storage;
+  } catch {
+    return fallbackStorage;
+  }
+}
+
+function readStoredHighScore(storage: Storage): number {
+  try {
+    return normalizeStoredValue(storage.getItem(HIGH_SCORE_STORAGE_KEY));
+  } catch {
+    return 0;
+  }
+}
+
+function writeStoredHighScore(storage: Storage, score: number): void {
+  try {
+    storage.setItem(HIGH_SCORE_STORAGE_KEY, String(score));
+  } catch {
+    // Storage failures are non-fatal for gameplay.
+  }
+}
+
+function normalizeStoredValue(value: string | null): number {
+  if (value === null) {
+    return 0;
+  }
+
+  return normalizeHighScore(Number(value));
+}
+
+function normalizeHighScore(score: number): number {
+  return Number.isFinite(score) && score >= 0 ? score : 0;
+}
+
+function createMemoryStorage(): Storage {
+  const entries = new Map<string, string>();
+
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key) {
+      return entries.get(key) ?? null;
+    },
+    key(index) {
+      return [...entries.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      entries.delete(key);
+    },
+    setItem(key, value) {
+      entries.set(key, value);
+    }
+  };
+}


### PR DESCRIPTION
## Persist high score via localStorage

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #76

### Changes
Add src/persistence.ts exporting createHighScoreStore(storage?: Storage) that reads/writes a numeric high score under a stable key (e.g. 'space-invaders-hd.highScore'). API: getHighScore(): number, recordScore(score: number): number (returns the new high, persisting only if score exceeds the stored value). Handle missing/invalid values (non-numeric, negative, NaN) by treating the stored high as 0. Guard against SecurityError / QuotaExceededError from set/getItem by catching and no-op'ing (never throw to the caller). Allow injecting a Storage-compatible object for tests; default to globalThis.localStorage when available, otherwise an in-memory fallback so Node tests and SSR don't crash. Add src/persistence.test.ts with Vitest using a fake Storage mock — cover: read fresh (returns 0), write-then-read round trip, ignore lower scores, persist higher scores, malformed stored value recovers to 0, getItem throwing is swallowed, setItem throwing is swallowed. In src/main.ts, construct the store at boot, read the high score once, and record state.hud.score when it transitions into `gameOver` (only then, not every frame). Pass the current high score into the renderer via the existing RenderFlags object by extending it with a `highScore: number` field and updating the renderer's RenderFlags type to include it; if wiring the HUD text changes is out of scope for this task, at minimum plumb the value through so future tasks can render it — but the store-and-record behavior MUST be active and covered by tests.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*