### PR TITLE
bug_fix: Extract deriveSfxEvents module filtering shoot SFX to player-owned projectiles

### DIFF
--- a/src/audio/events.test.ts
+++ b/src/audio/events.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPlayerProjectile,
+  createPlayingState,
+  getProjectileSpawnX,
+  getProjectileSpawnY,
+  type GameState
+} from "../game/state";
+
+import { deriveSfxEvents } from "./events";
+
+type TestProjectile = Omit<GameState["projectiles"][number], "owner"> & {
+  owner: GameState["projectiles"][number]["owner"] | "invader";
+};
+
+function createTestProjectile(
+  state: GameState,
+  id: number,
+  owner: TestProjectile["owner"]
+): TestProjectile {
+  return {
+    ...createPlayerProjectile(
+      state,
+      getProjectileSpawnX(state.player),
+      getProjectileSpawnY(state.player)
+    ),
+    id,
+    owner
+  };
+}
+
+function withProjectiles(
+  state: GameState,
+  projectiles: TestProjectile[]
+): GameState {
+  return {
+    ...state,
+    projectiles: projectiles as GameState["projectiles"]
+  };
+}
+
+describe("deriveSfxEvents", () => {
+  it("emits shoot when the player projectile count grows", () => {
+    const previousState = createPlayingState();
+    const nextState = withProjectiles(previousState, [
+      createTestProjectile(previousState, 1, "player")
+    ]);
+
+    expect(deriveSfxEvents(previousState, nextState)).toEqual(["shoot"]);
+  });
+
+  it("does not emit shoot when only invader projectile count grows", () => {
+    const previousState = createPlayingState();
+    const nextState = withProjectiles(previousState, [
+      createTestProjectile(previousState, 1, "invader")
+    ]);
+
+    expect(deriveSfxEvents(previousState, nextState)).toEqual([]);
+  });
+
+  it("emits shoot exactly once when player and invader projectile counts both grow", () => {
+    const previousState = createPlayingState();
+    const nextState = withProjectiles(previousState, [
+      createTestProjectile(previousState, 1, "player"),
+      createTestProjectile(previousState, 2, "invader")
+    ]);
+
+    expect(deriveSfxEvents(previousState, nextState)).toEqual(["shoot"]);
+  });
+
+  it("does not emit shoot when player projectiles stay flat while an invader projectile is added", () => {
+    const previousState = withProjectiles(createPlayingState(), [
+      createTestProjectile(createPlayingState(), 1, "player")
+    ]);
+    const nextState = withProjectiles(previousState, [
+      createTestProjectile(previousState, 2, "player"),
+      createTestProjectile(previousState, 3, "invader")
+    ]);
+
+    expect(deriveSfxEvents(previousState, nextState)).toEqual([]);
+  });
+
+  it("does not emit shoot when the player projectile count decreases", () => {
+    const previousState = withProjectiles(createPlayingState(), [
+      createTestProjectile(createPlayingState(), 1, "player"),
+      createTestProjectile(createPlayingState(), 2, "player")
+    ]);
+    const nextState = withProjectiles(previousState, [
+      createTestProjectile(previousState, 2, "player")
+    ]);
+
+    expect(deriveSfxEvents(previousState, nextState)).toEqual([]);
+  });
+
+  it("preserves hit, playerDeath, and waveClear semantics from main.ts", () => {
+    const previousState = createPlayingState();
+
+    const hitState = {
+      ...previousState,
+      invaders: previousState.invaders.slice(1)
+    };
+    expect(deriveSfxEvents(previousState, hitState)).toEqual(["hit"]);
+
+    const playerDeathState = {
+      ...previousState,
+      phase: "lifeLost" as const
+    };
+    expect(deriveSfxEvents(previousState, playerDeathState)).toEqual(["playerDeath"]);
+    expect(deriveSfxEvents(playerDeathState, playerDeathState)).toEqual([]);
+
+    const waveClearState = {
+      ...previousState,
+      phase: "waveClear" as const
+    };
+    expect(deriveSfxEvents(previousState, waveClearState)).toEqual(["waveClear"]);
+    expect(deriveSfxEvents(waveClearState, waveClearState)).toEqual([]);
+  });
+});

