### PR TITLE
feature: Add devicePixelRatio-aware viewport geometry helper with letterboxed logical coordinates

### DIFF
--- a/src/render/viewport.test.ts
+++ b/src/render/viewport.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyViewport,
+  computeViewport,
+  type Viewport
+} from "./viewport";
+
+type FakeWindow = {
+  devicePixelRatio?: number;
+  innerHeight: number;
+  innerWidth: number;
+};
+
+type FakeCanvas = {
+  clientHeight: number;
+  clientWidth: number;
+};
+
+type SetTransformCall = [number, number, number, number, number, number];
+
+class FakeViewportContext {
+  readonly canvas = {
+    height: 0,
+    width: 0
+  };
+
+  readonly setTransformCalls: SetTransformCall[] = [];
+
+  setTransform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number
+  ): void {
+    this.setTransformCalls.push([a, b, c, d, e, f]);
+  }
+}
+
+function createFakeWindow(overrides: Partial<FakeWindow> = {}): FakeWindow {
+  return {
+    innerWidth: 0,
+    innerHeight: 0,
+    ...overrides
+  };
+}
+
+function createFakeCanvas(overrides: Partial<FakeCanvas> = {}): FakeCanvas {
+  return {
+    clientWidth: 0,
+    clientHeight: 0,
+    ...overrides
+  };
+}
+
+describe("computeViewport", () => {
+  it("defaults the DPR to 1 and keeps a matching aspect ratio unletterboxed", () => {
+    const viewport = computeViewport(
+      createFakeWindow({
+        innerWidth: 1920,
+        innerHeight: 1080
+      }),
+      createFakeCanvas({
+        clientWidth: 1280,
+        clientHeight: 720
+      }),
+      320,
+      180
+    );
+
+    expect(viewport).toEqual({
+      cssWidth: 1280,
+      cssHeight: 720,
+      backingWidth: 1280,
+      backingHeight: 720,
+      scale: 4,
+      offsetX: 0,
+      offsetY: 0
+    });
+  });
+
+  it("computes a DPR-2 viewport for a square CSS area", () => {
+    const viewport = computeViewport(
+      createFakeWindow({
+        devicePixelRatio: 2,
+        innerWidth: 900,
+        innerHeight: 900
+      }),
+      createFakeCanvas({
+        clientWidth: 900,
+        clientHeight: 900
+      }),
+      320,
+      180
+    );
+
+    expect(viewport.cssWidth).toBe(900);
+    expect(viewport.cssHeight).toBe(900);
+    expect(viewport.backingWidth).toBe(1800);
+    expect(viewport.backingHeight).toBe(1800);
+    expect(viewport.scale).toBeCloseTo(2.8125);
+    expect(viewport.offsetX).toBe(0);
+    expect(viewport.offsetY).toBeCloseTo(196.875);
+  });
+
+  it("computes a DPR-3 viewport for a wide CSS area", () => {
+    const viewport = computeViewport(
+      createFakeWindow({
+        devicePixelRatio: 3,
+        innerWidth: 1200,
+        innerHeight: 600
+      }),
+      createFakeCanvas({
+        clientWidth: 1200,
+        clientHeight: 600
+      }),
+      320,
+      180
+    );
+
+    expect(viewport.cssWidth).toBe(1200);
+    expect(viewport.cssHeight).toBe(600);
+    expect(viewport.backingWidth).toBe(3600);
+    expect(viewport.backingHeight).toBe(1800);
+    expect(viewport.scale).toBeCloseTo(10 / 3);
+    expect(viewport.offsetX).toBeCloseTo(200 / 3);
+    expect(viewport.offsetY).toBe(0);
+  });
+
+  it("computes a viewport for a tall CSS area", () => {
+    const viewport = computeViewport(
+      createFakeWindow({
+        devicePixelRatio: 3,
+        innerWidth: 600,
+        innerHeight: 1200
+      }),
+      createFakeCanvas({
+        clientWidth: 600,
+        clientHeight: 1200
+      }),
+      320,
+      180
+    );
+
+    expect(viewport.cssWidth).toBe(600);
+    expect(viewport.cssHeight).toBe(1200);
+    expect(viewport.backingWidth).toBe(1800);
+    expect(viewport.backingHeight).toBe(3600);
+    expect(viewport.scale).toBeCloseTo(1.875);
+    expect(viewport.offsetX).toBe(0);
+    expect(viewport.offsetY).toBeCloseTo(431.25);
+  });
+
+  it("falls back to the window size when the canvas CSS size is zero", () => {
+    const viewport = computeViewport(
+      createFakeWindow({
+        devicePixelRatio: 2,
+        innerWidth: 1024,
+        innerHeight: 768
+      }),
+      createFakeCanvas(),
+      320,
+      240
+    );
+
+    expect(viewport).toEqual({
+      cssWidth: 1024,
+      cssHeight: 768,
+      backingWidth: 2048,
+      backingHeight: 1536,
+      scale: 3.2,
+      offsetX: 0,
+      offsetY: 0
+    });
+  });
+
+  it("prefers the canvas client size over the window size when available", () => {
+    const viewport = computeViewport(
+      createFakeWindow({
+        devicePixelRatio: 2,
+        innerWidth: 4000,
+        innerHeight: 4000
+      }),
+      createFakeCanvas({
+        clientWidth: 640,
+        clientHeight: 360
+      }),
+      320,
+      180
+    );
+
+    expect(viewport.cssWidth).toBe(640);
+    expect(viewport.cssHeight).toBe(360);
+    expect(viewport.backingWidth).toBe(1280);
+    expect(viewport.backingHeight).toBe(720);
+    expect(viewport.scale).toBe(2);
+    expect(viewport.offsetX).toBe(0);
+    expect(viewport.offsetY).toBe(0);
+  });
+
+  it("rounds CSS and backing dimensions to integers", () => {
+    const viewport = computeViewport(
+      createFakeWindow({
+        devicePixelRatio: 1.5,
+        innerWidth: 500,
+        innerHeight: 500
+      }),
+      createFakeCanvas({
+        clientWidth: 100.4,
+        clientHeight: 50.6
+      }),
+      10,
+      10
+    );
+
+    expect(viewport.cssWidth).toBe(100);
+    expect(viewport.cssHeight).toBe(51);
+    expect(viewport.backingWidth).toBe(150);
+    expect(viewport.backingHeight).toBe(77);
+    expect(viewport.scale).toBeCloseTo(5.1);
+    expect(viewport.offsetX).toBeCloseTo(24.5);
+    expect(viewport.offsetY).toBe(0);
+  });
+});
+
+describe("applyViewport", () => {
+  it("sets the backing size and applies a DPR-scaled transform", () => {
+    const context = new FakeViewportContext();
+    const viewport: Viewport = {
+      cssWidth: 640,
+      cssHeight: 360,
+      backingWidth: 1280,
+      backingHeight: 720,
+      scale: 2,
+      offsetX: 10,
+      offsetY: 20
+    };
+
+    applyViewport(context, viewport);
+
+    expect(context.canvas.width).toBe(1280);
+    expect(context.canvas.height).toBe(720);
+    expect(context.setTransformCalls).toEqual([[4, 0, 0, 4, 20, 40]]);
+  });
+
+  it("falls back to a DPR of 1 when cssWidth is zero", () => {
+    const context = new FakeViewportContext();
+    const viewport: Viewport = {
+      cssWidth: 0,
+      cssHeight: 240,
+      backingWidth: 0,
+      backingHeight: 240,
+      scale: 1.5,
+      offsetX: 8,
+      offsetY: 12
+    };
+
+    applyViewport(context, viewport);
+
+    expect(context.canvas.width).toBe(0);
+    expect(context.canvas.height).toBe(240);
+    expect(context.setTransformCalls).toEqual([[1.5, 0, 0, 1.5, 8, 12]]);
+  });
+});

