### PR TITLE
test: Unit-test WebAudio SFX module with mocked AudioContext

### DIFF
--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -1,0 +1,447 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock
+} from "vitest";
+
+import { createSfxController, type SfxName } from "./sfx";
+
+type MockDestination = {
+  readonly kind: "destination";
+};
+
+type MockAudioParam = {
+  value: number;
+  setValueAtTime: Mock<(value: number, time: number) => MockAudioParam>;
+  linearRampToValueAtTime: Mock<
+    (value: number, time: number) => MockAudioParam
+  >;
+  exponentialRampToValueAtTime: Mock<
+    (value: number, time: number) => MockAudioParam
+  >;
+};
+
+type MockOscillatorNode = {
+  type: OscillatorType;
+  frequency: MockAudioParam;
+  connect: Mock<(target: MockGainNode) => MockGainNode>;
+  start: Mock<(time: number) => void>;
+  stop: Mock<(time: number) => void>;
+};
+
+type MockGainNode = {
+  gain: MockAudioParam;
+  connect: Mock<(target: MockDestination) => MockDestination>;
+};
+
+type MockAudioContext = {
+  state: AudioContextState;
+  readonly destination: MockDestination;
+  readonly currentTime: number;
+  readonly resume: Mock<() => Promise<void>>;
+  readonly createOscillator: Mock<() => MockOscillatorNode>;
+  readonly createGain: Mock<() => MockGainNode>;
+};
+
+type MockPlayback = {
+  oscillators: MockOscillatorNode[];
+  gains: MockGainNode[];
+  frequencies: number[];
+  startTimes: number[];
+  stopTimes: number[];
+  totalDuration: number;
+};
+
+type MockWebAudioHarness = {
+  initialState: AudioContextState;
+  throwOnAudioContextConstruction: boolean;
+  readonly destination: MockDestination;
+  readonly contexts: MockAudioContext[];
+  readonly oscillators: MockOscillatorNode[];
+  readonly gains: MockGainNode[];
+  readonly audioContextConstructor: Mock<() => MockAudioContext>;
+  readonly oscillatorConstructor: Mock<() => MockOscillatorNode>;
+  readonly gainConstructor: Mock<() => MockGainNode>;
+};
+
+type MockOscillatorConstructor = new () => MockOscillatorNode;
+type MockGainConstructor = new () => MockGainNode;
+
+const SFX_NAMES = [
+  "shoot",
+  "hit",
+  "playerDeath",
+  "waveClear"
+] as const satisfies readonly SfxName[];
+
+let harness: MockWebAudioHarness;
+
+function createMockAudioParam(initialValue: number): MockAudioParam {
+  const audioParam: MockAudioParam = {
+    value: initialValue,
+    setValueAtTime: vi.fn<(value: number, time: number) => MockAudioParam>(),
+    linearRampToValueAtTime:
+      vi.fn<(value: number, time: number) => MockAudioParam>(),
+    exponentialRampToValueAtTime:
+      vi.fn<(value: number, time: number) => MockAudioParam>()
+  };
+
+  audioParam.setValueAtTime.mockImplementation((value) => {
+    audioParam.value = value;
+    return audioParam;
+  });
+  audioParam.linearRampToValueAtTime.mockImplementation((value) => {
+    audioParam.value = value;
+    return audioParam;
+  });
+  audioParam.exponentialRampToValueAtTime.mockImplementation((value) => {
+    audioParam.value = value;
+    return audioParam;
+  });
+
+  return audioParam;
+}
+
+function installMockWebAudio(
+  initialState: AudioContextState = "suspended"
+): MockWebAudioHarness {
+  const destination: MockDestination = { kind: "destination" };
+  const contexts: MockAudioContext[] = [];
+  const oscillators: MockOscillatorNode[] = [];
+  const gains: MockGainNode[] = [];
+
+  const oscillatorConstructor = vi.fn(function MockOscillatorNodeCtor() {
+    const oscillator: MockOscillatorNode = {
+      type: "sine",
+      frequency: createMockAudioParam(0),
+      connect: vi.fn((target: MockGainNode) => target),
+      start: vi.fn<(time: number) => void>(),
+      stop: vi.fn<(time: number) => void>()
+    };
+
+    oscillators.push(oscillator);
+
+    return oscillator;
+  });
+
+  const gainConstructor = vi.fn(function MockGainNodeCtor() {
+    const gain: MockGainNode = {
+      gain: createMockAudioParam(0),
+      connect: vi.fn((target: MockDestination) => target)
+    };
+
+    gains.push(gain);
+
+    return gain;
+  });
+
+  const harness: MockWebAudioHarness = {
+    initialState,
+    throwOnAudioContextConstruction: false,
+    destination,
+    contexts,
+    oscillators,
+    gains,
+    audioContextConstructor: vi.fn<() => MockAudioContext>(),
+    oscillatorConstructor,
+    gainConstructor
+  };
+
+  harness.audioContextConstructor.mockImplementation(
+    function MockAudioContextCtor() {
+      if (harness.throwOnAudioContextConstruction) {
+        throw new Error("AudioContext unavailable");
+      }
+
+      let currentTime = 0;
+
+      const context: MockAudioContext = {
+        state: harness.initialState,
+        destination,
+        get currentTime(): number {
+          currentTime += 0.125;
+          return currentTime;
+        },
+        resume: vi.fn(async () => {
+          context.state = "running";
+        }),
+        createOscillator: vi.fn(() => {
+          const OscillatorCtor =
+            globalThis.OscillatorNode as unknown as MockOscillatorConstructor;
+
+          return new OscillatorCtor();
+        }),
+        createGain: vi.fn(() => {
+          const GainCtor =
+            globalThis.GainNode as unknown as MockGainConstructor;
+
+          return new GainCtor();
+        })
+      };
+
+      contexts.push(context);
+
+      return context;
+    }
+  );
+
+  vi.stubGlobal(
+    "OscillatorNode",
+    oscillatorConstructor as unknown as typeof OscillatorNode
+  );
+  vi.stubGlobal("GainNode", gainConstructor as unknown as typeof GainNode);
+  vi.stubGlobal(
+    "AudioContext",
+    harness.audioContextConstructor as unknown as typeof AudioContext
+  );
+
+  return harness;
+}
+
+function getLastContext(mockHarness: MockWebAudioHarness): MockAudioContext {
+  const context = mockHarness.contexts.at(-1);
+
+  if (context === undefined) {
+    throw new Error("Expected an AudioContext instance.");
+  }
+
+  return context;
+}
+
+function getSingleTimeCall(
+  mock: Mock<(time: number) => void>,
+  label: string
+): number {
+  const call = mock.mock.calls[0];
+
+  if (call === undefined) {
+    throw new Error(`Expected ${label} to be called.`);
+  }
+
+  const [time] = call;
+
+  return time;
+}
+
+function getAudioParamCall(
+  mock: Mock<(value: number, time: number) => MockAudioParam>,
+  label: string
+): { value: number; time: number } {
+  const call = mock.mock.calls[0];
+
+  if (call === undefined) {
+    throw new Error(`Expected ${label} to be called.`);
+  }
+
+  const [value, time] = call;
+
+  return { value, time };
+}
+
+function capturePlayback(
+  mockHarness: MockWebAudioHarness,
+  controller: ReturnType<typeof createSfxController>,
+  name: SfxName
+): MockPlayback {
+  const oscillatorStartIndex = mockHarness.oscillators.length;
+  const gainStartIndex = mockHarness.gains.length;
+
+  controller.play(name);
+
+  const oscillators = mockHarness.oscillators.slice(oscillatorStartIndex);
+  const gains = mockHarness.gains.slice(gainStartIndex);
+  const startTimes = oscillators.map((oscillator) =>
+    getSingleTimeCall(oscillator.start, "oscillator.start")
+  );
+  const stopTimes = oscillators.map((oscillator) =>
+    getSingleTimeCall(oscillator.stop, "oscillator.stop")
+  );
+  const frequencies = oscillators.map(
+    (oscillator) =>
+      getAudioParamCall(
+        oscillator.frequency.setValueAtTime,
+        "oscillator.frequency.setValueAtTime"
+      ).value
+  );
+
+  return {
+    oscillators,
+    gains,
+    frequencies,
+    startTimes,
+    stopTimes,
+    totalDuration: Math.max(...stopTimes) - Math.min(...startTimes)
+  };
+}
+
+function expectScheduledShortBeeps(
+  playback: MockPlayback,
+  destination: MockDestination
+): void {
+  expect(playback.oscillators.length).toBeGreaterThan(0);
+  expect(playback.gains).toHaveLength(playback.oscillators.length);
+  expect(playback.totalDuration).toBeLessThanOrEqual(1.5);
+
+  playback.oscillators.forEach((oscillator, index) => {
+    const gain = playback.gains[index];
+
+    if (gain === undefined) {
+      throw new Error("Expected a gain node for each oscillator.");
+    }
+
+    const startTime = playback.startTimes[index];
+    const stopTime = playback.stopTimes[index];
+
+    if (startTime === undefined || stopTime === undefined) {
+      throw new Error("Expected scheduled start and stop times.");
+    }
+
+    expect(oscillator.connect).toHaveBeenCalledTimes(1);
+    expect(oscillator.connect).toHaveBeenCalledWith(gain);
+    expect(gain.connect).toHaveBeenCalledTimes(1);
+    expect(gain.connect).toHaveBeenCalledWith(destination);
+    expect(stopTime).toBeGreaterThan(startTime);
+
+    const frequencyCall = getAudioParamCall(
+      oscillator.frequency.setValueAtTime,
+      "oscillator.frequency.setValueAtTime"
+    );
+
+    expect(frequencyCall.value).toBeGreaterThan(0);
+    expect(frequencyCall.time).toBe(startTime);
+    expect(oscillator.frequency.value).toBe(frequencyCall.value);
+
+    const gainSetCall = getAudioParamCall(
+      gain.gain.setValueAtTime,
+      "gain.setValueAtTime"
+    );
+
+    expect(gainSetCall.time).toBe(startTime);
+    expect(gain.gain.linearRampToValueAtTime).not.toHaveBeenCalled();
+    expect(gain.gain.exponentialRampToValueAtTime).toHaveBeenCalledTimes(2);
+
+    const attackCall = gain.gain.exponentialRampToValueAtTime.mock.calls[0];
+    const releaseCall = gain.gain.exponentialRampToValueAtTime.mock.calls[1];
+
+    if (attackCall === undefined || releaseCall === undefined) {
+      throw new Error("Expected attack and release gain ramps.");
+    }
+
+    expect(attackCall[1]).toBeGreaterThan(startTime);
+    expect(releaseCall[1]).toBeLessThan(stopTime);
+  });
+}
+
+describe("createSfxController", () => {
+  beforeEach(() => {
+    harness = installMockWebAudio();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns idle before arming", () => {
+    const controller = createSfxController();
+
+    expect(controller.getStatus()).toBe("idle");
+  });
+
+  it("arms the controller, resumes a suspended context, and becomes ready", async () => {
+    const controller = createSfxController();
+
+    await controller.arm();
+
+    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
+
+    const context = getLastContext(harness);
+
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(context.state).toBe("running");
+    expect(controller.getStatus()).toBe("ready");
+  });
+
+  it("mutes itself when AudioContext construction fails and play becomes a no-op", async () => {
+    harness.throwOnAudioContextConstruction = true;
+
+    const controller = createSfxController();
+
+    await controller.arm();
+    controller.play("shoot");
+
+    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
+    expect(controller.getStatus()).toBe("muted");
+    expect(harness.oscillators).toHaveLength(0);
+    expect(harness.gains).toHaveLength(0);
+  });
+
+  it("does not create any nodes while idle", () => {
+    const controller = createSfxController();
+
+    controller.play("shoot");
+
+    expect(harness.oscillators).toHaveLength(0);
+    expect(harness.gains).toHaveLength(0);
+  });
+
+  it.each(SFX_NAMES)(
+    "schedules connected short beeps for %s after arming",
+    async (name) => {
+      const controller = createSfxController();
+      await controller.arm();
+
+      const playback = capturePlayback(harness, controller, name);
+
+      expectScheduledShortBeeps(playback, harness.destination);
+    }
+  );
+
+  it("keeps distinct tone patterns across the named SFX", async () => {
+    const controller = createSfxController();
+    await controller.arm();
+
+    const signatures = new Set(
+      SFX_NAMES.map((name) => {
+        const playback = capturePlayback(harness, controller, name);
+
+        return JSON.stringify({
+          oscillatorCount: playback.oscillators.length,
+          frequencies: playback.frequencies,
+          totalDuration: Number(playback.totalDuration.toFixed(3))
+        });
+      })
+    );
+
+    expect(signatures.size).toBeGreaterThan(1);
+  });
+
+  it("creates fresh oscillator and gain nodes on repeated shoot calls", async () => {
+    const controller = createSfxController();
+    await controller.arm();
+
+    const firstPlayback = capturePlayback(harness, controller, "shoot");
+    const secondPlayback = capturePlayback(harness, controller, "shoot");
+
+    expect(firstPlayback.oscillators.length).toBeGreaterThan(0);
+    expect(secondPlayback.oscillators.length).toBe(firstPlayback.oscillators.length);
+    expect(secondPlayback.gains.length).toBe(firstPlayback.gains.length);
+    expect(harness.oscillators).toHaveLength(
+      firstPlayback.oscillators.length + secondPlayback.oscillators.length
+    );
+    expect(harness.gains).toHaveLength(
+      firstPlayback.gains.length + secondPlayback.gains.length
+    );
+
+    firstPlayback.oscillators.forEach((oscillator, index) => {
+      expect(secondPlayback.oscillators[index]).not.toBe(oscillator);
+    });
+    firstPlayback.gains.forEach((gain, index) => {
+      expect(secondPlayback.gains[index]).not.toBe(gain);
+    });
+  });
+});


