### PR TITLE
feature: Extract fixed-timestep loop into testable src/loop/fixedStep.ts module

### DIFF
--- a/src/loop/fixedStep.test.ts
+++ b/src/loop/fixedStep.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createFixedStepLoop,
+  type FixedStepLoop,
+  type FixedStepLoopStepInput
+} from "./fixedStep";
+
+type ScheduledFrame = (timestamp: number) => void;
+
+type LoopHarness = {
+  loop: FixedStepLoop;
+  renderCalls: number[];
+  runFrame: (advanceMs: number) => void;
+  setHidden: (nextHidden: boolean) => void;
+  stepCalls: FixedStepLoopStepInput[];
+};
+
+function createLoopHarness(stepMs = 10): LoopHarness {
+  const scheduledFrames: ScheduledFrame[] = [];
+  const stepCalls: FixedStepLoopStepInput[] = [];
+  const renderCalls: number[] = [];
+  let hidden = false;
+
+  const loop = createFixedStepLoop({
+    stepMs,
+    now: () => Date.now(),
+    schedule: (callback) => {
+      scheduledFrames.push(callback);
+      return scheduledFrames.length;
+    },
+    isHidden: () => hidden,
+    onStep: (input) => {
+      stepCalls.push(input);
+    },
+    onRender: () => {
+      renderCalls.push(Date.now());
+    }
+  });
+
+  const runFrame = (advanceMs: number): void => {
+    vi.advanceTimersByTime(advanceMs);
+    const callback = scheduledFrames.shift();
+
+    if (callback === undefined) {
+      throw new Error("Expected a scheduled frame.");
+    }
+
+    callback(Date.now());
+  };
+
+  return {
+    loop,
+    renderCalls,
+    runFrame,
+    setHidden: (nextHidden) => {
+      hidden = nextHidden;
+    },
+    stepCalls
+  };
+}
+
+describe("createFixedStepLoop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs exactly one fixed step when frames advance by stepMs", () => {
+    const harness = createLoopHarness();
+
+    harness.loop.start();
+    harness.runFrame(10);
+    harness.runFrame(10);
+    harness.runFrame(10);
+
+    expect(harness.stepCalls).toEqual([
+      { dtMs: 10, firstStepOfFrame: true },
+      { dtMs: 10, firstStepOfFrame: true },
+      { dtMs: 10, firstStepOfFrame: true }
+    ]);
+    expect(harness.renderCalls).toEqual([10, 20, 30]);
+  });
+
+  it("runs catch-up steps for a long frame", () => {
+    const harness = createLoopHarness();
+
+    harness.loop.start();
+    harness.runFrame(35);
+
+    expect(harness.stepCalls).toEqual([
+      { dtMs: 10, firstStepOfFrame: true },
+      { dtMs: 10, firstStepOfFrame: false },
+      { dtMs: 10, firstStepOfFrame: false }
+    ]);
+    expect(harness.renderCalls).toEqual([35]);
+  });
+
+  it("caps catch-up work with the 100ms spiral-of-death clamp", () => {
+    const harness = createLoopHarness();
+
+    harness.loop.start();
+    harness.runFrame(1_000);
+
+    expect(harness.stepCalls).toHaveLength(10);
+    expect(harness.stepCalls[0]).toEqual({
+      dtMs: 10,
+      firstStepOfFrame: true
+    });
+    expect(harness.stepCalls[9]).toEqual({
+      dtMs: 10,
+      firstStepOfFrame: false
+    });
+    expect(harness.renderCalls).toEqual([1_000]);
+  });
+
+  it("pauses while hidden and resumes without a catch-up burst", () => {
+    const harness = createLoopHarness();
+
+    harness.loop.start();
+    harness.runFrame(10);
+
+    harness.setHidden(true);
+    harness.runFrame(50);
+    harness.runFrame(50);
+
+    expect(harness.stepCalls).toEqual([
+      { dtMs: 10, firstStepOfFrame: true }
+    ]);
+    expect(harness.renderCalls).toEqual([10]);
+
+    harness.setHidden(false);
+    harness.runFrame(50);
+
+    expect(harness.stepCalls).toEqual([
+      { dtMs: 10, firstStepOfFrame: true }
+    ]);
+    expect(harness.renderCalls).toEqual([10, 160]);
+
+    harness.runFrame(10);
+
+    expect(harness.stepCalls).toEqual([
+      { dtMs: 10, firstStepOfFrame: true },
+      { dtMs: 10, firstStepOfFrame: true }
+    ]);
+    expect(harness.renderCalls).toEqual([10, 160, 170]);
+  });
+
+  it("marks only the first step in each frame as firstStepOfFrame", () => {
+    const harness = createLoopHarness();
+
+    harness.loop.start();
+    harness.runFrame(25);
+    harness.runFrame(20);
+
+    expect(harness.stepCalls.map((call) => call.firstStepOfFrame)).toEqual([
+      true,
+      false,
+      true,
+      false
+    ]);
+  });
+});