--- a/src/render/viewport.ts
+++ b/src/render/viewport.ts
@@ -1,0 +1,79 @@
+type ViewportWindow = {
+  devicePixelRatio?: number;
+  innerHeight: number;
+  innerWidth: number;
+};
+
+type ViewportCanvas = {
+  clientHeight: number;
+  clientWidth: number;
+};
+
+type ViewportContext = {
+  canvas: {
+    height: number;
+    width: number;
+  };
+  setTransform: (
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number
+  ) => void;
+};
+
+export type Viewport = {
+  backingHeight: number;
+  backingWidth: number;
+  cssHeight: number;
+  cssWidth: number;
+  offsetX: number;
+  offsetY: number;
+  scale: number;
+};
+
+export function computeViewport(
+  window: ViewportWindow,
+  canvas: ViewportCanvas,
+  logicalW: number,
+  logicalH: number
+): Viewport {
+  const dpr = window.devicePixelRatio ?? 1;
+  const hasCanvasSize = canvas.clientWidth > 0 && canvas.clientHeight > 0;
+  const cssWidth = Math.round(hasCanvasSize ? canvas.clientWidth : window.innerWidth);
+  const cssHeight = Math.round(hasCanvasSize ? canvas.clientHeight : window.innerHeight);
+  const scale = Math.min(cssWidth / logicalW, cssHeight / logicalH);
+  const offsetX = (cssWidth - scale * logicalW) / 2;
+  const offsetY = (cssHeight - scale * logicalH) / 2;
+
+  return {
+    cssWidth,
+    cssHeight,
+    backingWidth: Math.round(cssWidth * dpr),
+    backingHeight: Math.round(cssHeight * dpr),
+    scale,
+    offsetX,
+    offsetY
+  };
+}
+
+export function applyViewport(
+  context: ViewportContext,
+  viewport: Viewport
+): void {
+  const dpr =
+    viewport.cssWidth === 0 ? 1 : viewport.backingWidth / viewport.cssWidth;
+
+  context.canvas.width = viewport.backingWidth;
+  context.canvas.height = viewport.backingHeight;
+  context.setTransform(
+    viewport.scale * dpr,
+    0,
+    0,
+    viewport.scale * dpr,
+    viewport.offsetX * dpr,
+    viewport.offsetY * dpr
+  );
+}


