### PR TITLE
feature: Throttle duplicate SFX triggers within a short cooldown window

### DIFF
--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -41,7 +41,7 @@ type MockGainNode = {
 type MockAudioContext = {
   state: AudioContextState;
   readonly destination: MockDestination;
-  readonly currentTime: number;
+  currentTime: number;
   readonly resume: Mock<() => Promise<void>>;
   readonly createOscillator: Mock<() => MockOscillatorNode>;
   readonly createGain: Mock<() => MockGainNode>;
@@ -77,6 +77,7 @@ const SFX_NAMES = [
   "playerDeath",
   "waveClear"
 ] as const satisfies readonly SfxName[];
+const AFTER_SFX_COOLDOWN_SECONDS = 0.031;
 
 let harness: MockWebAudioHarness;
 
@@ -157,15 +158,10 @@ function installMockWebAudio(
         throw new Error("AudioContext unavailable");
       }
 
-      let currentTime = 0;
-
       const context: MockAudioContext = {
         state: harness.initialState,
         destination,
-        get currentTime(): number {
-          currentTime += 0.125;
-          return currentTime;
-        },
+        currentTime: 0,
         resume: vi.fn(async () => {
           context.state = "running";
         }),
@@ -454,12 +450,35 @@ describe("createSfxController", () => {
     expect(signatures.size).toBeGreaterThan(1);
   });
 
-  it("creates fresh oscillator and gain nodes on repeated shoot calls", async () => {
+  it("deduplicates repeated hit playback inside the cooldown window", async () => {
     const controller = createSfxController();
     await controller.arm();
+    const context = getLastContext(harness);
 
-    const firstPlayback = capturePlayback(harness, controller, "shoot");
-    const secondPlayback = capturePlayback(harness, controller, "shoot");
+    context.currentTime = 1;
+    controller.play("hit");
+
+    const createOscillatorCallsBeforeSecondPlay =
+      context.createOscillator.mock.calls.length;
+
+    controller.play("hit");
+
+    expect(
+      context.createOscillator.mock.calls.length -
+        createOscillatorCallsBeforeSecondPlay
+    ).toBe(0);
+  });
+
+  it("schedules hit playback again after the cooldown window elapses", async () => {
+    const controller = createSfxController();
+    await controller.arm();
+    const context = getLastContext(harness);
+
+    context.currentTime = 1;
+    const firstPlayback = capturePlayback(harness, controller, "hit");
+
+    context.currentTime += AFTER_SFX_COOLDOWN_SECONDS;
+    const secondPlayback = capturePlayback(harness, controller, "hit");
 
     expect(firstPlayback.oscillators.length).toBeGreaterThan(0);
     expect(secondPlayback.oscillators.length).toBe(firstPlayback.oscillators.length);
@@ -477,5 +496,42 @@ describe("createSfxController", () => {
     firstPlayback.gains.forEach((gain, index) => {
       expect(secondPlayback.gains[index]).not.toBe(gain);
     });
+  });
+
+  it("tracks cooldowns independently for each SFX name", async () => {
+    const controller = createSfxController();
+    await controller.arm();
+    const context = getLastContext(harness);
+
+    context.currentTime = 1;
+    const hitPlayback = capturePlayback(harness, controller, "hit");
+    const shootPlayback = capturePlayback(harness, controller, "shoot");
+
+    expect(hitPlayback.oscillators.length).toBeGreaterThan(0);
+    expect(shootPlayback.oscillators.length).toBeGreaterThan(0);
+  });
+
+  it("anchors the cooldown to AudioContext.currentTime", async () => {
+    const controller = createSfxController();
+    await controller.arm();
+    const context = getLastContext(harness);
+
+    context.currentTime = 1;
+    controller.play("hit");
+
+    const createOscillatorCallsAfterFirstPlay =
+      context.createOscillator.mock.calls.length;
+
+    controller.play("hit");
+    expect(context.createOscillator).toHaveBeenCalledTimes(
+      createOscillatorCallsAfterFirstPlay
+    );
+
+    context.currentTime += AFTER_SFX_COOLDOWN_SECONDS;
+    controller.play("hit");
+
+    expect(context.createOscillator.mock.calls.length).toBeGreaterThan(
+      createOscillatorCallsAfterFirstPlay
+    );
   });
 });

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -14,10 +14,13 @@ type Tone = {
   type: OscillatorType;
 };
 
+const SFX_COOLDOWN_SECONDS = 0.03;
+
 export function createSfxController(): SfxController {
   let context: AudioContext | null = null;
   let status: "idle" | "ready" | "muted" = "idle";
   let muted = false;
+  const lastPlayedAtByName = new Map<SfxName, number>();
 
   return {
     arm: async () => {
@@ -26,7 +29,10 @@ export function createSfxController(): SfxController {
       }
 
       try {
-        context ??= new AudioContext();
+        if (context === null) {
+          context = new AudioContext();
+          lastPlayedAtByName.clear();
+        }
         if (context.state === "suspended") {
           await context.resume();
         }
@@ -41,9 +47,19 @@ export function createSfxController(): SfxController {
         return;
       }
 
+      const now = context.currentTime;
+      const lastPlayedAt = lastPlayedAtByName.get(name);
+
+      if (
+        lastPlayedAt !== undefined &&
+        now - lastPlayedAt < SFX_COOLDOWN_SECONDS
+      ) {
+        return;
+      }
+
+      lastPlayedAtByName.set(name, now);
       const tones = getTonePattern(name);
       let offset = 0;
-      const now = context.currentTime;
 
       for (const tone of tones) {
         playTone(context, now + offset, tone);


### PR DESCRIPTION
## Throttle duplicate SFX triggers within a short cooldown window

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #153

### Changes
In `src/audio/sfx.ts`, add per-SfxName cooldown de-duplication so a burst of identical `play(name)` calls within a short window (~30ms, measured against `context.currentTime`) only schedules one oscillator pass. Maintain a `Map<SfxName, number>` (or equivalent record) of `lastPlayedAt` timestamps. On `play(name)`, if `context.currentTime - lastPlayedAt < COOLDOWN_SECONDS`, return early without creating oscillator/gain nodes; otherwise update the timestamp and proceed with the existing tone scheduling. Use a single `const SFX_COOLDOWN_SECONDS = 0.03` (or similar) module-level constant. Reset/clear the map when `arm()` (re)initializes the AudioContext so a fresh context starts with an empty history. Add Vitest cases in `src/audio/sfx.test.ts` covering: (1) two rapid `play('hit')` calls within the cooldown window only create one oscillator (assert `createOscillator` mock call count for the second call equals zero new calls), (2) two `play('hit')` calls separated by more than the cooldown both schedule oscillators, (3) different SfxNames are tracked independently — `play('hit')` immediately followed by `play('shoot')` both fire, (4) the cooldown is anchored to `context.currentTime`, so advancing the mock `currentTime` past the threshold allows replay. Reuse the existing `MockAudioContext` harness — give it a mutable `currentTime` if it isn't already mutable.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*