### PR TITLE
feature: Scale formation march speed by kill count and wave number

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -134,8 +134,12 @@ export const INVADER_HEIGHT = 30;
 export const INVADER_GAP_X = 18;
 export const INVADER_GAP_Y = 18;
 export const INVADER_START_Y = 108;
-export const INVADER_BASE_SPEED = 72;
-export const INVADER_WAVE_SPEED_STEP = 12;
+export const FORMATION_SPEED_BASE = 72;
+export const FORMATION_SPEED_PER_WAVE = 1 / 6;
+export const FORMATION_SPEED_MAX = 288;
+export const INVADER_BASE_SPEED = FORMATION_SPEED_BASE;
+export const INVADER_WAVE_SPEED_STEP =
+  FORMATION_SPEED_BASE * FORMATION_SPEED_PER_WAVE;
 export const INVADER_DESCEND_STEP = 24;
 export const LIFE_LOST_DURATION_MS = 900;
 export const RESPAWN_INVULNERABILITY_MS = 1500;
@@ -150,6 +154,7 @@ export const EMPTY_INPUT: Input = {
 };
 
 const ROW_POINTS = [50, 40, 30, 20, 10] as const;
+const FORMATION_SPEED_KILL_MULTIPLIER = 2.7;
 
 export function createInitialGameState(): GameState {
   return createGameState({ phase: "start" });
@@ -216,7 +221,7 @@ export function createPlayer(arena: Arena): Player {
 export function createFormation(arena: Arena, wave: number): Formation {
   return {
     direction: 1,
-    speed: INVADER_BASE_SPEED + Math.max(0, wave - 1) * INVADER_WAVE_SPEED_STEP,
+    speed: getFormationStartSpeed(wave),
     descendStep: INVADER_DESCEND_STEP,
     leftBound: arena.padding,
     rightBound: arena.width - arena.padding
@@ -327,12 +332,37 @@ export function getPlayerMaxX(arena: Arena, player: Player): number {
   return arena.width - arena.padding - player.width;
 }
 
-export function getFormationSpeed(invaderCount: number, baseSpeed: number): number {
-  const totalInvaders = INVADER_ROWS * INVADER_COLS;
-  const eliminated = totalInvaders - invaderCount;
-  const intensity = eliminated / totalInvaders;
+function getFormationStartSpeed(wave: number): number {
+  return Math.min(
+    FORMATION_SPEED_MAX,
+    FORMATION_SPEED_BASE *
+      (1 + Math.max(0, wave - 1) * FORMATION_SPEED_PER_WAVE)
+  );
+}
 
-  return baseSpeed * (1 + intensity * 1.7);
+export function getFormationSpeed(
+  invaderCount: number,
+  waveStartSpeed: number,
+  totalInvaders = INVADER_ROWS * INVADER_COLS
+): number {
+  const clampedTotalInvaders = Math.max(1, totalInvaders);
+  const clampedInvaderCount = Math.max(
+    0,
+    Math.min(invaderCount, clampedTotalInvaders)
+  );
+  const killedRatio =
+    (clampedTotalInvaders - clampedInvaderCount) / clampedTotalInvaders;
+  const cappedWaveStartSpeed = Math.min(waveStartSpeed, FORMATION_SPEED_MAX);
+  const waveMaxSpeed = Math.min(
+    FORMATION_SPEED_MAX,
+    cappedWaveStartSpeed * FORMATION_SPEED_KILL_MULTIPLIER
+  );
+
+  // Interpolate between the wave's opening pace and its cap as the formation thins out.
+  return (
+    cappedWaveStartSpeed +
+    (waveMaxSpeed - cappedWaveStartSpeed) * killedRatio
+  );
 }
 
 export function getProjectileSpawnX(player: Player): number {

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   EMPTY_INPUT,
+  FORMATION_SPEED_MAX,
   INVADER_COLS,
   INVADER_HEIGHT,
   INVADER_ROWS,
@@ -464,6 +465,39 @@ describe("step", () => {
     expect(reducedDelta).toBeGreaterThan(fullDelta);
     expect(getFormationSpeed(reduced.invaders.length, reduced.formation.speed)).toBeGreaterThan(
       getFormationSpeed(full.invaders.length, full.formation.speed)
+    );
+  });
+
+  it("increases formation speed as invaders are killed within the same wave", () => {
+    const state = createPlayingState({ wave: 2 });
+    const totalInvaders = state.invaders.length;
+    const fullRosterSpeed = getFormationSpeed(totalInvaders, state.formation.speed);
+    const halfRosterSpeed = getFormationSpeed(
+      Math.ceil(totalInvaders / 2),
+      state.formation.speed
+    );
+    const oneInvaderSpeed = getFormationSpeed(1, state.formation.speed);
+
+    expect(fullRosterSpeed).toBeLessThan(halfRosterSpeed);
+    expect(halfRosterSpeed).toBeLessThan(oneInvaderSpeed);
+  });
+
+  it("starts faster on later waves at the same kill count", () => {
+    const waveOne = createPlayingState({ wave: 1 });
+    const waveFour = createPlayingState({ wave: 4 });
+    const fullRosterCount = waveOne.invaders.length;
+
+    expect(fullRosterCount).toBe(waveFour.invaders.length);
+    expect(
+      getFormationSpeed(fullRosterCount, waveFour.formation.speed)
+    ).toBeGreaterThan(getFormationSpeed(fullRosterCount, waveOne.formation.speed));
+  });
+
+  it("caps the formation speed on very late waves", () => {
+    const state = createPlayingState({ wave: 99 });
+
+    expect(getFormationSpeed(1, state.formation.speed)).toBeLessThanOrEqual(
+      FORMATION_SPEED_MAX
     );
   });
 


### PR DESCRIPTION
## Scale formation march speed by kill count and wave number

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #149

### Changes
Extend getFormationSpeed in src/game/state.ts so the invader march speed accelerates based on BOTH (a) remaining invader count within the current wave (fewer invaders remaining → faster march, classic Space Invaders behavior) and (b) the current wave number (higher waves start faster). Use a clear interpolation curve — e.g., linearly (or with a gentle ease) map the ratio of killed-to-total invaders from a base speed up to a per-wave max, where the per-wave max itself scales with the wave number up to a documented absolute cap. Introduce named, exported constants for the key tunables — at minimum a base speed, a per-wave starting multiplier, and an absolute speed cap (e.g., FORMATION_SPEED_BASE, FORMATION_SPEED_PER_WAVE, FORMATION_SPEED_MAX). The function signature should continue to accept whatever invader/wave inputs the existing call sites provide; if additional inputs are needed (wave number, total invaders), update the call site(s) in src/game/step.ts accordingly — but keep those updates minimal and self-contained. Then add test cases to src/game/step.test.ts that exercise the new behavior directly against getFormationSpeed (or via step() when it's cleaner): (1) speed strictly increases as invaders are killed within the same wave — assert speed at full roster < speed at half roster < speed at one invader, (2) at equal kill counts (e.g., full roster), a higher wave returns a strictly larger speed than a lower wave, (3) the absolute speed cap holds — e.g., wave 99 with one invader left does not exceed FORMATION_SPEED_MAX.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*