### PR TITLE
feature: Add respawn invulnerability window after life lost

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -27,6 +27,7 @@ export type Player = {
   height: number;
   speed: number;
   shootCooldownMs: number;
+  invulnerableUntilMs: number;
 };
 
 export type Invader = {
@@ -78,6 +79,7 @@ export type GameState = {
   playerShootFrame: number;
   nextProjectileId: number;
   transitionTimerMs: number;
+  elapsedMs: number;
 };
 
 export type GameStateSeed = {
@@ -88,6 +90,7 @@ export type GameStateSeed = {
   frame?: number;
   nextProjectileId?: number;
   transitionTimerMs?: number;
+  elapsedMs?: number;
 };
 
 export const ARENA_WIDTH = 960;
@@ -113,6 +116,7 @@ export const INVADER_BASE_SPEED = 72;
 export const INVADER_WAVE_SPEED_STEP = 12;
 export const INVADER_DESCEND_STEP = 24;
 export const LIFE_LOST_DURATION_MS = 900;
+export const RESPAWN_INVULNERABILITY_MS = 1500;
 
 export const EMPTY_INPUT: Input = {
   moveX: 0,
@@ -157,7 +161,8 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
     marchFrame: 0,
     playerShootFrame: 0,
     nextProjectileId,
-    transitionTimerMs: seed.transitionTimerMs ?? 0
+    transitionTimerMs: seed.transitionTimerMs ?? 0,
+    elapsedMs: seed.elapsedMs ?? 0
   };
 }
 
@@ -177,7 +182,8 @@ export function createPlayer(arena: Arena): Player {
     width: PLAYER_WIDTH,
     height: PLAYER_HEIGHT,
     speed: PLAYER_SPEED,
-    shootCooldownMs: 0
+    shootCooldownMs: 0,
+    invulnerableUntilMs: 0
   };
 }
 

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -8,6 +8,7 @@ import {
   LIFE_LOST_DURATION_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
   PROJECTILE_HEIGHT,
+  RESPAWN_INVULNERABILITY_MS,
   STARTING_LIVES,
   createGameState,
   createPlayingState,
@@ -16,6 +17,21 @@ import {
   getPlayerMinX
 } from "./state";
 import { step } from "./step";
+
+function createRespawnedPlayingState() {
+  const lifeLost = {
+    ...createPlayingState({
+      elapsedMs: 2_000,
+      lives: 2,
+      score: 440,
+      wave: 2
+    }),
+    phase: "lifeLost" as const,
+    transitionTimerMs: 50
+  };
+
+  return step(lifeLost, 60, EMPTY_INPUT);
+}
 
 describe("step", () => {
   it("keeps the start screen active without confirm input", () => {
@@ -392,6 +408,85 @@ describe("step", () => {
     expect(next.hud.lives).toBe(2);
     expect(next.invaders).toHaveLength(INVADER_ROWS * INVADER_COLS);
     expect(next.projectiles).toHaveLength(0);
+  });
+
+  it("sets respawn invulnerability ahead of the current simulation time", () => {
+    const next = createRespawnedPlayingState();
+
+    expect(next.phase).toBe("playing");
+    expect(next.elapsedMs).toBe(2_050);
+    expect(next.player.invulnerableUntilMs).toBe(
+      next.elapsedMs + RESPAWN_INVULNERABILITY_MS
+    );
+  });
+
+  it("does not lose another life on invader contact during respawn invulnerability", () => {
+    const respawned = createRespawnedPlayingState();
+    const invader = respawned.invaders[0];
+    expect(invader).toBeDefined();
+    const state = {
+      ...respawned,
+      invaders:
+        invader === undefined
+          ? []
+          : [
+              {
+                ...invader,
+                x: respawned.player.x,
+                y: respawned.player.y
+              }
+            ]
+    };
+
+    const next = step(state, 0, EMPTY_INPUT);
+
+    expect(next.phase).toBe("playing");
+    expect(next.hud.lives).toBe(respawned.hud.lives);
+    expect(next.invaders).toHaveLength(1);
+  });
+
+  it("allows a later collision once respawn invulnerability expires", () => {
+    const respawned = createRespawnedPlayingState();
+    const invader = respawned.invaders[0];
+    expect(invader).toBeDefined();
+    const safeState = {
+      ...respawned,
+      invaders:
+        invader === undefined
+          ? []
+          : [
+              {
+                ...invader,
+                x: respawned.arena.padding,
+                y: 0
+              }
+            ]
+    };
+
+    const expired = step(
+      safeState,
+      RESPAWN_INVULNERABILITY_MS,
+      EMPTY_INPUT
+    );
+    const collidingState = {
+      ...expired,
+      invaders: expired.invaders.map((currentInvader) => ({
+        ...currentInvader,
+        x: expired.player.x,
+        y: expired.player.y
+      }))
+    };
+    const next = step(collidingState, 0, EMPTY_INPUT);
+
+    expect(expired.player.invulnerableUntilMs).toBe(expired.elapsedMs);
+    expect(next.phase).toBe("lifeLost");
+    expect(next.hud.lives).toBe(expired.hud.lives - 1);
+  });
+
+  it("exposes invulnerableUntilMs on state.player for rendering", () => {
+    const state = createPlayingState();
+
+    expect(state.player.invulnerableUntilMs).toBe(0);
   });
 
   it("transitions to game over after the final life is lost", () => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -2,6 +2,7 @@ import {
   EMPTY_INPUT,
   LIFE_LOST_DURATION_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
+  RESPAWN_INVULNERABILITY_MS,
   createGameState,
   createPlayerProjectile,
   getFormationSpeed,
@@ -38,7 +39,8 @@ export function step(state: GameState, dtMs: number, input: Input = EMPTY_INPUT)
             phase: "playing",
             wave: state.hud.wave + 1,
             score: state.hud.score,
-            lives: state.hud.lives
+            lives: state.hud.lives,
+            elapsedMs: state.elapsedMs
           })
         : advanceFrame(state);
     case "gameOver":
@@ -72,19 +74,32 @@ function advanceLifeLost(state: GameState, dtMs: number): GameState {
   if (remaining > 0) {
     return {
       ...state,
-      transitionTimerMs: remaining
+      transitionTimerMs: remaining,
+      elapsedMs: state.elapsedMs + dtMs
     };
   }
 
+  const resolvedElapsedMs = state.elapsedMs + state.transitionTimerMs;
+
   if (state.hud.lives > 0) {
-    return createGameState({
+    const respawnedState = createGameState({
       phase: "playing",
       wave: state.hud.wave,
       score: state.hud.score,
       lives: state.hud.lives,
       frame: state.frame + 1,
-      nextProjectileId: state.nextProjectileId
+      nextProjectileId: state.nextProjectileId,
+      elapsedMs: resolvedElapsedMs
     });
+
+    return {
+      ...respawnedState,
+      player: {
+        ...respawnedState.player,
+        invulnerableUntilMs:
+          resolvedElapsedMs + RESPAWN_INVULNERABILITY_MS
+      }
+    };
   }
 
   return {
@@ -97,7 +112,8 @@ function advanceLifeLost(state: GameState, dtMs: number): GameState {
       ...state.player,
       shootCooldownMs: 0
     },
-    frame: state.frame + 1
+    frame: state.frame + 1,
+    elapsedMs: resolvedElapsedMs
   };
 }
 
@@ -111,6 +127,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
 
   const dtSeconds = dtMs / 1000;
   const nextFrame = state.frame + 1;
+  const nextElapsedMs = state.elapsedMs + dtMs;
   const cooldown = Math.max(0, state.player.shootCooldownMs - dtMs);
   const playerShootFrame = Math.max(0, state.playerShootFrame - dtMs);
   const movedPlayer = {
@@ -136,8 +153,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
   const marchFrame = formationBundle.didAdvance
     ? toggleMarchFrame(state.marchFrame)
     : state.marchFrame;
+  const playerIsInvulnerable =
+    movedPlayer.invulnerableUntilMs > nextElapsedMs;
 
-  if (hasInvaderBreached(collisionBundle.invaders, movedPlayer)) {
+  if (!playerIsInvulnerable && hasInvaderBreached(collisionBundle.invaders, movedPlayer)) {
     return {
       ...state,
       phase: "lifeLost",
@@ -157,7 +176,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       },
       transitionTimerMs: LIFE_LOST_DURATION_MS,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId
+      nextProjectileId: projectileBundle.nextProjectileId,
+      elapsedMs: nextElapsedMs
     };
   }
 
@@ -180,7 +200,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       },
       transitionTimerMs: 0,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId
+      nextProjectileId: projectileBundle.nextProjectileId,
+      elapsedMs: nextElapsedMs
     };
   }
 
@@ -201,7 +222,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     },
     frame: nextFrame,
     transitionTimerMs: 0,
-    nextProjectileId: projectileBundle.nextProjectileId
+    nextProjectileId: projectileBundle.nextProjectileId,
+    elapsedMs: nextElapsedMs
   };
 }
 


### PR DESCRIPTION
## Add respawn invulnerability window after life lost

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #124

### Changes
Extend the pure simulation to grant the player ~1500ms of invulnerability after a LIFE_LOST phase resolves back to playing. (1) In src/game/state.ts, add `invulnerableUntilMs: number` to the `Player` type and initialize it to 0 in `createPlayingState` / new-game helpers. Export a new `RESPAWN_INVULNERABILITY_MS` constant (1500). (2) In src/game/step.ts, when transitioning out of the `lifeLost` phase (once `LIFE_LOST_DURATION_MS` elapses and the player respawns), set `player.invulnerableUntilMs` to the current elapsed time + RESPAWN_INVULNERABILITY_MS. Track elapsed simulation time on the state (e.g. bump an existing time counter or add `elapsedMs` to GameState if not already present — inspect state.ts first). During `playing`, decrement/track and skip both invader-body collision against the player and any invader-projectile collision against the player while `invulnerableUntilMs > elapsedMs`. Expose the flag to consumers via a derived `player.invulnerableUntilMs` field (do NOT add separate boolean — the renderer can compare against state time). (3) Add test cases to src/game/step.test.ts covering: (a) after LIFE_LOST resolves, `invulnerableUntilMs` is set ahead of current sim time; (b) invader-body collision against the player during the window does NOT decrement lives or trigger another lifeLost; (c) after ~1500ms of sim steps, `invulnerableUntilMs` is no longer in the future and a subsequent collision DOES trigger a life loss; (d) the `invulnerableUntilMs` field is accessible on `state.player` for the renderer to flicker. If invader projectile support already exists in step.ts, also add a test that an invader projectile passes through the player during the window; if not, skip that case. Keep `any` out — all new state fields must be typed.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*