### PR DESCRIPTION
## Unit-test WebAudio SFX module with mocked AudioContext

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #112

### Changes
Create `src/audio/sfx.test.ts` that exercises the existing `createSfxController` exported from `src/audio/sfx.ts` without touching any real audio device. Use vitest's `vi.stubGlobal` (with `vi.restoreAllMocks()`/`vi.unstubAllGlobals()` between tests) to install mock constructors for `AudioContext`, `OscillatorNode`, and `GainNode`. The mock `AudioContext` should expose a monotonically-advancing `currentTime`, a settable `state` (`suspended` → `running` after `resume()`), an async `resume()` that resolves, a `destination` sentinel, and `createOscillator()` / `createGain()` factories that return spyable mock nodes. Mock oscillator nodes must track `type`, `frequency.value`/`frequency.setValueAtTime` calls, `connect(target)` calls, and `start(time)` / `stop(time)` calls. Mock gain nodes must track `gain.value`, `gain.setValueAtTime`/`gain.linearRampToValueAtTime`/`gain.exponentialRampToValueAtTime` calls, and `connect(target)` calls.

Cover (at minimum): (1) `getStatus()` returns `idle` before `arm()`; (2) `arm()` constructs an `AudioContext`, calls `resume()` when suspended, and flips status to `ready`; (3) when the `AudioContext` constructor throws, `arm()` sets status to `muted` and `play()` becomes a no-op; (4) `play()` is a no-op while status is `idle` (no oscillators created); (5-8) after `arm()`, calling `play('shoot')`, `play('hit')`, `play('playerDeath')`, and `play('waveClear')` each creates at least one oscillator, connects oscillator → gain → destination (verify `connect` call chain), and schedules `start(t)` and `stop(t + duration)` with `stop` time strictly greater than `start` time and within a short upper bound (≤ 1.5 s total per SFX) — treat this bound as the 'short beeps' contract; (9) the four SFX do not all produce identical tone patterns (assert at least two of them differ in oscillator count, frequency, or total scheduled duration) so the test locks in per-name differentiation; (10) repeated `play('shoot')` calls each spawn fresh oscillator/gain nodes (no accidental reuse).

Structure tests with `describe('createSfxController')` and focused `it(...)` cases. Use `beforeEach` to install the global stubs and `afterEach` to restore them so tests stay isolated. Do not import or touch `src/main.ts`, the renderer, or the keyboard controller.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*