### PR TITLE
feature: Surface persisted high score in the canvas HUD

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,7 @@ import { createHighScoreStore } from "./persistence";
 import { createCanvasRenderer, type CanvasRenderer } from "./render/canvas";
 
 const FIXED_TIMESTEP_MS = 1000 / 60;
-type RuntimeRenderFlags = Parameters<CanvasRenderer["render"]>[1] & {
-  highScore: number;
-};
+type RuntimeRenderFlags = Parameters<CanvasRenderer["render"]>[1];
 
 const canvas = document.querySelector<HTMLCanvasElement>("#game");
 
@@ -25,7 +23,6 @@ const highScoreStore = createHighScoreStore();
 let state = createInitialGameState();
 let bootstrapping = true;
 let audioAttempted = false;
-let highScore = highScoreStore.getHighScore();
 let frameInput: Input = keyboard.snapshot();
 
 renderer.render(state, createRenderFlags(false));
@@ -45,7 +42,7 @@ const loop = createFixedStepLoop({
         };
     const previousState = state;
     state = step(state, dtMs, stepInput);
-    highScore = maybeRecordHighScore(previousState, state);
+    maybeRecordHighScore(previousState, state);
     playDerivedEvents(previousState, state);
   },
   onRender: () => {
@@ -113,19 +110,19 @@ function playDerivedEvents(previousState: GameState, nextState: GameState): void
 function maybeRecordHighScore(
   previousState: GameState,
   nextState: GameState
-): number {
+): void {
   if (previousState.phase === "gameOver" || nextState.phase !== "gameOver") {
-    return highScore;
+    return;
   }
 
-  return highScoreStore.recordScore(nextState.hud.score);
+  highScoreStore.recordScore(nextState.hud.score);
 }
 
 function createRenderFlags(muted: boolean): RuntimeRenderFlags {
   return {
     bootstrapping,
     muted,
-    highScore
+    highScore: highScoreStore.getHighScore()
   };
 }
 

--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -140,7 +140,11 @@ describe("createCanvasRenderer", () => {
       projectiles: []
     };
 
-    renderer.render(state, { bootstrapping: false, muted: false });
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 360,
+      muted: false
+    });
 
     expect(
       context.fillTextCalls.some(
@@ -169,5 +173,35 @@ describe("createCanvasRenderer", () => {
     );
 
     expect(countClusters(uniqueHudXValues)).toBe(state.hud.lives);
+  });
+
+  it("renders the persisted high score inside the HUD band", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const highScore = 424242;
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore,
+      muted: false
+    });
+
+    expect(
+      context.fillTextCalls.some(
+        (call) =>
+          call.text.startsWith("HIGH ") &&
+          call.text.includes(String(highScore)) &&
+          call.y >= HUD_TOP &&
+          call.y < HUD_TOP + HUD_HEIGHT
+      )
+    ).toBe(true);
   });
 });

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -10,6 +10,7 @@ import {
 
 export type RenderFlags = {
   bootstrapping: boolean;
+  highScore: number;
   muted: boolean;
 };
 
@@ -77,7 +78,7 @@ function drawScene(
 ): void {
   context.clearRect(0, 0, state.arena.width, state.arena.height);
   drawBackground(context, state);
-  drawHud(context, state);
+  drawHud(context, state, flags);
   drawInvaders(context, state.invaders, state.marchFrame);
   drawProjectiles(context, state.projectiles);
   drawPlayer(context, state);
@@ -187,7 +188,11 @@ function drawBackground(
   }
 }
 
-function drawHud(context: CanvasRenderingContext2D, state: GameState): void {
+function drawHud(
+  context: CanvasRenderingContext2D,
+  state: GameState,
+  flags: RenderFlags
+): void {
   const hudX = 22;
   const hudY = 18;
   const hudWidth = state.arena.width - 44;
@@ -206,6 +211,7 @@ function drawHud(context: CanvasRenderingContext2D, state: GameState): void {
   context.fillText(`SCORE ${padHudScore(state.hud.score)}`, hudX + 22, hudY + 42);
 
   context.textAlign = "center";
+  context.fillText(`HIGH ${padHudScore(flags.highScore)}`, state.arena.width / 2, hudY + 26);
   context.fillText(`WAVE ${state.hud.wave}`, state.arena.width / 2, hudY + 42);
 
   context.textAlign = "right";


### PR DESCRIPTION
## Surface persisted high score in the canvas HUD

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #148

### Changes
Thread the persisted high score through the renderer so it appears in the HUD next to score/lives/wave. Extend `RenderFlags` in src/render/canvas.ts with a numeric `highScore` field, and update `CanvasRenderer.render` to draw a clearly labeled high-score value inside the existing HUD region (between y=0 and y=HUD_HEIGHT=68, using the same HUD_MONOSPACE_FONT as the other HUD labels). In src/main.ts, read the current high score from the existing `HighScoreStore` (whichever accessor it exposes, e.g. `getHighScore()`) on every frame and pass it in via the flags object given to `render` (update `createRenderFlags` if such a helper exists, otherwise populate the object at the render call site). In src/render/canvas.test.ts, add a test that constructs a `createPlayingState()`, calls `renderer.render(state, { ...flags, highScore: <number> })` with a recognizable value, and asserts via the existing FakeCanvasContext `fillTextCalls` that a text draw for the high score (e.g. label like `HI` or `HIGH` plus the number) is emitted in the HUD band (y < HUD_HEIGHT). Keep the rest of the HUD rendering behavior intact; existing canvas tests must continue to pass.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*