### PR DESCRIPTION
## Add devicePixelRatio-aware viewport geometry helper with letterboxed logical coordinates

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #138

### Changes
Create `src/render/viewport.ts` that exports two pure-enough helpers for a DPR-aware, letterboxed canvas mapping. (1) `computeViewport(window, canvas, logicalW, logicalH)` — inspect `window.devicePixelRatio` (default to 1 if missing) and the available CSS size (prefer `canvas.clientWidth/clientHeight`; fall back to `window.innerWidth/innerHeight` when the canvas has zero CSS size), then compute a uniform scale that fits the logical area inside the CSS area preserving aspect ratio. Return `{ cssWidth, cssHeight, backingWidth, backingHeight, scale, offsetX, offsetY }` where `cssWidth/cssHeight` are the integer-rounded CSS pixel dimensions of the canvas element, `backingWidth/backingHeight = round(cssWidth*dpr)` / `round(cssHeight*dpr)`, `scale` is the CSS-pixels-per-logical-unit factor (`min(cssWidth/logicalW, cssHeight/logicalH)`), and `offsetX/offsetY` are the CSS-pixel letterbox offsets (`(cssWidth - scale*logicalW) / 2`, likewise for Y). (2) `applyViewport(ctx, viewport)` — set `ctx.canvas.width = viewport.backingWidth`, `ctx.canvas.height = viewport.backingHeight`, then call `ctx.setTransform(scale*dpr, 0, 0, scale*dpr, offsetX*dpr, offsetY*dpr)` so subsequent draw calls can use logical units directly; recover `dpr` from the viewport via `backingWidth / cssWidth` (guard against division by zero by falling back to 1). Export the `Viewport` type. Add `src/render/viewport.test.ts` with >= 8 cases exercising pure math: DPR=1/2/3, square/wide/tall windows, a window whose aspect exactly matches logical aspect (zero letterbox), zero-size canvas falling back to window, integer rounding of backing dimensions, and a test that `applyViewport` sets canvas.width/height and calls setTransform with the expected matrix values (use a minimal fake canvas/context object — no jsdom required). Keep the module free of side effects at import time, do not touch `src/render/canvas.ts` or `src/main.ts`, and do not introduce `any`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*