### PR TITLE
feature: Add HUD rendering (score, lives, wave) to canvas renderer

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createPlayingState } from "../game/state";
+import { createCanvasRenderer } from "./canvas";
+import { PLAYER_SHIP_DESCRIPTOR } from "./sprites";
+
+const HUD_TOP = 18;
+const HUD_HEIGHT = 68;
+const HUD_SHIP_COLORS = new Set(Object.values(PLAYER_SHIP_DESCRIPTOR.palette));
+
+type FillRectCall = {
+  fillStyle: string | CanvasGradient | CanvasPattern;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type FillTextCall = {
+  font: string;
+  text: string;
+  textAlign: CanvasTextAlign;
+  x: number;
+  y: number;
+};
+
+class FakeCanvasGradient {
+  readonly colorStops: Array<{ color: string; offset: number }> = [];
+
+  addColorStop(offset: number, color: string): void {
+    this.colorStops.push({ color, offset });
+  }
+}
+
+class FakeCanvasContext {
+  readonly fillRectCalls: FillRectCall[] = [];
+  readonly fillTextCalls: FillTextCall[] = [];
+
+  fillStyle: string | CanvasGradient | CanvasPattern = "";
+  font = "";
+  lineWidth = 1;
+  strokeStyle: string | CanvasGradient | CanvasPattern = "";
+  textAlign: CanvasTextAlign = "start";
+
+  arc(): void {}
+
+  beginPath(): void {}
+
+  clearRect(): void {}
+
+  closePath(): void {}
+
+  createLinearGradient(): CanvasGradient {
+    return new FakeCanvasGradient() as unknown as CanvasGradient;
+  }
+
+  createRadialGradient(): CanvasGradient {
+    return new FakeCanvasGradient() as unknown as CanvasGradient;
+  }
+
+  fill(): void {}
+
+  fillRect(x: number, y: number, width: number, height: number): void {
+    this.fillRectCalls.push({
+      fillStyle: this.fillStyle,
+      x,
+      y,
+      width,
+      height
+    });
+  }
+
+  fillText(text: string, x: number, y: number): void {
+    this.fillTextCalls.push({
+      font: this.font,
+      text,
+      textAlign: this.textAlign,
+      x,
+      y
+    });
+  }
+
+  lineTo(): void {}
+
+  moveTo(): void {}
+
+  roundRect(): void {}
+
+  setTransform(): void {}
+
+  stroke(): void {}
+}
+
+function createFakeCanvas(context: FakeCanvasContext): HTMLCanvasElement {
+  return {
+    getContext: (contextId: string) =>
+      contextId === "2d" ? (context as unknown as CanvasRenderingContext2D) : null,
+    height: 0,
+    width: 0
+  } as HTMLCanvasElement;
+}
+
+function countClusters(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  let clusterCount = 1;
+  let previous = values[0];
+
+  for (const value of values.slice(1)) {
+    if (previous !== undefined && value - previous > 8) {
+      clusterCount += 1;
+    }
+
+    previous = value;
+  }
+
+  return clusterCount;
+}
+
+describe("createCanvasRenderer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the HUD score, wave, and one ship glyph per remaining life", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState({
+        lives: 3,
+        score: 120,
+        wave: 2
+      }),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, { bootstrapping: false, muted: false });
+
+    expect(
+      context.fillTextCalls.some(
+        (call) =>
+          call.text.startsWith("SCORE ") &&
+          call.text.includes(String(state.hud.score))
+      )
+    ).toBe(true);
+    expect(
+      context.fillTextCalls.some(
+        (call) =>
+          call.text.startsWith("WAVE ") &&
+          call.text.includes(String(state.hud.wave))
+      )
+    ).toBe(true);
+
+    const hudLifeFillRects = context.fillRectCalls.filter(
+      (call) =>
+        typeof call.fillStyle === "string" &&
+        HUD_SHIP_COLORS.has(call.fillStyle) &&
+        call.y >= HUD_TOP &&
+        call.y < HUD_TOP + HUD_HEIGHT
+    );
+    const uniqueHudXValues = [...new Set(hudLifeFillRects.map((call) => call.x))].sort(
+      (left, right) => left - right
+    );
+
+    expect(countClusters(uniqueHudXValues)).toBe(state.hud.lives);
+  });
+});

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -18,6 +18,8 @@ export type CanvasRenderer = {
 };
 
 const HUD_HEIGHT = 68;
