### PR TITLE
feature: Add mute store with localStorage persistence

### DIFF
--- a/src/audio/mute.test.ts
+++ b/src/audio/mute.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { createMuteStore } from "./mute";
+
+const MUTE_STORAGE_KEY = "audio:muted";
+
+class FakeStorage implements Storage {
+  private readonly entries = new Map<string, string>();
+
+  get length(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.entries.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.entries.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.entries.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.entries.set(key, value);
+  }
+
+  seed(key: string, value: string): void {
+    this.entries.set(key, value);
+  }
+}
+
+describe("createMuteStore", () => {
+  it("defaults to false when storage is empty", () => {
+    const store = createMuteStore(new FakeStorage());
+
+    expect(store.isMuted()).toBe(false);
+  });
+
+  it("toggles the muted state and returns the new value", () => {
+    const storage = new FakeStorage();
+    const store = createMuteStore(storage);
+
+    expect(store.toggle()).toBe(true);
+    expect(store.isMuted()).toBe(true);
+    expect(storage.getItem(MUTE_STORAGE_KEY)).toBe("true");
+
+    expect(store.toggle()).toBe(false);
+    expect(store.isMuted()).toBe(false);
+    expect(storage.getItem(MUTE_STORAGE_KEY)).toBe("false");
+  });
+
+  it("round-trips the stored muted state", () => {
+    const storage = new FakeStorage();
+    const firstStore = createMuteStore(storage);
+
+    expect(firstStore.toggle()).toBe(true);
+
+    const secondStore = createMuteStore(storage);
+
+    expect(secondStore.isMuted()).toBe(true);
+  });
+
+  it.each(["TRUE", "1", "yes", ""])(
+    "falls back to false for invalid stored value %s",
+    (storedValue) => {
+      const storage = new FakeStorage();
+      storage.seed(MUTE_STORAGE_KEY, storedValue);
+      const store = createMuteStore(storage);
+
+      expect(store.isMuted()).toBe(false);
+    }
+  );
+
+  it("notifies subscribers on toggle and stops after unsubscribe", () => {
+    const storage = new FakeStorage();
+    const store = createMuteStore(storage);
+    const notifications: Array<{ muted: boolean; storedValue: string | null }> =
+      [];
+    const unsubscribe = store.subscribe(() => {
+      notifications.push({
+        muted: store.isMuted(),
+        storedValue: storage.getItem(MUTE_STORAGE_KEY)
+      });
+    });
+
+    expect(store.toggle()).toBe(true);
+    expect(notifications).toEqual([
+      { muted: true, storedValue: "true" }
+    ]);
+
+    unsubscribe();
+
+    expect(store.toggle()).toBe(false);
+    expect(notifications).toEqual([
+      { muted: true, storedValue: "true" }
+    ]);
+  });
+});

--- a/src/audio/mute.ts
+++ b/src/audio/mute.ts
@@ -1,0 +1,96 @@
+const MUTE_STORAGE_KEY = "audio:muted";
+
+const fallbackStorage = createMemoryStorage();
+
+type MuteStoreListener = () => void;
+
+export type MuteStore = {
+  isMuted: () => boolean;
+  toggle: () => boolean;
+  subscribe: (listener: MuteStoreListener) => () => void;
+};
+
+export function createMuteStore(
+  storage: Storage = getDefaultStorage()
+): MuteStore {
+  let muted = readStoredMuted(storage);
+  const listeners = new Set<MuteStoreListener>();
+
+  return {
+    isMuted: () => muted,
+    toggle: () => {
+      muted = !muted;
+      writeStoredMuted(storage, muted);
+
+      for (const listener of listeners) {
+        listener();
+      }
+
+      return muted;
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    }
+  };
+}
+
+function getDefaultStorage(): Storage {
+  try {
+    if (typeof window === "undefined") {
+      return fallbackStorage;
+    }
+
+    return window.localStorage;
+  } catch {
+    return fallbackStorage;
+  }
+}
+
+function readStoredMuted(storage: Storage): boolean {
+  try {
+    return parseStoredMuted(storage.getItem(MUTE_STORAGE_KEY));
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredMuted(storage: Storage, muted: boolean): void {
+  try {
+    storage.setItem(MUTE_STORAGE_KEY, String(muted));
+  } catch {
+    // Storage failures are non-fatal for audio state.
+  }
+}
+
+function parseStoredMuted(value: string | null): boolean {
+  return value === "true";
+}
+
+function createMemoryStorage(): Storage {
+  const entries = new Map<string, string>();
+
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key) {
+      return entries.get(key) ?? null;
+    },
+    key(index) {
+      return [...entries.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      entries.delete(key);
+    },
+    setItem(key, value) {
+      entries.set(key, value);
+    }
+  };
+}


### PR DESCRIPTION
## Add mute store with localStorage persistence

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #103

### Changes
Create `src/audio/mute.ts` exporting a `MuteStore` factory: `createMuteStore(storage?: Storage)` returning `{ isMuted(): boolean; toggle(): boolean; subscribe(listener): () => void }`. The store reads the initial value from `storage.getItem('audio:muted')` parsing the string `'true'`/`'false'` (default `false` when missing/invalid), and writes the new value on every toggle. Emit updates to subscribers synchronously after the write. Accept an optional `Storage`-shaped argument so tests can inject a fake; default to `window.localStorage` when available, otherwise fall back to an in-memory shim so the module is safe to import under Node. Add `src/audio/mute.test.ts` with vitest cases covering: default-false when storage empty; toggle flips and returns the new value; persistence round-trip (second store created against the same fake storage reads `true` after the first toggled); invalid stored values fall back to `false`; subscribers fire on toggle and unsubscribe stops further notifications. Use an in-memory `Storage` fake (object with `getItem`/`setItem`/`removeItem`/`clear`/`length`/`key`) rather than stubbing the global, since vitest runs under `environment: 'node'`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*