### PR TITLE
feature: Add destructible bunker shields to pure simulation

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -52,6 +52,20 @@ export type Projectile = {
   active: boolean;
 };
 
+export type ShieldCell = {
+  id: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  alive: boolean;
+};
+
+export type Shield = {
+  id: number;
+  cells: ShieldCell[];
+};
+
 export type Formation = {
   direction: -1 | 1;
   speed: number;
@@ -72,6 +86,7 @@ export type GameState = {
   player: Player;
   invaders: Invader[];
   projectiles: Projectile[];
+  shields: Shield[];
   formation: Formation;
   hud: HudState;
   frame: number;
@@ -105,6 +120,11 @@ export const STARTING_LIVES = 3;
 export const PROJECTILE_WIDTH = 6;
 export const PROJECTILE_HEIGHT = 18;
 export const PROJECTILE_SPEED = -720;
+export const SHIELD_COUNT = 4;
+export const SHIELD_CELL_ROWS = 4;
+export const SHIELD_CELL_COLS = 6;
+export const SHIELD_CELL_WIDTH = 16;
+export const SHIELD_CELL_HEIGHT = 12;
 export const INVADER_ROWS = 5;
 export const INVADER_COLS = 11;
 export const INVADER_WIDTH = 48;
@@ -143,6 +163,7 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
   const score = seed.score ?? 0;
   const lives = seed.lives ?? STARTING_LIVES;
   const invaders = createInvaders(arena, wave);
+  const shields = createShields(arena);
   const nextProjectileId = seed.nextProjectileId ?? 1;
 
   return {
@@ -151,6 +172,7 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
     player: createPlayer(arena),
     invaders,
     projectiles: [],
+    shields,
     formation: createFormation(arena, wave),
     hud: {
       score,
@@ -222,6 +244,58 @@ export function createInvaders(arena: Arena, wave: number): Invader[] {
   }
 
   return invaders;
+}
+
+export function createShields(arena: Arena): Shield[] {
+  const shieldWidth = SHIELD_CELL_COLS * SHIELD_CELL_WIDTH;
+  const shieldHeight = SHIELD_CELL_ROWS * SHIELD_CELL_HEIGHT;
+  const availableWidth = arena.width - arena.padding * 2;
+  const gapX = Math.max(
+    0,
+    (availableWidth - SHIELD_COUNT * shieldWidth) / (SHIELD_COUNT + 1)
+  );
+  const invaderBottom =
+    INVADER_START_Y +
+    INVADER_ROWS * INVADER_HEIGHT +
+    (INVADER_ROWS - 1) * INVADER_GAP_Y;
+  const playerTop = arena.floorY - PLAYER_HEIGHT;
+  const desiredY =
+    invaderBottom + (playerTop - invaderBottom - shieldHeight) / 2;
+  const startY = Math.min(
+    playerTop - shieldHeight,
+    Math.max(invaderBottom, desiredY)
+  );
+
+  let cellId = 1;
+
+  return Array.from({ length: SHIELD_COUNT }, (_, shieldIndex) => {
+    const startX =
+      arena.padding + gapX * (shieldIndex + 1) + shieldWidth * shieldIndex;
+    const cells = Array.from(
+      { length: SHIELD_CELL_ROWS * SHIELD_CELL_COLS },
+      (_, cellIndex) => {
+        const row = Math.floor(cellIndex / SHIELD_CELL_COLS);
+        const col = cellIndex % SHIELD_CELL_COLS;
+
+        const cell: ShieldCell = {
+          id: cellId,
+          x: startX + col * SHIELD_CELL_WIDTH,
+          y: startY + row * SHIELD_CELL_HEIGHT,
+          width: SHIELD_CELL_WIDTH,
+          height: SHIELD_CELL_HEIGHT,
+          alive: true
+        };
+
+        cellId += 1;
+        return cell;
+      }
+    );
+
+    return {
+      id: shieldIndex + 1,
+      cells
+    };
+  });
 }
 
 export function createPlayerProjectile(

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -8,15 +8,23 @@ import {
   LIFE_LOST_DURATION_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
   PROJECTILE_HEIGHT,
+  PROJECTILE_SPEED,
+  PROJECTILE_WIDTH,
   RESPAWN_INVULNERABILITY_MS,
+  SHIELD_COUNT,
+  SHIELD_CELL_COLS,
+  SHIELD_CELL_ROWS,
   STARTING_LIVES,
   createGameState,
   createPlayingState,
   getFormationSpeed,
   getPlayerMaxX,
-  getPlayerMinX
+  getPlayerMinX,
+  type GameState
 } from "./state";
 import { step } from "./step";
+
+const SHIELD_HIT_DT_MS = 21;
 
 function createRespawnedPlayingState() {
   const lifeLost = {
@@ -31,6 +39,55 @@ function createRespawnedPlayingState() {
   };
 
   return step(lifeLost, 60, EMPTY_INPUT);
+}
+
+function getShieldCell(state: GameState, shieldIndex: number, row: number, col: number) {
+  const cell = state.shields[shieldIndex]?.cells[row * SHIELD_CELL_COLS + col];
+  if (cell === undefined) {
+    throw new Error(`Missing shield cell ${shieldIndex}:${row},${col}`);
+  }
+  return cell;
+}
+
+function countAliveShieldCells(state: GameState): number {
+  return state.shields.flatMap((shield) => shield.cells).filter((cell) => cell.alive).length;
+}
+
+function setShieldCellAlive(state: GameState, cellId: number, alive: boolean): GameState {
+  return {
+    ...state,
+    shields: state.shields.map((shield) => ({
+      ...shield,
+      cells: shield.cells.map((cell) =>
+        cell.id === cellId
+          ? {
+              ...cell,
+              alive
+            }
+          : cell
+      )
+    }))
+  };
+}
+
+function createShieldProjectile(
+  state: GameState,
+  row: number,
+  col: number,
+  id: number,
+  velocityY: number
+) {
+  const cell = getShieldCell(state, 0, row, col);
+  return {
+    id,
+    owner: "player" as const,
+    x: cell.x + (cell.width - PROJECTILE_WIDTH) / 2,
+    y: velocityY < 0 ? cell.y + cell.height + 4 : cell.y - PROJECTILE_HEIGHT - 4,
+    width: PROJECTILE_WIDTH,
+    height: PROJECTILE_HEIGHT,
+    velocityY,
+    active: true
+  };
 }
 
 describe("step", () => {
@@ -98,6 +155,85 @@ describe("step", () => {
 
     expect(next.projectiles).toHaveLength(1);
     expect(next.player.shootCooldownMs).toBe(PLAYER_SHOOT_COOLDOWN_MS);
+  });
+
+  it("creates a full set of live shield cells for a fresh playing state", () => {
+    const state = createPlayingState();
+
+    expect(state.shields).toHaveLength(SHIELD_COUNT);
+    expect(countAliveShieldCells(state)).toBe(SHIELD_COUNT * SHIELD_CELL_ROWS * SHIELD_CELL_COLS);
+    expect(state.shields.flatMap((shield) => shield.cells).every((cell) => cell.alive)).toBe(true);
+  });
+
+  it.each([
+    ["destroys exactly one shield cell from an upward projectile and consumes it", SHIELD_CELL_ROWS - 1, PROJECTILE_SPEED],
+    ["destroys a shield cell from above with a downward projectile and consumes it", 0, Math.abs(PROJECTILE_SPEED)]
+  ])("%s", (_, targetRow, velocityY) => {
+    const targetCol = 2;
+    const base = createPlayingState();
+    const next = step(
+      {
+        ...base,
+        projectiles: [createShieldProjectile(base, targetRow, targetCol, 1, velocityY)],
+        nextProjectileId: 2
+      },
+      SHIELD_HIT_DT_MS,
+      EMPTY_INPUT
+    );
+
+    expect(next.projectiles).toHaveLength(0);
+    expect(getShieldCell(next, 0, targetRow, targetCol).alive).toBe(false);
+    expect(countAliveShieldCells(next)).toBe(countAliveShieldCells(base) - 1);
+  });
+
+  it("lets a projectile continue through a dead shield-cell gap", () => {
+    const targetRow = SHIELD_CELL_ROWS - 1;
+    const targetCol = 2;
+    const base = createPlayingState();
+    const cell = getShieldCell(base, 0, targetRow, targetCol);
+    const stateWithGap = setShieldCellAlive(base, cell.id, false);
+    const projectile = createShieldProjectile(stateWithGap, targetRow, targetCol, 1, PROJECTILE_SPEED);
+    const state = {
+      ...stateWithGap,
+      projectiles: [projectile],
+      nextProjectileId: 2
+    };
+
+    const next = step(state, SHIELD_HIT_DT_MS, EMPTY_INPUT);
+
+    expect(next.projectiles).toHaveLength(1);
+    expect(next.projectiles[0]?.y).toBeLessThan(projectile.y);
+    expect(getShieldCell(next, 0, targetRow, targetCol).alive).toBe(false);
+    expect(countAliveShieldCells(next)).toBe(countAliveShieldCells(stateWithGap));
+  });
+
+  it("only destroys a shield cell once and later projectiles pass through that slot", () => {
+    const targetRow = SHIELD_CELL_ROWS - 1;
+    const targetCol = 2;
+    const base = createPlayingState();
+    const firstHitState = {
+      ...base,
+      projectiles: [createShieldProjectile(base, targetRow, targetCol, 1, PROJECTILE_SPEED)],
+      nextProjectileId: 2
+    };
+
+    const afterFirstHit = step(firstHitState, SHIELD_HIT_DT_MS, EMPTY_INPUT);
+    const secondShot = createShieldProjectile(afterFirstHit, targetRow, targetCol, 2, PROJECTILE_SPEED);
+    const secondState = {
+      ...afterFirstHit,
+      projectiles: [secondShot],
+      nextProjectileId: 3
+    };
+
+    const afterSecondHit = step(secondState, SHIELD_HIT_DT_MS, EMPTY_INPUT);
+
+    expect(getShieldCell(afterFirstHit, 0, targetRow, targetCol).alive).toBe(false);
+    expect(getShieldCell(afterSecondHit, 0, targetRow, targetCol).alive).toBe(false);
+    expect(countAliveShieldCells(afterSecondHit)).toBe(
+      countAliveShieldCells(afterFirstHit)
+    );
+    expect(afterSecondHit.projectiles).toHaveLength(1);
+    expect(afterSecondHit.projectiles[0]?.y).toBeLessThan(secondShot.y);
   });
 
   it("does not fire another projectile while the cooldown is active", () => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -13,7 +13,8 @@ import {
   type GameState,
   type Input,
   type Invader,
-  type Projectile
+  type Projectile,
+  type Shield
 } from "./state";
 
 type Rect = {
@@ -146,9 +147,17 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     input.firePressed,
     playerShootFrame
   );
-  const movedProjectiles = moveProjectiles(projectileBundle.projectiles, dtSeconds, state.arena.height);
+  const projectileShieldBundle = moveProjectilesThroughShields(
+    projectileBundle.projectiles,
+    dtSeconds,
+    state.arena.height,
+    state.shields
+  );
   const formationBundle = moveInvaders(state, dtSeconds);
-  const collisionBundle = resolveProjectileHits(movedProjectiles, formationBundle.invaders);
+  const collisionBundle = resolveProjectileHits(
+    projectileShieldBundle.projectiles,
+    formationBundle.invaders
+  );
   const score = state.hud.score + collisionBundle.scoreDelta;
   const marchFrame = formationBundle.didAdvance
     ? toggleMarchFrame(state.marchFrame)
@@ -167,6 +176,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         shootCooldownMs: 0
       },
       projectiles: [],
+      shields: projectileShieldBundle.shields,
       invaders: collisionBundle.invaders,
       formation: formationBundle.formation,
       hud: {
@@ -192,6 +202,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         shootCooldownMs: projectileBundle.playerShootCooldownMs
       },
       projectiles: [],
+      shields: projectileShieldBundle.shields,
       invaders: [],
       formation: formationBundle.formation,
       hud: {
@@ -214,6 +225,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       shootCooldownMs: projectileBundle.playerShootCooldownMs
     },
     projectiles: collisionBundle.projectiles,
+    shields: projectileShieldBundle.shields,
     invaders: collisionBundle.invaders,
     formation: formationBundle.formation,
     hud: {
@@ -261,22 +273,57 @@ function maybeSpawnProjectile(
   };
 }
 
-function moveProjectiles(
+function moveProjectilesThroughShields(
   projectiles: Projectile[],
   dtSeconds: number,
-  arenaHeight: number
-): Projectile[] {
-  return projectiles
-    .map((projectile) => ({
+  arenaHeight: number,
+  shields: Shield[]
+): {
+  projectiles: Projectile[];
+  shields: Shield[];
+} {
+  let nextShields = shields;
+  const nextProjectiles: Projectile[] = [];
+
+  for (const projectile of projectiles) {
+    const movedProjectile = {
       ...projectile,
       y: projectile.y + projectile.velocityY * dtSeconds
-    }))
-    .filter(
-      (projectile) =>
-        projectile.active &&
-        projectile.y + projectile.height >= 0 &&
-        projectile.y <= arenaHeight
-    );
+    };
+    const collision = findShieldCollision(projectile, movedProjectile, nextShields);
+
+    if (collision !== undefined) {
+      nextShields = nextShields.map((shield) =>
+        shield.id !== collision.shieldId
+          ? shield
+          : {
+              ...shield,
+              cells: shield.cells.map((cell) =>
+                cell.id !== collision.cellId
+                  ? cell
+                  : {
+                      ...cell,
+                      alive: false
+                    }
+              )
+            }
+      );
+      continue;
+    }
+
+    if (
+      movedProjectile.active &&
+      movedProjectile.y + movedProjectile.height >= 0 &&
+      movedProjectile.y <= arenaHeight
+    ) {
+      nextProjectiles.push(movedProjectile);
+    }
+  }
+
+  return {
+    projectiles: nextProjectiles,
+    shields: nextShields
+  };
 }
 
 function moveInvaders(
@@ -365,6 +412,75 @@ function resolveProjectileHits(
       (projectile) => !consumedProjectileIds.has(projectile.id)
     ),
     scoreDelta
+  };
+}
+
+function findShieldCollision(
+  projectile: Projectile,
+  movedProjectile: Projectile,
+  shields: Shield[]
+):
+  | {
+      shieldId: number;
+      cellId: number;
+    }
+  | undefined {
+  const path = getProjectilePath(projectile, movedProjectile);
+  const movingDown = movedProjectile.velocityY > 0;
+  let collision:
+    | {
+        shieldId: number;
+        cellId: number;
+        edge: number;
+      }
+    | undefined;
+
+  for (const shield of shields) {
+    for (const cell of shield.cells) {
+      if (!cell.alive || !intersects(cell, path)) {
+        continue;
+      }
+
+      const edge = movingDown ? cell.y : cell.y + cell.height;
+      if (
+        collision === undefined ||
+        (movingDown ? edge < collision.edge : edge > collision.edge) ||
+        (edge === collision.edge && cell.id < collision.cellId)
+      ) {
+        collision = {
+          shieldId: shield.id,
+          cellId: cell.id,
+          edge
+        };
+      }
+    }
+  }
+
+  return collision === undefined
+    ? undefined
+    : { shieldId: collision.shieldId, cellId: collision.cellId };
+}
+
+function getProjectilePath(
+  projectile: Projectile,
+  movedProjectile: Projectile
+): Rect {
+  const left = Math.min(projectile.x, movedProjectile.x);
+  const right = Math.max(
+    projectile.x + projectile.width,
+    movedProjectile.x + movedProjectile.width
+  );
+  const top = Math.min(projectile.y, movedProjectile.y);
+  const bottom = Math.max(
+    projectile.y + projectile.height,
+    movedProjectile.y + movedProjectile.height
+  );
+
+  return {
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top
   };
 }
 


### PR DESCRIPTION
## Add destructible bunker shields to pure simulation

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #93

### Changes
Introduce bunker/shield entities to the pure simulation. In src/game/state.ts: add a `ShieldCell` type `{ id: number; x: number; y: number; width: number; height: number; alive: boolean }` and a `Shield` type grouping a grid of cells (e.g. `{ id: number; cells: ShieldCell[] }`). Add a `shields: Shield[]` field to `GameState`. Export constants for shield count (e.g. 4), cells-per-shield grid dimensions, and cell size, plus a `createShields(arena)` helper that positions shield rectangles evenly between the player row and the invader formation. Wire shield creation into the existing `createGameState` / `createPlayingState` / `createInitialGameState` helpers so a fresh playing state always has populated shields, and preserve shields through non-reset phase transitions the same way existing entities are preserved. In src/game/step.ts: during projectile advancement, test each active projectile AABB against every alive shield cell. On collision, mark the cell `alive: false` (produce a new array/shield immutably, consistent with existing pure-step style) and deactivate/remove the projectile, consuming it so it does not continue past the shield. The collision logic must work for a projectile moving in either vertical direction (velocityY > 0 or < 0), so it is forward-compatible with future invader projectiles even though only player projectiles exist today. In src/game/step.test.ts: add at least five focused tests covering (1) a fresh playing state has the expected number of shields and cells with all cells alive, (2) a player projectile whose path crosses a shield cell from below destroys exactly that cell and is removed from state.projectiles, (3) a projectile with downward velocity (manually constructed with velocityY > 0) destroys a shield cell from above and is consumed — exercising the bidirectional collision, (4) a projectile passing through a gap where cells are already dead continues unaffected, (5) repeated hits on the same cell only destroy it once and subsequent projectiles pass through that now-dead slot. Keep everything pure-data — no renderer or DOM changes.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*