### PR TITLE
bug_fix: Emit rising-edge firePressed/pausePressed from keyboard adapter

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -10,6 +10,8 @@ export type Input = {
   moveX: -1 | 0 | 1;
   firePressed: boolean;
   pausePressed: boolean;
+  fireHeld?: boolean;
+  pauseHeld?: boolean;
   mutePressed?: boolean;
 };
 
@@ -122,6 +124,8 @@ export const EMPTY_INPUT: Input = {
   moveX: 0,
   firePressed: false,
   pausePressed: false,
+  fireHeld: false,
+  pauseHeld: false,
   mutePressed: false
 };
 

--- a/src/input/keyboard.ts
+++ b/src/input/keyboard.ts
@@ -94,6 +94,8 @@ export function createKeyboardController(target: Window = window): KeyboardContr
         moveX,
         firePressed: held.fireEdge,
         pausePressed: held.pauseEdge,
+        fireHeld: held.fire,
+        pauseHeld: held.pause,
         mutePressed: held.muteEdge
       };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,8 @@ const loop = createFixedStepLoop({
       : {
           ...frameInput,
           firePressed: false,
-          pausePressed: false
+          pausePressed: false,
+          mutePressed: false
         };
     const previousState = state;
     state = step(state, dtMs, stepInput);


### PR DESCRIPTION
## Emit rising-edge firePressed/pausePressed from keyboard adapter

**Category:** `bug_fix` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #137

### Changes
Fix the keyboard adapter so the per-frame Input snapshot reports firePressed and pausePressed as rising edges (true only on the first frame the key transitioned from up to down) rather than every frame the key is held. The adapter already tracks `fireEdge`/`pauseEdge`/`muteEdge` internally — verify and make snapshot() return those as firePressed/pausePressed/mutePressed and clear them after each snapshot so the next frame starts fresh. Also expose held state: add optional `fireHeld` and `pauseHeld` booleans to the `Input` type in `src/game/state.ts` and populate them from the keyboard adapter for use by callers that want continuous-hold info. Update `EMPTY_INPUT` in state.ts to include the new fields (default false). Update call sites in `src/main.ts` as needed (they should already consume the snapshot structurally, but verify types still compile). This closes a latent bug where `step.ts` phase transitions (start→playing, paused toggle, game-over restart) retrigger every frame the space/P key is held, because `step.ts` treats firePressed as an edge. All existing step.test.ts cases must continue to pass since they already use edge semantics via `EMPTY_INPUT` spreads.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*