--- a/src/audio/events.ts
+++ b/src/audio/events.ts
@@ -1,0 +1,40 @@
+import type { GameState } from "../game/state";
+
+import type { SfxName } from "./sfx";
+
+export function deriveSfxEvents(
+  previousState: GameState,
+  nextState: GameState
+): SfxName[] {
+  const events: SfxName[] = [];
+
+  if (countPlayerProjectiles(nextState) > countPlayerProjectiles(previousState)) {
+    events.push("shoot");
+  }
+
+  if (nextState.invaders.length < previousState.invaders.length) {
+    events.push("hit");
+  }
+
+  if (previousState.phase !== "lifeLost" && nextState.phase === "lifeLost") {
+    events.push("playerDeath");
+  }
+
+  if (previousState.phase !== "waveClear" && nextState.phase === "waveClear") {
+    events.push("waveClear");
+  }
+
+  return events;
+}
+
+function countPlayerProjectiles(state: GameState): number {
+  let count = 0;
+
+  for (const projectile of state.projectiles) {
+    if (projectile.owner === "player") {
+      count += 1;
+    }
+  }
+
+  return count;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { createSfxController, type SfxName } from "./audio/sfx";
+import { deriveSfxEvents } from "./audio/events";
+import { createSfxController } from "./audio/sfx";
 import { createInitialGameState, type GameState, type Input } from "./game/state";
 import { step } from "./game/step";
 import { createKeyboardController } from "./input/keyboard";
@@ -78,31 +79,7 @@ function maybeArmAudio(phase: GameState["phase"], input: Input): void {
 }
 
 function playDerivedEvents(previousState: GameState, nextState: GameState): void {
-  const events: SfxName[] = [];
-
-  if (nextState.projectiles.length > previousState.projectiles.length) {
-    events.push("shoot");
-  }
-
-  if (nextState.invaders.length < previousState.invaders.length) {
-    events.push("hit");
-  }
-
-  if (
-    previousState.phase !== "lifeLost" &&
-    nextState.phase === "lifeLost"
-  ) {
-    events.push("playerDeath");
-  }
-
-  if (
-    previousState.phase !== "waveClear" &&
-    nextState.phase === "waveClear"
-  ) {
-    events.push("waveClear");
-  }
-
-  for (const event of events) {
+  for (const event of deriveSfxEvents(previousState, nextState)) {
     sfx.play(event);
   }
 }


### PR DESCRIPTION
## Extract deriveSfxEvents module filtering shoot SFX to player-owned projectiles

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #172

### Changes
Fix a correctness regression where invader projectiles trigger the player 'shoot' SFX because they now share `state.projectiles` with the player's shots. Extract the state-diff → SFX logic currently inline in `playDerivedEvents` in `src/main.ts` into a new pure module `src/audio/events.ts` that exports `deriveSfxEvents(prev: GameState, next: GameState): SfxName[]` (reuse the `SfxName` type from `./sfx`). The implementation must: (1) emit 'shoot' only when the count of projectiles with `owner === 'player'` increases between prev and next — never for invader-owned projectiles; (2) preserve the existing trigger semantics for 'hit', 'playerDeath', and 'waveClear' events (port the current rules from `main.ts` verbatim for those). The function must be pure (no side effects, no references to the SFX controller, DOM, or timers). Then update `src/main.ts` to import `deriveSfxEvents` and drive `sfx.play(...)` from its return value, replacing the inline diff logic. Add `src/audio/events.test.ts` with Vitest cases covering: (a) player projectile count grows → emits 'shoot'; (b) invader projectile count grows while player count stays same → does NOT emit 'shoot'; (c) both grow in the same tick → emits 'shoot' exactly once; (d) projectiles replaced (player fired and invader fired simultaneously) with net player count flat → no 'shoot'; (e) player count decreases → no 'shoot'; (f) hit/playerDeath/waveClear emission parity with prior behavior. Use `createPlayingState` / game-state helpers to build fixtures. If the current `Projectile` type in `src/game/state.ts` only declares `owner: 'player'`, infer the invader owner literal from the existing invader-projectile task's expected shape (likely `'player' | 'invader'`) and handle both — the filter must be defensive enough that it still works once invader-owned projectiles land.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*