### PR TITLE
feature: Wire sprites and animation frames into renderer

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -73,6 +73,8 @@ export type GameState = {
   formation: Formation;
   hud: HudState;
   frame: number;
+  marchFrame: 0 | 1;
+  playerShootFrame: number;
   nextProjectileId: number;
   transitionTimerMs: number;
 };
@@ -150,6 +152,8 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
       wave
     },
     frame: seed.frame ?? 0,
+    marchFrame: 0,
+    playerShootFrame: 0,
     nextProjectileId,
     transitionTimerMs: seed.transitionTimerMs ?? 0
   };

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -22,6 +22,8 @@ type Rect = {
   height: number;
 };
 
+const PLAYER_SHOOT_FRAME_DURATION_MS = 120;
+
 export function step(state: GameState, dtMs: number, input: Input = EMPTY_INPUT): GameState {
   const dt = Math.max(0, dtMs);
 
@@ -89,6 +91,7 @@ function advanceLifeLost(state: GameState, dtMs: number): GameState {
     ...state,
     phase: "gameOver",
     projectiles: [],
+    playerShootFrame: 0,
     transitionTimerMs: 0,
     player: {
       ...state.player,
@@ -109,26 +112,37 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
   const dtSeconds = dtMs / 1000;
   const nextFrame = state.frame + 1;
   const cooldown = Math.max(0, state.player.shootCooldownMs - dtMs);
+  const playerShootFrame = Math.max(0, state.playerShootFrame - dtMs);
   const movedPlayer = {
-      ...state.player,
-      x: clamp(
-        state.player.x + input.moveX * state.player.speed * dtSeconds,
-        getPlayerMinX(state.arena),
-        getPlayerMaxX(state.arena, state.player)
-      ),
+    ...state.player,
+    x: clamp(
+      state.player.x + input.moveX * state.player.speed * dtSeconds,
+      getPlayerMinX(state.arena),
+      getPlayerMaxX(state.arena, state.player)
+    ),
     shootCooldownMs: cooldown
   };
 
-  const projectileBundle = maybeSpawnProjectile(state, movedPlayer, input.firePressed);
+  const projectileBundle = maybeSpawnProjectile(
+    state,
+    movedPlayer,
+    input.firePressed,
+    playerShootFrame
+  );
   const movedProjectiles = moveProjectiles(projectileBundle.projectiles, dtSeconds, state.arena.height);
   const formationBundle = moveInvaders(state, dtSeconds);
   const collisionBundle = resolveProjectileHits(movedProjectiles, formationBundle.invaders);
   const score = state.hud.score + collisionBundle.scoreDelta;
+  const marchFrame = formationBundle.didAdvance
+    ? toggleMarchFrame(state.marchFrame)
+    : state.marchFrame;
 
   if (hasInvaderBreached(collisionBundle.invaders, movedPlayer)) {
     return {
       ...state,
       phase: "lifeLost",
+      marchFrame,
+      playerShootFrame: 0,
       player: {
         ...movedPlayer,
         shootCooldownMs: 0
@@ -151,6 +165,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     return {
       ...state,
       phase: "waveClear",
+      marchFrame,
+      playerShootFrame: projectileBundle.playerShootFrame,
       player: {
         ...movedPlayer,
         shootCooldownMs: projectileBundle.playerShootCooldownMs
@@ -170,6 +186,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
 
   return {
     ...state,
+    marchFrame,
+    playerShootFrame: projectileBundle.playerShootFrame,
     player: {
       ...movedPlayer,
       shootCooldownMs: projectileBundle.playerShootCooldownMs
@@ -190,16 +208,19 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
 function maybeSpawnProjectile(
   state: GameState,
   player: GameState["player"],
-  firePressed: boolean
+  firePressed: boolean,
+  playerShootFrame: number
 ): {
   nextProjectileId: number;
   playerShootCooldownMs: number;
+  playerShootFrame: number;
   projectiles: Projectile[];
 } {
   if (!firePressed || player.shootCooldownMs > 0) {
     return {
       nextProjectileId: state.nextProjectileId,
       playerShootCooldownMs: player.shootCooldownMs,
+      playerShootFrame,
       projectiles: state.projectiles
     };
   }
@@ -213,6 +234,7 @@ function maybeSpawnProjectile(
   return {
     nextProjectileId: state.nextProjectileId + 1,
     playerShootCooldownMs: PLAYER_SHOOT_COOLDOWN_MS,
+    playerShootFrame: PLAYER_SHOOT_FRAME_DURATION_MS,
     projectiles: [...state.projectiles, projectile]
   };
 }
@@ -239,6 +261,7 @@ function moveInvaders(
   state: GameState,
   dtSeconds: number
 ): {
+  didAdvance: boolean;
   formation: GameState["formation"];
   invaders: Invader[];
 } {
@@ -275,6 +298,7 @@ function moveInvaders(
   }
 
   return {
+    didAdvance: dtSeconds > 0 && state.invaders.length > 0,
     formation: {
       ...state.formation,
       direction
@@ -344,4 +368,8 @@ function intersects(a: Rect, b: Rect): boolean {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function toggleMarchFrame(marchFrame: GameState["marchFrame"]): GameState["marchFrame"] {
+  return marchFrame === 0 ? 1 : 0;
 }

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -1,4 +1,12 @@
 import type { GameState, Invader, Projectile } from "../game/state";
+import {
+  INVADER_ROW_DESCRIPTORS,
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  PLAYER_SHIP_DESCRIPTOR,
+  createSpriteSheet,
+  type SpriteDescriptor,
+  type SpriteSheet
+} from "./sprites";
 
 export type RenderFlags = {
   bootstrapping: boolean;
@@ -10,6 +18,17 @@ export type CanvasRenderer = {
 };
 
 const HUD_HEIGHT = 68;
+
+type PreparedSprite = {
+  frameCount: number;
+  height: number;
+  sheet: SpriteSheet;
+  width: number;
+};
+
+const PLAYER_SHIP_SPRITE = prepareSprite(PLAYER_SHIP_DESCRIPTOR);
+const INVADER_ROW_SPRITES = INVADER_ROW_DESCRIPTORS.map(prepareSprite);
+const PLAYER_PROJECTILE_SPRITE = prepareSprite(PLAYER_PROJECTILE_DESCRIPTOR);
 
 export function createCanvasRenderer(canvas: HTMLCanvasElement): CanvasRenderer {
   const context = canvas.getContext("2d");
@@ -52,7 +71,7 @@ function drawScene(
   context.clearRect(0, 0, state.arena.width, state.arena.height);
   drawBackground(context, state);
   drawHud(context, state);
-  drawInvaders(context, state.invaders);
+  drawInvaders(context, state.invaders, state.marchFrame);
   drawProjectiles(context, state.projectiles);
   drawPlayer(context, state);
   drawFloor(context, state);
@@ -177,36 +196,33 @@ function drawHud(context: CanvasRenderingContext2D, state: GameState): void {
   context.fillText(`LIVES ${state.hud.lives}`, state.arena.width - 156, 60);
 }
 
-function drawInvaders(context: CanvasRenderingContext2D, invaders: Invader[]): void {
+function drawInvaders(
+  context: CanvasRenderingContext2D,
+  invaders: Invader[],
+  marchFrame: GameState["marchFrame"]
+): void {
   for (const invader of invaders) {
+    const sprite = INVADER_ROW_SPRITES[invader.row];
+
+    if (sprite === undefined) {
+      continue;
+    }
+
     const hue = 190 + invader.row * 18;
-    const bodyFill = `hsla(${hue}, 88%, 62%, 0.92)`;
     const shadowFill = `hsla(${hue}, 100%, 60%, 0.18)`;
 
     context.fillStyle = shadowFill;
     roundRect(context, invader.x - 4, invader.y - 4, invader.width + 8, invader.height + 10, 12);
     context.fill();
-
-    context.fillStyle = bodyFill;
-    roundRect(context, invader.x, invader.y, invader.width, invader.height, 10);
-    context.fill();
-
-    context.fillStyle = "rgba(10, 18, 34, 0.8)";
-    context.fillRect(invader.x + 10, invader.y + 10, 8, 6);
-    context.fillRect(invader.x + invader.width - 18, invader.y + 10, 8, 6);
-
-    context.fillStyle = "rgba(255, 255, 255, 0.86)";
-    context.fillRect(invader.x + 8, invader.y + invader.height - 6, 10, 4);
-    context.fillRect(invader.x + invader.width - 18, invader.y + invader.height - 6, 10, 4);
-
-    context.strokeStyle = "rgba(255, 255, 255, 0.42)";
-    context.lineWidth = 2;
-    context.beginPath();
-    context.moveTo(invader.x + 12, invader.y + invader.height);
-    context.lineTo(invader.x + 8, invader.y + invader.height + 6);
-    context.moveTo(invader.x + invader.width - 12, invader.y + invader.height);
-    context.lineTo(invader.x + invader.width - 8, invader.y + invader.height + 6);
-    context.stroke();
+    drawSpriteInBounds(
+      context,
+      sprite,
+      marchFrame,
+      invader.x,
+      invader.y,
+      invader.width,
+      invader.height
+    );
   }
 }
 
@@ -215,22 +231,18 @@ function drawProjectiles(
   projectiles: Projectile[]
 ): void {
   for (const projectile of projectiles) {
-    const gradient = context.createLinearGradient(
-      projectile.x,
-      projectile.y,
-      projectile.x,
-      projectile.y + projectile.height
-    );
-    gradient.addColorStop(0, "#e9fcff");
-    gradient.addColorStop(1, "#43d3ff");
-
     context.fillStyle = "rgba(114, 226, 255, 0.25)";
     roundRect(context, projectile.x - 3, projectile.y - 6, projectile.width + 6, projectile.height + 12, 6);
     context.fill();
-
-    context.fillStyle = gradient;
-    roundRect(context, projectile.x, projectile.y, projectile.width, projectile.height, 4);
-    context.fill();
+    drawSpriteInBounds(
+      context,
+      PLAYER_PROJECTILE_SPRITE,
+      0,
+      projectile.x,
+      projectile.y,
+      projectile.width,
+      projectile.height
+    );
   }
 }
 
@@ -244,29 +256,15 @@ function drawPlayer(context: CanvasRenderingContext2D, state: GameState): void {
   context.lineTo(player.x + player.width + 16, player.y + player.height + 10);
   context.closePath();
   context.fill();
-
-  const hull = context.createLinearGradient(player.x, player.y, player.x, player.y + player.height);
-  hull.addColorStop(0, "#f7fbff");
-  hull.addColorStop(0.42, "#96ddff");
-  hull.addColorStop(1, "#38b8ff");
-  context.fillStyle = hull;
-  context.beginPath();
-  context.moveTo(player.x, player.y + player.height);
-  context.lineTo(player.x + player.width / 2, player.y);
-  context.lineTo(player.x + player.width, player.y + player.height);
-  context.closePath();
-  context.fill();
-
-  context.fillStyle = "#05101e";
-  context.beginPath();
-  context.moveTo(player.x + 18, player.y + player.height);
-  context.lineTo(player.x + player.width / 2, player.y + 10);
-  context.lineTo(player.x + player.width - 18, player.y + player.height);
-  context.closePath();
-  context.fill();
-
-  context.fillStyle = "#9df1ff";
-  context.fillRect(player.x + player.width / 2 - 4, player.y + 8, 8, 12);
+  drawSpriteInBounds(
+    context,
+    PLAYER_SHIP_SPRITE,
+    state.playerShootFrame > 0 ? 1 : 0,
+    player.x,
+    player.y,
+    player.width,
+    player.height
+  );
 }
 
 function drawFloor(context: CanvasRenderingContext2D, state: GameState): void {
@@ -372,4 +370,41 @@ function roundRect(
 ): void {
   context.beginPath();
   context.roundRect(x, y, width, height, radius);
+}
+
+function prepareSprite(descriptor: SpriteDescriptor): PreparedSprite {
+  const firstFrame = descriptor.frames[0];
+  const firstRow = firstFrame?.[0];
+
+  if (firstFrame === undefined || firstRow === undefined) {
+    throw new Error(`Sprite "${descriptor.id}" must include a non-empty frame.`);
+  }
+
+  return {
+    frameCount: descriptor.frames.length,
+    height: firstFrame.length * descriptor.pixelSize,
+    sheet: createSpriteSheet(descriptor),
+    width: firstRow.length * descriptor.pixelSize
+  };
+}
+
+function drawSpriteInBounds(
+  context: CanvasRenderingContext2D,
+  sprite: PreparedSprite,
+  frameIndex: number,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): void {
+  sprite.sheet.drawFrame(
+    context,
+    getFrameIndex(sprite, frameIndex),
+    x + (width - sprite.width) / 2,
+    y + (height - sprite.height) / 2
+  );
+}
+
+function getFrameIndex(sprite: PreparedSprite, frameIndex: number): number {
+  return Math.max(0, Math.min(frameIndex, sprite.frameCount - 1));
 }


### PR DESCRIPTION
## Wire sprites and animation frames into renderer

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #74

### Changes
Extend GameState in src/game/state.ts with animation frame counters: (1) marchFrame: 0 | 1 that toggles each time the invader formation steps, and (2) playerShootFrame: number that tracks ms-remaining of a shoot pose (seeded when a projectile fires, decayed toward 0 in step). Update createGameState/createPlayingState to initialize them to 0. In src/game/step.ts, advance marchFrame at the moment the formation march tick fires (toggle 0↔1) and decrement playerShootFrame by dtMs (clamped at 0), setting it to a fixed animation duration (e.g. 120ms) when the player fires. Existing step tests must still pass — defaults keep behavior equivalent. In src/render/canvas.ts, import the sprite-sheet module and use it to draw the player, invaders, and projectiles by sprite frame instead of plain rects: player frame uses playerShootFrame > 0, invader frame uses marchFrame. Keep HUD text drawing as-is. Do not add tests in this task (step tests are expanded in the next task).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*