--- a/src/loop/fixedStep.ts
+++ b/src/loop/fixedStep.ts
@@ -1,0 +1,99 @@
+const MAX_FRAME_DELTA_MS = 100;
+
+type ScheduledFrame = (timestamp: number) => void;
+
+export type FixedStepLoopStepInput = {
+  dtMs: number;
+  firstStepOfFrame: boolean;
+};
+
+export type FixedStepLoop = {
+  start: () => void;
+  stop: () => void;
+};
+
+export type FixedStepLoopOptions = {
+  stepMs: number;
+  onStep: (input: FixedStepLoopStepInput) => void;
+  onRender: () => void;
+  now?: () => number;
+  schedule?: (callback: ScheduledFrame) => number;
+  isHidden?: () => boolean;
+};
+
+export function createFixedStepLoop({
+  stepMs,
+  onStep,
+  onRender,
+  now = () => performance.now(),
+  schedule = requestAnimationFrame,
+  isHidden = () => document.hidden
+}: FixedStepLoopOptions): FixedStepLoop {
+  let accumulator = 0;
+  let previousTimestamp: number | null = null;
+  let running = false;
+
+  const scheduleNextFrame = (): void => {
+    if (running) {
+      schedule(tick);
+    }
+  };
+
+  const resetTiming = (): void => {
+    accumulator = 0;
+    previousTimestamp = null;
+  };
+
+  const tick = (timestamp: number): void => {
+    if (!running) {
+      return;
+    }
+
+    if (isHidden()) {
+      resetTiming();
+      scheduleNextFrame();
+      return;
+    }
+
+    if (previousTimestamp === null) {
+      previousTimestamp = timestamp;
+      onRender();
+      scheduleNextFrame();
+      return;
+    }
+
+    const delta = Math.min(MAX_FRAME_DELTA_MS, timestamp - previousTimestamp);
+    previousTimestamp = timestamp;
+    accumulator += delta;
+
+    let firstStepOfFrame = true;
+    while (accumulator >= stepMs) {
+      onStep({
+        dtMs: stepMs,
+        firstStepOfFrame
+      });
+      accumulator -= stepMs;
+      firstStepOfFrame = false;
+    }
+
+    onRender();
+    scheduleNextFrame();
+  };
+
+  return {
+    start: () => {
+      if (running) {
+        return;
+      }
+
+      accumulator = 0;
+      previousTimestamp = now();
+      running = true;
+      scheduleNextFrame();
+    },
+    stop: () => {
+      running = false;
+      resetTiming();
+    }
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createSfxController, type SfxName } from "./audio/sfx";
 import { createInitialGameState, type GameState, type Input } from "./game/state";
 import { step } from "./game/step";
 import { createKeyboardController } from "./input/keyboard";
+import { createFixedStepLoop } from "./loop/fixedStep";
 import { createHighScoreStore } from "./persistence";
 import { createCanvasRenderer, type CanvasRenderer } from "./render/canvas";
 
@@ -22,32 +23,19 @@ const sfx = createSfxController();
 const highScoreStore = createHighScoreStore();
 
 let state = createInitialGameState();
-let previousTimestamp = performance.now();
-let accumulator = 0;
 let bootstrapping = true;
 let audioAttempted = false;
 let highScore = highScoreStore.getHighScore();
+let frameInput: Input = keyboard.snapshot();
 
 renderer.render(state, createRenderFlags(false));
 bootstrapping = false;
+maybeArmAudio(state.phase, frameInput);
 
-window.addEventListener("beforeunload", () => {
-  keyboard.dispose();
-});
-
-requestAnimationFrame(loop);
-
-function loop(timestamp: number): void {
-  const delta = Math.min(100, timestamp - previousTimestamp);
-  previousTimestamp = timestamp;
-  accumulator += delta;
-
-  const frameInput = keyboard.snapshot();
-  maybeArmAudio(state.phase, frameInput);
-
-  let firstStep = true;
-  while (accumulator >= FIXED_TIMESTEP_MS) {
-    const stepInput = firstStep
+const loop = createFixedStepLoop({
+  stepMs: FIXED_TIMESTEP_MS,
+  onStep: ({ dtMs, firstStepOfFrame }) => {
+    const stepInput = firstStepOfFrame
       ? frameInput
       : {
           ...frameInput,
@@ -55,17 +43,23 @@ function loop(timestamp: number): void {
           pausePressed: false
         };
     const previousState = state;
-    state = step(state, FIXED_TIMESTEP_MS, stepInput);
+    state = step(state, dtMs, stepInput);
     highScore = maybeRecordHighScore(previousState, state);
     playDerivedEvents(previousState, state);
-    accumulator -= FIXED_TIMESTEP_MS;
-    firstStep = false;
+  },
+  onRender: () => {
+    frameInput = keyboard.snapshot();
+    maybeArmAudio(state.phase, frameInput);
+    renderer.render(state, createRenderFlags(sfx.getStatus() === "muted"));
   }
+});
 
-  renderer.render(state, createRenderFlags(sfx.getStatus() === "muted"));
+window.addEventListener("beforeunload", () => {
+  loop.stop();
+  keyboard.dispose();
+});
 
-  requestAnimationFrame(loop);
-}
+loop.start();
 
 function maybeArmAudio(phase: GameState["phase"], input: Input): void {
   if (audioAttempted) {


### PR DESCRIPTION
## Extract fixed-timestep loop into testable src/loop/fixedStep.ts module

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #125

### Changes
Create src/loop/fixedStep.ts that exports `createFixedStepLoop({ stepMs, onStep, onRender, now?, schedule?, isHidden? })` returning `{ start(), stop() }`. The module must encapsulate the requestAnimationFrame + accumulator pattern currently inline in src/main.ts: clamp delta to a max (current cap is 100ms — keep as the spiral-of-death clamp), accumulate, run zero or more fixed `onStep(stepInput)` calls per frame, then a single `onRender()` per frame. Inject `now` (defaults to `performance.now`), `schedule` (defaults to `requestAnimationFrame`), and `isHidden` (defaults to `() => document.hidden`) so tests can drive it deterministically. When the tab is hidden, skip stepping/rendering and reset the accumulator + previousTimestamp on resume so a long hidden interval does not flood with catch-up steps. Preserve the existing first-step-of-frame edge-trigger semantics by having `onStep` receive a `firstStepOfFrame: boolean` argument (or expose a similar hook). Then update src/main.ts to construct the loop via `createFixedStepLoop`, removing the inline `loop()` function and accumulator state — main.ts becomes a thin wiring shim that owns renderer/keyboard/sfx/state and forwards them through the loop callbacks. Add src/loop/fixedStep.test.ts using vitest fake timers (`vi.useFakeTimers()`) plus a manual fake `schedule` queue: cover (1) exactly one onStep per stepMs when frames advance by stepMs, (2) catch-up runs the correct number of onStep calls across a single long frame, (3) the spiral-of-death clamp caps catch-up so a very long frame does not produce unbounded steps, (4) when isHidden returns true the loop pauses (no onStep, no onRender) and resumes cleanly without a catch-up burst, and (5) firstStepOfFrame is true only for the first onStep call of a given frame.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*