### PR TITLE
bug_fix: Reset held-key state on window blur in keyboard controller

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { createKeyboardController } from "./keyboard";
+
+if (typeof globalThis.KeyboardEvent === "undefined") {
+  Object.defineProperty(globalThis, "KeyboardEvent", {
+    configurable: true,
+    writable: true,
+    value: class KeyboardEventShim extends Event {
+      readonly code: string;
+
+      constructor(type: string, init: KeyboardEventInit = {}) {
+        super(type, init);
+        this.code = init.code ?? "";
+      }
+    }
+  });
+}
+
+type WindowTarget = Pick<
+  Window,
+  "addEventListener" | "removeEventListener" | "dispatchEvent"
+>;
+
+class FakeWindow extends EventTarget implements WindowTarget {}
+
+function createTarget(): Window {
+  const target: WindowTarget = new FakeWindow();
+  return target as Window;
+}
+
+function dispatchKeyDown(target: Window, code: string): void {
+  target.dispatchEvent(new KeyboardEvent("keydown", { code }));
+}
+
+function dispatchBlur(target: Window): void {
+  target.dispatchEvent(new Event("blur"));
+}
+
+describe("createKeyboardController", () => {
+  it("clears held ArrowLeft input on blur", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "ArrowLeft");
+    dispatchBlur(target);
+
+    expect(controller.snapshot().moveX).toBe(0);
+  });
+
+  it("clears held ArrowRight, Space, and KeyP input and resets mute gating on blur", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "ArrowRight");
+    dispatchBlur(target);
+    expect(controller.snapshot().moveX).toBe(0);
+
+    dispatchKeyDown(target, "Space");
+    dispatchBlur(target);
+    expect(controller.snapshot().fireHeld).toBe(false);
+
+    dispatchKeyDown(target, "KeyP");
+    dispatchBlur(target);
+    expect(controller.snapshot().pauseHeld).toBe(false);
+
+    dispatchKeyDown(target, "KeyM");
+    expect(controller.snapshot().mutePressed).toBe(true);
+    dispatchBlur(target);
+    dispatchKeyDown(target, "KeyM");
+    expect(controller.snapshot().mutePressed).toBe(true);
+  });
+
+  it("does not synthesize a firePressed edge on blur", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "Space");
+    expect(controller.snapshot().firePressed).toBe(true);
+
+    dispatchBlur(target);
+
+    const snapshot = controller.snapshot();
+
+    expect(snapshot.firePressed).toBe(false);
+    expect(snapshot.fireHeld).toBe(false);
+  });
+
+  it("preserves fire edge tracking after blur", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "Space");
+    expect(controller.snapshot().firePressed).toBe(true);
+
+    dispatchBlur(target);
+    expect(controller.snapshot().firePressed).toBe(false);
+
+    dispatchKeyDown(target, "Space");
+
+    const snapshot = controller.snapshot();
+
+    expect(snapshot.firePressed).toBe(true);
+    expect(snapshot.fireHeld).toBe(true);
+  });
+
+  it("removes the blur listener on dispose", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "ArrowLeft");
+    controller.dispose();
+    dispatchBlur(target);
+
+    expect(controller.snapshot().moveX).toBe(-1);
+  });
+});

--- a/src/input/keyboard.ts
+++ b/src/input/keyboard.ts
@@ -80,13 +80,23 @@ export function createKeyboardController(target: Window = window): KeyboardContr
     }
   };
 
+  const onBlur = (): void => {
+    held.left = false;
+    held.right = false;
+    held.fire = false;
+    held.pause = false;
+    held.mute = false;
+  };
+
   target.addEventListener("keydown", onKeyDown);
   target.addEventListener("keyup", onKeyUp);
+  target.addEventListener("blur", onBlur);
 
   return {
     dispose: () => {
       target.removeEventListener("keydown", onKeyDown);
       target.removeEventListener("keyup", onKeyUp);
+      target.removeEventListener("blur", onBlur);
     },
     snapshot: () => {
       const moveX = held.left === held.right ? 0 : held.left ? -1 : 1;


### PR DESCRIPTION
## Reset held-key state on window blur in keyboard controller

**Category:** `bug_fix` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #171

### Changes
Fix a stuck-input bug in createKeyboardController: if the window loses focus (alt-tab, devtools, overlay prompts) while the user holds Arrow/Space/KeyP/KeyM, no keyup fires and `held.left/right/fire/pause/mute` stay true, causing continued movement or spurious fires on return. In src/input/keyboard.ts, register a `blur` listener on the `target` window inside createKeyboardController that zeroes `held.left`, `held.right`, `held.fire`, `held.pause`, and `held.mute` to false. Do NOT set the `*Edge` fields (fireEdge/pauseEdge/muteEdge) — blur must not synthesize a press event; it only clears continuous-hold state. Wire the blur listener through the same add/remove bookkeeping as the existing keydown/keyup listeners so `dispose()` removes it too. Then add tests in src/input/keyboard.test.ts (create the file if it does not exist) using a minimal EventTarget-based fake window that exposes addEventListener/removeEventListener/dispatchEvent so you can pass it as the `target`. Cover: (1) holding ArrowLeft then firing a `blur` event clears `held.left` in the next snapshot; (2) same for ArrowRight, Space, KeyP, KeyM; (3) blur while Space is held does NOT produce a `firePressed` edge on the next snapshot (i.e. no synthetic fire); (4) after blur, a fresh keydown on Space again produces a fireEdge on the next snapshot (edge tracking still works post-blur); (5) `dispose()` removes the blur listener (subsequent blur events have no effect on state). Use `new KeyboardEvent('keydown', { code: 'Space' })` and `new Event('blur')` with dispatchEvent on the fake target. Keep the snapshot shape and the existing `Input` contract unchanged.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*