### PR TITLE
feature: Add procedural sprite-sheet module

### DIFF
--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INVADER_ROW_DESCRIPTORS,
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  PLAYER_SHIP_DESCRIPTOR,
+  SPRITE_DESCRIPTORS,
+  createSpriteSheet,
+  type SpriteCanvasContext,
+  type SpriteDescriptor
+} from "./sprites";
+
+type FillRectCall = {
+  fillStyle: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+class FakeSpriteContext implements SpriteCanvasContext {
+  readonly fillRectCalls: FillRectCall[] = [];
+  readonly fillStyleCalls: string[] = [];
+
+  private currentFillStyle = "";
+
+  get fillStyle(): string {
+    return this.currentFillStyle;
+  }
+
+  set fillStyle(value: string | CanvasGradient | CanvasPattern) {
+    if (typeof value !== "string") {
+      throw new Error("FakeSpriteContext only supports string fill styles.");
+    }
+
+    this.currentFillStyle = value;
+    this.fillStyleCalls.push(value);
+  }
+
+  fillRect(x: number, y: number, width: number, height: number): void {
+    this.fillRectCalls.push({
+      fillStyle: this.currentFillStyle,
+      x,
+      y,
+      width,
+      height
+    });
+  }
+}
+
+describe("createSpriteSheet", () => {
+  it("includes descriptors for the player, each invader row, and the projectile", () => {
+    expect(SPRITE_DESCRIPTORS).toHaveLength(7);
+    expect(INVADER_ROW_DESCRIPTORS).toHaveLength(5);
+
+    expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(PLAYER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(1);
+
+    for (const descriptor of INVADER_ROW_DESCRIPTORS) {
+      expect(createSpriteSheet(descriptor).getFrameCount()).toBe(2);
+    }
+  });
+
+  it("looks up palette colors and draws each filled pixel at the expected coordinates", () => {
+    const descriptor: SpriteDescriptor = {
+      id: "test-sprite",
+      frames: [
+        ["ab", ".a"],
+        ["bb", "bb"]
+      ],
+      palette: {
+        a: "#112233",
+        b: "#445566"
+      },
+      pixelSize: 2
+    };
+    const spriteSheet = createSpriteSheet(descriptor);
+    const context = new FakeSpriteContext();
+
+    spriteSheet.drawFrame(context, 0, 10, 20);
+
+    expect(context.fillStyleCalls).toEqual([
+      "#112233",
+      "#445566",
+      "#112233"
+    ]);
+    expect(context.fillRectCalls).toEqual([
+      {
+        fillStyle: "#112233",
+        x: 10,
+        y: 20,
+        width: 2,
+        height: 2
+      },
+      {
+        fillStyle: "#445566",
+        x: 12,
+        y: 20,
+        width: 2,
+        height: 2
+      },
+      {
+        fillStyle: "#112233",
+        x: 12,
+        y: 22,
+        width: 2,
+        height: 2
+      }
+    ]);
+  });
+
+  it("draws the requested animation frame", () => {
+    const descriptor: SpriteDescriptor = {
+      id: "animated-sprite",
+      frames: [
+        ["x.", ".x"],
+        ["xx", "xx"]
+      ],
+      palette: {
+        x: "#aabbcc"
+      },
+      pixelSize: 3
+    };
+    const spriteSheet = createSpriteSheet(descriptor);
+    const context = new FakeSpriteContext();
+
+    spriteSheet.drawFrame(context, 1, 4, 6);
+
+    expect(spriteSheet.getFrameCount()).toBe(2);
+    expect(context.fillRectCalls).toHaveLength(4);
+    expect(context.fillRectCalls).toEqual([
+      {
+        fillStyle: "#aabbcc",
+        x: 4,
+        y: 6,
+        width: 3,
+        height: 3
+      },
+      {
+        fillStyle: "#aabbcc",
+        x: 7,
+        y: 6,
+        width: 3,
+        height: 3
+      },
+      {
+        fillStyle: "#aabbcc",
+        x: 4,
+        y: 9,
+        width: 3,
+        height: 3
+      },
+      {
+        fillStyle: "#aabbcc",
+        x: 7,
+        y: 9,
+        width: 3,
+        height: 3
+      }
+    ]);
+  });
+
+  it("throws when the requested frame index is out of bounds", () => {
+    const spriteSheet = createSpriteSheet(PLAYER_SHIP_DESCRIPTOR);
+    const context = new FakeSpriteContext();
+
+    expect(() => spriteSheet.drawFrame(context, 99, 0, 0)).toThrow(RangeError);
+  });
+});

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -1,0 +1,223 @@
+export type SpriteFrame = readonly string[];
+
+export type SpriteDescriptor = {
+  id: string;
+  frames: readonly SpriteFrame[];
+  palette: Readonly<Record<string, string>>;
+  pixelSize: number;
+};
+
+export type SpriteCanvasContext = {
+  fillStyle: string | CanvasGradient | CanvasPattern;
+  fillRect: (x: number, y: number, width: number, height: number) => void;
+};
+
+export type SpriteSheet = {
+  drawFrame: (
+    context: SpriteCanvasContext,
+    frameIndex: number,
+    x: number,
+    y: number
+  ) => void;
+  getFrameCount: () => number;
+};
+
+export const EMPTY_PIXEL = ".";
+
+const PLAYER_SHIP_FRAMES: readonly SpriteFrame[] = [
+  [
+    ".........c.........",
+    "........ccc........",
+    ".......ccccc.......",
+    "......cccbccc......",
+    ".....ccbbbbbcc.....",
+    "...ccbbbbbbbbbcc...",
+    "..ccbbbbbbbbbbbcc.."
+  ]
+];
+
+const INVADER_SQUID_FRAMES: readonly SpriteFrame[] = [
+  [
+    "..xx....xx..",
+    "...xxxxxx...",
+    "..xxxxxxxx..",
+    ".xx.xxxx.xx.",
+    ".xxxxxxxxxx.",
+    "...xx..xx...",
+    "..xx....xx..",
+    ".xx......xx."
+  ],
+  [
+    "..xx....xx..",
+    "...xxxxxx...",
+    "..xxxxxxxx..",
+    ".xx.xxxx.xx.",
+    ".xxxxxxxxxx.",
+    "..xx.xx.xx..",
+    ".xx......xx.",
+    "xx........xx"
+  ]
+];
+
+const INVADER_CRAB_FRAMES: readonly SpriteFrame[] = [
+  [
+    "...xx..xx...",
+    "..xxxxxxxx..",
+    ".xxxxxxxxxx.",
+    "xx..xxxx..xx",
+    "xxxxxxxxxxxx",
+    "..xx.xx.xx..",
+    ".xx..xx..xx.",
+    "xx........xx"
+  ],
+  [
+    "...xx..xx...",
+    "..xxxxxxxx..",
+    ".xxxxxxxxxx.",
+    "xx..xxxx..xx",
+    "xxxxxxxxxxxx",
+    "...xx..xx...",
+    "..xx.xx.xx..",
+    ".xx......xx."
+  ]
+];
+
+const INVADER_BOMBER_FRAMES: readonly SpriteFrame[] = [
+  [
+    "...xxxxxx...",
+    "..xxxxxxxx..",
+    ".xxxxxxxxxx.",
+    "xxxx.xx.xxxx",
+    "xxxxxxxxxxxx",
+    "..xx.xx.xx..",
+    ".xx......xx.",
+    "xx........xx"
+  ],
+  [
+    "...xxxxxx...",
+    "..xxxxxxxx..",
+    ".xxxxxxxxxx.",
+    "xxxx.xx.xxxx",
+    "xxxxxxxxxxxx",
+    ".xx..xx..xx.",
+    "xx..xx..xx..",
+    "..xx....xx.."
+  ]
+];
+
+function createInvaderDescriptor(
+  id: string,
+  color: string,
+  frames: readonly SpriteFrame[]
+): SpriteDescriptor {
+  return {
+    id,
+    frames,
+    palette: {
+      x: color
+    },
+    pixelSize: 4
+  };
+}
+
+export const PLAYER_SHIP_DESCRIPTOR = {
+  id: "player-ship",
+  frames: PLAYER_SHIP_FRAMES,
+  palette: {
+    c: "#d7f4ff",
+    b: "#59d8ff"
+  },
+  pixelSize: 4
+} satisfies SpriteDescriptor;
+
+export const INVADER_ROW_DESCRIPTORS = [
+  createInvaderDescriptor("invader-row-0", "#8bf3ff", INVADER_SQUID_FRAMES),
+  createInvaderDescriptor("invader-row-1", "#7ad7ff", INVADER_CRAB_FRAMES),
+  createInvaderDescriptor("invader-row-2", "#5fbbff", INVADER_CRAB_FRAMES),
+  createInvaderDescriptor("invader-row-3", "#62f4c3", INVADER_BOMBER_FRAMES),
+  createInvaderDescriptor("invader-row-4", "#ffe37a", INVADER_BOMBER_FRAMES)
+] as const satisfies readonly SpriteDescriptor[];
+
+export const PLAYER_PROJECTILE_DESCRIPTOR = {
+  id: "player-projectile",
+  frames: [["p.", "pp", "pp", "pp", "pp", ".p"]],
+  palette: {
+    p: "#f7fbff"
+  },
+  pixelSize: 3
+} satisfies SpriteDescriptor;
+
+export const SPRITE_DESCRIPTORS = [
+  PLAYER_SHIP_DESCRIPTOR,
+  ...INVADER_ROW_DESCRIPTORS,
+  PLAYER_PROJECTILE_DESCRIPTOR
+] as const satisfies readonly SpriteDescriptor[];
+
+export function createSpriteSheet(descriptor: SpriteDescriptor): SpriteSheet {
+  validateDescriptor(descriptor);
+
+  return {
+    drawFrame: (context, frameIndex, x, y) => {
+      const frame = descriptor.frames[frameIndex];
+
+      if (frame === undefined) {
+        throw new RangeError(
+          `Sprite "${descriptor.id}" has no frame at index ${frameIndex}.`
+        );
+      }
+
+      for (const [rowIndex, row] of frame.entries()) {
+        for (let columnIndex = 0; columnIndex < row.length; columnIndex += 1) {
+          const pixelKey = row.charAt(columnIndex);
+
+          if (pixelKey === EMPTY_PIXEL) {
+            continue;
+          }
+
+          const color = descriptor.palette[pixelKey];
+
+          if (color === undefined) {
+            throw new Error(
+              `Sprite "${descriptor.id}" is missing a palette entry for "${pixelKey}".`
+            );
+          }
+
+          context.fillStyle = color;
+          context.fillRect(
+            x + columnIndex * descriptor.pixelSize,
+            y + rowIndex * descriptor.pixelSize,
+            descriptor.pixelSize,
+            descriptor.pixelSize
+          );
+        }
+      }
+    },
+    getFrameCount: () => descriptor.frames.length
+  };
+}
+
+function validateDescriptor(descriptor: SpriteDescriptor): void {
+  if (!Number.isFinite(descriptor.pixelSize) || descriptor.pixelSize <= 0) {
+    throw new Error(`Sprite "${descriptor.id}" must use a positive pixelSize.`);
+  }
+
+  if (descriptor.frames.length === 0) {
+    throw new Error(`Sprite "${descriptor.id}" must include at least one frame.`);
+  }
+
+  for (const frame of descriptor.frames) {
+    const expectedWidth = frame[0]?.length ?? 0;
+
+    if (expectedWidth === 0) {
+      throw new Error(`Sprite "${descriptor.id}" cannot include an empty frame.`);
+    }
+
+    for (const row of frame) {
+      if (row.length !== expectedWidth) {
+        throw new Error(
+          `Sprite "${descriptor.id}" must use rectangular pixel grids.`
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Add procedural sprite-sheet module

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #75

### Changes
Create a procedural sprite-sheet module that builds sprites in-memory from a small JSON descriptor (no external image files). Export a SpriteDescriptor type (id, frames as 2D pixel grids, palette, pixelSize) and a createSpriteSheet(descriptor) function that returns an object exposing drawFrame(ctx, frameIndex, x, y) plus a getFrameCount() helper. Include entries for the player ship, each invader row (with 2 march frames), and the player projectile. Implement drawing by iterating pixel grids and filling rects on a 2D canvas context (consumers pass in their own context). Add Vitest coverage in sprites.test.ts using a fake context that records fillRect/fillStyle calls — verify frame counts, palette lookups, and that drawFrame renders the expected number of pixel rects with the correct coordinates. Keep the descriptor data small (<50 KB when bundled).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*