### PR TITLE
feature: Add mutePressed edge (M key) to Input and keyboard controller

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -10,6 +10,7 @@ export type Input = {
   moveX: -1 | 0 | 1;
   firePressed: boolean;
   pausePressed: boolean;
+  mutePressed?: boolean;
 };
 
 export type Arena = {
@@ -114,7 +115,8 @@ export const LIFE_LOST_DURATION_MS = 900;
 export const EMPTY_INPUT: Input = {
   moveX: 0,
   firePressed: false,
-  pausePressed: false
+  pausePressed: false,
+  mutePressed: false
 };
 
 const ROW_POINTS = [50, 40, 30, 20, 10] as const;

--- a/src/input/keyboard.ts
+++ b/src/input/keyboard.ts
@@ -11,8 +11,10 @@ export function createKeyboardController(target: Window = window): KeyboardContr
     right: false,
     fire: false,
     pause: false,
+    mute: false,
     fireEdge: false,
-    pauseEdge: false
+    pauseEdge: false,
+    muteEdge: false
   };
 
   const onKeyDown = (event: KeyboardEvent): void => {
@@ -39,6 +41,13 @@ export function createKeyboardController(target: Window = window): KeyboardContr
         held.pause = true;
         event.preventDefault();
         break;
+      case "KeyM":
+        if (!held.mute) {
+          held.muteEdge = true;
+        }
+        held.mute = true;
+        event.preventDefault();
+        break;
       default:
         break;
     }
@@ -62,6 +71,10 @@ export function createKeyboardController(target: Window = window): KeyboardContr
         held.pause = false;
         event.preventDefault();
         break;
+      case "KeyM":
+        held.mute = false;
+        event.preventDefault();
+        break;
       default:
         break;
     }
@@ -80,11 +93,13 @@ export function createKeyboardController(target: Window = window): KeyboardContr
       const snapshot: Input = {
         moveX,
         firePressed: held.fireEdge,
-        pausePressed: held.pauseEdge
+        pausePressed: held.pauseEdge,
+        mutePressed: held.muteEdge
       };
 
       held.fireEdge = false;
       held.pauseEdge = false;
+      held.muteEdge = false;
 
       return snapshot;
     }


### PR DESCRIPTION
## Add mutePressed edge (M key) to Input and keyboard controller

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #102

### Changes
Extend the `Input` type in `src/game/state.ts` with `mutePressed: boolean` and add the corresponding `mutePressed: false` field to `EMPTY_INPUT` (and any other Input literal constructed in state.ts). In `src/input/keyboard.ts`, mirror the existing `fireEdge`/`pauseEdge` pattern for a new `muteEdge` bound to `event.code === 'KeyM'`: set `held.mute = true` on keydown and flip `muteEdge = true` only on the rising edge; clear `held.mute` on keyup; include and clear `mutePressed` in the `snapshot()` return alongside the existing edges. Do not change the behaviour of `step()` — `step.ts` should simply ignore the new field. Existing `step.test.ts` cases already spread `EMPTY_INPUT` so they continue to pass without edits.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*