+const HUD_MONOSPACE_FONT =
+  '600 18px ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace';
 
 type PreparedSprite = {
   frameCount: number;
@@ -27,6 +29,11 @@ type PreparedSprite = {
 };
 
 const PLAYER_SHIP_SPRITE = prepareSprite(PLAYER_SHIP_DESCRIPTOR);
+const HUD_PLAYER_SHIP_SPRITE = prepareSprite({
+  ...PLAYER_SHIP_DESCRIPTOR,
+  id: "hud-player-ship",
+  pixelSize: 2
+});
 const INVADER_ROW_SPRITES = INVADER_ROW_DESCRIPTORS.map(prepareSprite);
 const PLAYER_PROJECTILE_SPRITE = prepareSprite(PLAYER_PROJECTILE_DESCRIPTOR);
 
@@ -181,19 +188,31 @@ function drawBackground(
 }
 
 function drawHud(context: CanvasRenderingContext2D, state: GameState): void {
+  const hudX = 22;
+  const hudY = 18;
+  const hudWidth = state.arena.width - 44;
+  const hudRight = hudX + hudWidth;
+
   context.fillStyle = "rgba(8, 14, 30, 0.78)";
-  context.fillRect(22, 18, state.arena.width - 44, HUD_HEIGHT);
+  context.fillRect(hudX, hudY, hudWidth, HUD_HEIGHT);
 
   context.strokeStyle = "rgba(140, 207, 255, 0.26)";
   context.lineWidth = 1.5;
-  roundRect(context, 22, 18, state.arena.width - 44, HUD_HEIGHT, 20);
+  roundRect(context, hudX, hudY, hudWidth, HUD_HEIGHT, 20);
   context.stroke();
 
-  context.font = '600 18px "Arial Narrow", "Avenir Next Condensed", sans-serif';
+  context.font = HUD_MONOSPACE_FONT;
   context.fillStyle = "#d3f4ff";
-  context.fillText(`SCORE ${padScore(state.hud.score)}`, 44, 60);
-  context.fillText(`WAVE ${state.hud.wave}`, state.arena.width / 2 - 44, 60);
-  context.fillText(`LIVES ${state.hud.lives}`, state.arena.width - 156, 60);
+  context.fillText(`SCORE ${padHudScore(state.hud.score)}`, hudX + 22, hudY + 42);
+
+  context.textAlign = "center";
+  context.fillText(`WAVE ${state.hud.wave}`, state.arena.width / 2, hudY + 42);
+
+  context.textAlign = "right";
+  context.fillText("LIVES", hudRight - 22, hudY + 26);
+  context.textAlign = "start";
+
+  drawHudLives(context, state, hudRight);
 }
 
 function drawInvaders(
@@ -358,6 +377,33 @@ function drawOverlay(
 
 function padScore(score: number): string {
   return score.toString().padStart(4, "0");
+}
+
+function padHudScore(score: number): string {
+  return score.toString().padStart(6, "0");
+}
+
+function drawHudLives(
+  context: CanvasRenderingContext2D,
+  state: GameState,
+  hudRight: number
+): void {
+  const lifeCount = Math.max(0, state.hud.lives);
+
+  if (lifeCount === 0) {
+    return;
+  }
+
+  const gap = 10;
+  const totalWidth =
+    lifeCount * HUD_PLAYER_SHIP_SPRITE.width + (lifeCount - 1) * gap;
+  let x = hudRight - 22 - totalWidth;
+  const y = 56;
+
+  for (let index = 0; index < lifeCount; index += 1) {
+    HUD_PLAYER_SHIP_SPRITE.sheet.drawFrame(context, 0, x, y);
+    x += HUD_PLAYER_SHIP_SPRITE.width + gap;
+  }
 }
 
 function roundRect(


### PR DESCRIPTION
## Add HUD rendering (score, lives, wave) to canvas renderer

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #132

### Changes
Extend src/render/canvas.ts to draw a top HUD bar showing state.hud.score, state.hud.lives, and state.hud.wave. Use Canvas 2D fillText with a monospaced system font (e.g. 'monospace' or 'ui-monospace, monospace') at a legible size for crisp text. Labels should be clearly readable — e.g. 'SCORE 000120', 'WAVE 1', and a lives indicator rendered as N small player-ship glyphs (one per remaining life) using the existing PLAYER_SHIP_SPRITE sheet (or a simple shape fallback). The HUD_HEIGHT constant (already 68) reserves space at the top — draw HUD content inside that band. Pure read of GameState — do NOT mutate state. Create src/render/canvas.test.ts with a mocked CanvasRenderingContext2D that records fillText calls and sprite/fillRect draw calls. Assert: (1) an fillText call occurs whose text contains the score value, (2) an fillText call contains the wave value, (3) the number of life glyphs rendered equals state.hud.lives (e.g. count fillText 'lives' string occurrences or sprite draws at distinct HUD x positions). Build the fake context by implementing the subset of CanvasRenderingContext2D methods the renderer invokes (getContext in tests can return the fake via a stubbed canvas). If overlap exists with the open 'phase overlays' task, confine changes strictly to HUD drawing logic (top bar) and do not add overlay rendering here.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*