### PR TITLE
feature: Scale formation march speed by kill count and wave number

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -134,8 +134,13 @@ export const INVADER_HEIGHT = 30;
 export const INVADER_GAP_X = 18;
 export const INVADER_GAP_Y = 18;
 export const INVADER_START_Y = 108;
-export const INVADER_BASE_SPEED = 72;
-export const INVADER_WAVE_SPEED_STEP = 12;
+export const FORMATION_SPEED_BASE = 72;
+export const FORMATION_SPEED_PER_WAVE = 1 / 6;
+export const FORMATION_SPEED_MAX = 288;
+const FORMATION_SPEED_END_MULTIPLIER = 2.7;
+export const INVADER_BASE_SPEED = FORMATION_SPEED_BASE;
+export const INVADER_WAVE_SPEED_STEP =
+  FORMATION_SPEED_BASE * FORMATION_SPEED_PER_WAVE;
 export const INVADER_DESCEND_STEP = 24;
 export const LIFE_LOST_DURATION_MS = 900;
 export const RESPAWN_INVULNERABILITY_MS = 1500;
@@ -216,7 +221,7 @@ export function createPlayer(arena: Arena): Player {
 export function createFormation(arena: Arena, wave: number): Formation {
   return {
     direction: 1,
-    speed: INVADER_BASE_SPEED + Math.max(0, wave - 1) * INVADER_WAVE_SPEED_STEP,
+    speed: getFormationBaseSpeed(wave),
     descendStep: INVADER_DESCEND_STEP,
     leftBound: arena.padding,
     rightBound: arena.width - arena.padding
@@ -329,10 +334,15 @@ export function getPlayerMaxX(arena: Arena, player: Player): number {
 
 export function getFormationSpeed(invaderCount: number, baseSpeed: number): number {
   const totalInvaders = INVADER_ROWS * INVADER_COLS;
-  const eliminated = totalInvaders - invaderCount;
-  const intensity = eliminated / totalInvaders;
+  const clampedInvaderCount = Math.max(0, Math.min(invaderCount, totalInvaders));
+  const eliminatedRatio = (totalInvaders - clampedInvaderCount) / totalInvaders;
+  const startSpeed = Math.min(baseSpeed, FORMATION_SPEED_MAX);
+  const maxSpeed = Math.min(
+    startSpeed * FORMATION_SPEED_END_MULTIPLIER,
+    FORMATION_SPEED_MAX
+  );
 
-  return baseSpeed * (1 + intensity * 1.7);
+  return startSpeed + (maxSpeed - startSpeed) * eliminatedRatio;
 }
 
 export function getProjectileSpawnX(player: Player): number {
@@ -341,4 +351,13 @@ export function getProjectileSpawnX(player: Player): number {
 
 export function getProjectileSpawnY(player: Player): number {
   return player.y - PROJECTILE_HEIGHT;
+}
+
+function getFormationBaseSpeed(wave: number): number {
+  const waveOffset = Math.max(0, wave - 1);
+
+  return Math.min(
+    FORMATION_SPEED_BASE * (1 + waveOffset * FORMATION_SPEED_PER_WAVE),
+    FORMATION_SPEED_MAX
+  );
 }

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   EMPTY_INPUT,
+  FORMATION_SPEED_MAX,
   INVADER_COLS,
   INVADER_HEIGHT,
   INVADER_ROWS,
@@ -464,6 +465,38 @@ describe("step", () => {
     expect(reducedDelta).toBeGreaterThan(fullDelta);
     expect(getFormationSpeed(reduced.invaders.length, reduced.formation.speed)).toBeGreaterThan(
       getFormationSpeed(full.invaders.length, full.formation.speed)
+    );
+  });
+
+  it("increases march speed as invaders are cleared within the same wave", () => {
+    const totalInvaders = INVADER_ROWS * INVADER_COLS;
+    const state = createPlayingState({ wave: 1 });
+    const fullRosterSpeed = getFormationSpeed(totalInvaders, state.formation.speed);
+    const halfRosterSpeed = getFormationSpeed(
+      Math.ceil(totalInvaders / 2),
+      state.formation.speed
+    );
+    const oneInvaderSpeed = getFormationSpeed(1, state.formation.speed);
+
+    expect(fullRosterSpeed).toBeLessThan(halfRosterSpeed);
+    expect(halfRosterSpeed).toBeLessThan(oneInvaderSpeed);
+  });
+
+  it("starts higher waves with a faster formation speed at the same kill count", () => {
+    const totalInvaders = INVADER_ROWS * INVADER_COLS;
+    const lowWave = createPlayingState({ wave: 1 });
+    const highWave = createPlayingState({ wave: 4 });
+
+    expect(
+      getFormationSpeed(totalInvaders, lowWave.formation.speed)
+    ).toBeLessThan(getFormationSpeed(totalInvaders, highWave.formation.speed));
+  });
+
+  it("caps formation speed even on extreme waves with one invader left", () => {
+    const waveNinetyNine = createPlayingState({ wave: 99 });
+
+    expect(getFormationSpeed(1, waveNinetyNine.formation.speed)).toBeLessThanOrEqual(
+      FORMATION_SPEED_MAX
     );
   });
 


### PR DESCRIPTION
## Scale formation march speed by kill count and wave number

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #149

### Changes
Extend getFormationSpeed in src/game/state.ts so the invader march speed accelerates based on BOTH (a) remaining invader count within the current wave (fewer invaders remaining → faster march, classic Space Invaders behavior) and (b) the current wave number (higher waves start faster). Use a clear interpolation curve — e.g., linearly (or with a gentle ease) map the ratio of killed-to-total invaders from a base speed up to a per-wave max, where the per-wave max itself scales with the wave number up to a documented absolute cap. Introduce named, exported constants for the key tunables — at minimum a base speed, a per-wave starting multiplier, and an absolute speed cap (e.g., FORMATION_SPEED_BASE, FORMATION_SPEED_PER_WAVE, FORMATION_SPEED_MAX). The function signature should continue to accept whatever invader/wave inputs the existing call sites provide; if additional inputs are needed (wave number, total invaders), update the call site(s) in src/game/step.ts accordingly — but keep those updates minimal and self-contained. Then add test cases to src/game/step.test.ts that exercise the new behavior directly against getFormationSpeed (or via step() when it's cleaner): (1) speed strictly increases as invaders are killed within the same wave — assert speed at full roster < speed at half roster < speed at one invader, (2) at equal kill counts (e.g., full roster), a higher wave returns a strictly larger speed than a lower wave, (3) the absolute speed cap holds — e.g., wave 99 with one invader left does not exceed FORMATION_SPEED_MAX.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*