### PR TITLE
test: Integration tests for pause toggle and game-over restart

### DIFF
--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -432,4 +432,89 @@ describe("step", () => {
     expect(next.phase).toBe("waveClear");
     expect(next.hud.score).toBe(220);
   });
+
+  describe("phase transition integration", () => {
+    it("freezes the current simulation after pausing from active play", () => {
+      const playing = step(createPlayingState(), 16, {
+        ...EMPTY_INPUT,
+        firePressed: true
+      });
+      const paused = step(playing, 16, { ...EMPTY_INPUT, pausePressed: true });
+
+      expect(paused.phase).toBe("paused");
+      expect(paused.invaders).toHaveLength(INVADER_ROWS * INVADER_COLS);
+      expect(paused.projectiles).toHaveLength(1);
+
+      const frozen = step(paused, 200, EMPTY_INPUT);
+
+      expect(frozen.phase).toBe("paused");
+      expect(frozen.player.x).toBe(paused.player.x);
+      expect(frozen.invaders[0]?.x).toBe(paused.invaders[0]?.x);
+      expect(frozen.projectiles[0]?.y).toBe(paused.projectiles[0]?.y);
+    });
+
+    it("toggles back to playing when P is pressed again from pause", () => {
+      const playing = step(createPlayingState(), 16, {
+        ...EMPTY_INPUT,
+        firePressed: true
+      });
+      const paused = step(playing, 16, { ...EMPTY_INPUT, pausePressed: true });
+
+      expect(paused.phase).toBe("paused");
+      expect(paused.projectiles).toHaveLength(1);
+
+      const resumed = step(paused, 16, { ...EMPTY_INPUT, pausePressed: true });
+
+      expect(resumed.phase).toBe("playing");
+      expect(resumed.player.x).toBe(paused.player.x);
+      expect(resumed.invaders[0]?.x).toBe(paused.invaders[0]?.x);
+      expect(resumed.projectiles[0]?.y).toBe(paused.projectiles[0]?.y);
+    });
+
+    it("reaches game over after an invader collision takes the final life", () => {
+      const base = createPlayingState({ lives: 1 });
+      const invader = base.invaders[0];
+      expect(invader).toBeDefined();
+      const finalLifeState = {
+        ...base,
+        invaders:
+          invader === undefined
+            ? []
+            : [
+                {
+                  ...invader,
+                  x: base.player.x,
+                  y: base.player.y
+                }
+              ]
+      };
+
+      const lifeLost = step(finalLifeState, 0, EMPTY_INPUT);
+
+      expect(lifeLost.phase).toBe("lifeLost");
+      expect(lifeLost.hud.lives).toBe(0);
+
+      const gameOver = step(lifeLost, LIFE_LOST_DURATION_MS, EMPTY_INPUT);
+
+      expect(gameOver.phase).toBe("gameOver");
+      expect(gameOver.hud.lives).toBe(0);
+    });
+
+    it("resets to a fresh first wave when fire is pressed from game over", () => {
+      const state = createGameState({
+        phase: "gameOver",
+        wave: 4,
+        score: 650,
+        lives: 0
+      });
+
+      const next = step(state, 16, { ...EMPTY_INPUT, firePressed: true });
+
+      expect(next.phase).toBe("playing");
+      expect(next.hud.score).toBe(0);
+      expect(next.hud.lives).toBe(STARTING_LIVES);
+      expect(next.hud.wave).toBe(1);
+      expect(next.invaders).toHaveLength(INVADER_ROWS * INVADER_COLS);
+    });
+  });
 });


### PR DESCRIPTION
## Integration tests for pause toggle and game-over restart

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #88

### Changes
Append integration-style test cases to src/game/step.test.ts that lock in the phase state-machine behavior already implemented in src/game/step.ts. Required cases: (1) pressing P from 'playing' transitions to 'paused' and a subsequent step with no input does NOT advance simulation (player x unchanged, no invader march, no projectile movement); (2) pressing P again from 'paused' transitions back to 'playing'; (3) from a playing state, reduce lives to 1 and set up an invader–player collision (or advance invader formation until it reaches the player) so that the next step produces phase 'gameOver' with lives 0; (4) from a 'gameOver' state, stepping with firePressed resets to a fresh 'playing' state with hud.score === 0, hud.lives === STARTING_LIVES, hud.wave === 1, and a full invader formation of INVADER_ROWS * INVADER_COLS. Use the existing createGameState / createPlayingState helpers and EMPTY_INPUT. Do NOT modify step.ts or state.ts — if a test cannot be written against current behavior, the test is wrong, not the implementation.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*