### PR TITLE
feature: Wire M-key mute toggle through main.ts using persisted mute store

### DIFF
--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -380,6 +380,40 @@ describe("createSfxController", () => {
     expect(harness.gains).toHaveLength(0);
   });
 
+  it("reports muted while the user mute preference is enabled, even after arming", async () => {
+    const controller = createSfxController();
+
+    controller.setMuted(true);
+    await controller.arm();
+
+    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
+    expect(controller.getStatus()).toBe("muted");
+  });
+
+  it("does not create any nodes while the user mute preference is enabled", async () => {
+    const controller = createSfxController();
+    await controller.arm();
+
+    controller.setMuted(true);
+    controller.play("shoot");
+
+    expect(harness.oscillators).toHaveLength(0);
+    expect(harness.gains).toHaveLength(0);
+  });
+
+  it("restores playback after the user mute preference is cleared", async () => {
+    const controller = createSfxController();
+
+    controller.setMuted(true);
+    await controller.arm();
+    controller.setMuted(false);
+
+    const playback = capturePlayback(harness, controller, "shoot");
+
+    expect(controller.getStatus()).toBe("ready");
+    expectScheduledShortBeeps(playback, harness.destination);
+  });
+
   it("does not create any nodes while idle", () => {
     const controller = createSfxController();
 

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -4,6 +4,7 @@ export type SfxController = {
   arm: () => Promise<void>;
   getStatus: () => "idle" | "ready" | "muted";
   play: (name: SfxName) => void;
+  setMuted: (muted: boolean) => void;
 };
 
 type Tone = {
@@ -16,6 +17,7 @@ type Tone = {
 export function createSfxController(): SfxController {
   let context: AudioContext | null = null;
   let status: "idle" | "ready" | "muted" = "idle";
+  let muted = false;
 
   return {
     arm: async () => {
@@ -33,9 +35,9 @@ export function createSfxController(): SfxController {
         status = "muted";
       }
     },
-    getStatus: () => status,
+    getStatus: () => (muted ? "muted" : status),
     play: (name) => {
-      if (status !== "ready" || context === null) {
+      if (muted || status !== "ready" || context === null) {
         return;
       }
 
@@ -47,6 +49,9 @@ export function createSfxController(): SfxController {
         playTone(context, now + offset, tone);
         offset += tone.duration * 0.68;
       }
+    },
+    setMuted: (value) => {
+      muted = value;
     }
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { deriveSfxEvents } from "./audio/events";
+import { createMuteStore } from "./audio/mute";
 import { createSfxController } from "./audio/sfx";
 import { createInitialGameState, type GameState, type Input } from "./game/state";
 import { step } from "./game/step";
@@ -19,6 +20,7 @@ if (canvas === null) {
 const renderer = createRenderer(canvas);
 const keyboard = createKeyboardController(window);
 const sfx = createSfxController();
+const muteStore = createMuteStore();
 const highScoreStore = createHighScoreStore();
 
 let state = createInitialGameState();
@@ -26,7 +28,8 @@ let bootstrapping = true;
 let audioAttempted = false;
 let frameInput: Input = keyboard.snapshot();
 
-renderer.render(state, createRenderFlags(false));
+sfx.setMuted(muteStore.isMuted());
+renderer.render(state, createRenderFlags(muteStore.isMuted()));
 bootstrapping = false;
 maybeArmAudio(state.phase, frameInput);
 
@@ -48,8 +51,14 @@ const loop = createFixedStepLoop({
   },
   onRender: () => {
     frameInput = keyboard.snapshot();
+
+    if (frameInput.mutePressed) {
+      muteStore.toggle();
+      sfx.setMuted(muteStore.isMuted());
+    }
+
     maybeArmAudio(state.phase, frameInput);
-    renderer.render(state, createRenderFlags(sfx.getStatus() === "muted"));
+    renderer.render(state, createRenderFlags(muteStore.isMuted()));
   }
 });
 


### PR DESCRIPTION
## Wire M-key mute toggle through main.ts using persisted mute store

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #176

### Changes
Complete the integration between the existing mute store (src/audio/mute.ts), the keyboard controller's rising mutePressed edge (src/input/keyboard.ts), and the canvas muted badge (src/render/canvas.ts) so the M key actually silences SFX and persists the preference.

1. In src/audio/sfx.ts:
   - Add a `setMuted(muted: boolean): void` method to the `SfxController` type and the returned object.
   - Track the muted preference as a separate internal flag, distinct from the existing `status` that represents AudioContext readiness. Do NOT conflate a user-initiated mute with the AudioContext failure state.
   - When setMuted(true) is called, `play()` must short-circuit and produce no audio nodes regardless of AudioContext readiness.
   - `getStatus()` must return `"muted"` whenever the user has muted via setMuted(true), taking precedence over the `"idle"` / `"ready"` AudioContext states. When unmuted, `getStatus()` returns the underlying AudioContext status as before.
   - `arm()` should still work while user-muted (i.e., it can prepare the AudioContext) but must not switch `getStatus()` away from `"muted"` while the user preference is muted.

2. In src/audio/sfx.test.ts, add tests covering:
   - `setMuted(true)` causes `getStatus()` to return `"muted"` even after a successful `arm()`.
   - `setMuted(true)` causes `play()` to be a no-op (no oscillator/gain nodes created) after `arm()` succeeded.
   - `setMuted(false)` after previously muting restores playback — subsequent `play()` creates oscillator nodes again.
   - The existing AudioContext-failure branch still reports `"muted"` status via `getStatus()`.

3. In src/main.ts:
   - Import `createMuteStore` from `./audio/mute`.
   - Construct a mute store alongside the existing `sfx`, `highScoreStore`, etc.
   - Before the initial render, call `sfx.setMuted(muteStore.isMuted())` so startup reflects the persisted preference.
   - In the frame loop where `frameInput` is refreshed (the `onRender` / pre-step path), detect the rising edge of `frameInput.mutePressed` and call `muteStore.toggle()`, then `sfx.setMuted(muteStore.isMuted())`. Use the Input snapshot's edge flag — do NOT re-implement edge detection, keyboard.ts already exposes the edge through `mutePressed`.
   - Ensure the existing `createRenderFlags` / `RuntimeRenderFlags` path passes `muted: muteStore.isMuted()` to the renderer so the muted badge reflects the live store state.
   - Do not swallow or alter the existing SFX-event derivation; muting is orthogonal to which events fire.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*