### PR TITLE
feature: Auto-pause on tab visibilitychange when playing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,18 @@
 import { deriveSfxEvents } from "./audio/events";
 import { createMuteStore } from "./audio/mute";
 import { createSfxController } from "./audio/sfx";
-import { createInitialGameState, type GameState, type Input } from "./game/state";
+import {
+  EMPTY_INPUT,
+  createInitialGameState,
+  type GameState,
+  type Input
+} from "./game/state";
 import { step } from "./game/step";
 import { createKeyboardController } from "./input/keyboard";
 import { createFixedStepLoop } from "./loop/fixedStep";
 import { createHighScoreStore } from "./persistence";
 import { createCanvasRenderer, type CanvasRenderer } from "./render/canvas";
+import { createVisibilityPauseController } from "./visibility";
 
 const FIXED_TIMESTEP_MS = 1000 / 60;
 type RuntimeRenderFlags = Parameters<CanvasRenderer["render"]>[1];
@@ -33,6 +39,21 @@ renderer.render(state, createRenderFlags(muteStore.isMuted()));
 bootstrapping = false;
 maybeArmAudio(state.phase, frameInput);
 
+const visibilityPauseController = createVisibilityPauseController({
+  target: document,
+  isHidden: () => document.hidden,
+  onHide: () => {
+    if (state.phase !== "playing") {
+      return;
+    }
+
+    advanceState(0, {
+      ...EMPTY_INPUT,
+      pausePressed: true
+    });
+  }
+});
+
 const loop = createFixedStepLoop({
   stepMs: FIXED_TIMESTEP_MS,
   onStep: ({ dtMs, firstStepOfFrame }) => {
@@ -44,10 +65,7 @@ const loop = createFixedStepLoop({
           pausePressed: false,
           mutePressed: false
         };
-    const previousState = state;
-    state = step(state, dtMs, stepInput);
-    maybeRecordHighScore(previousState, state);
-    playDerivedEvents(previousState, state);
+    advanceState(dtMs, stepInput);
   },
   onRender: () => {
     frameInput = keyboard.snapshot();
@@ -65,6 +83,7 @@ const loop = createFixedStepLoop({
 window.addEventListener("beforeunload", () => {
   loop.stop();
   keyboard.dispose();
+  visibilityPauseController.dispose();
 });
 
 loop.start();
@@ -85,6 +104,13 @@ function maybeArmAudio(phase: GameState["phase"], input: Input): void {
 
   audioAttempted = true;
   void sfx.arm();
+}
+
+function advanceState(dtMs: number, input: Input): void {
+  const previousState = state;
+  state = step(state, dtMs, input);
+  maybeRecordHighScore(previousState, state);
+  playDerivedEvents(previousState, state);
 }
 
 function playDerivedEvents(previousState: GameState, nextState: GameState): void {

--- a/src/visibility.test.ts
+++ b/src/visibility.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createVisibilityPauseController } from "./visibility";
+
+type Listener = EventListenerOrEventListenerObject;
+
+class FakeVisibilityTarget {
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  readonly addedTypes: string[] = [];
+  readonly removedTypes: string[] = [];
+
+  addEventListener(type: string, listener: Listener | null): void {
+    this.addedTypes.push(type);
+
+    if (listener === null) {
+      return;
+    }
+
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: Listener | null): void {
+    this.removedTypes.push(type);
+
+    if (listener === null) {
+      return;
+    }
+
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: string): void {
+    const event = new Event(type);
+
+    for (const listener of this.listeners.get(type) ?? []) {
+      if (typeof listener === "function") {
+        listener(event);
+        continue;
+      }
+
+      listener.handleEvent(event);
+    }
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+function createTarget(): FakeVisibilityTarget {
+  return new FakeVisibilityTarget();
+}
+
+describe("createVisibilityPauseController", () => {
+  it("fires onHide when the visibilitychange event reports hidden", () => {
+    const target = createTarget();
+    const onHide = vi.fn();
+
+    createVisibilityPauseController({
+      target: target as Pick<Document, "addEventListener" | "removeEventListener">,
+      isHidden: () => true,
+      onHide
+    });
+
+    target.dispatch("visibilitychange");
+
+    expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onHide when the visibilitychange event reports visible", () => {
+    const target = createTarget();
+    const onHide = vi.fn();
+
+    createVisibilityPauseController({
+      target: target as Pick<Document, "addEventListener" | "removeEventListener">,
+      isHidden: () => false,
+      onHide
+    });
+
+    target.dispatch("visibilitychange");
+
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("detaches the listener on dispose", () => {
+    const target = createTarget();
+    const onHide = vi.fn();
+    const controller = createVisibilityPauseController({
+      target: target as Pick<Document, "addEventListener" | "removeEventListener">,
+      isHidden: () => true,
+      onHide
+    });
+
+    controller.dispose();
+    target.dispatch("visibilitychange");
+
+    expect(onHide).not.toHaveBeenCalled();
+    expect(target.removedTypes).toEqual(["visibilitychange"]);
+  });
+
+  it("adds exactly one visibilitychange listener", () => {
+    const target = createTarget();
+
+    createVisibilityPauseController({
+      target: target as Pick<Document, "addEventListener" | "removeEventListener">,
+      isHidden: () => true,
+      onHide: () => {}
+    });
+
+    expect(target.addedTypes).toEqual(["visibilitychange"]);
+    expect(target.listenerCount("visibilitychange")).toBe(1);
+  });
+});

--- a/src/visibility.ts
+++ b/src/visibility.ts
@@ -1,0 +1,29 @@
+type VisibilityPauseControllerOptions = {
+  target: Pick<Document, "addEventListener" | "removeEventListener">;
+  isHidden: () => boolean;
+  onHide: () => void;
+};
+
+type VisibilityPauseController = {
+  dispose: () => void;
+};
+
+export function createVisibilityPauseController({
+  target,
+  isHidden,
+  onHide
+}: VisibilityPauseControllerOptions): VisibilityPauseController {
+  const handleVisibilityChange = (): void => {
+    if (isHidden()) {
+      onHide();
+    }
+  };
+
+  target.addEventListener("visibilitychange", handleVisibilityChange);
+
+  return {
+    dispose: () => {
+      target.removeEventListener("visibilitychange", handleVisibilityChange);
+    }
+  };
+}


### PR DESCRIPTION
## Auto-pause on tab visibilitychange when playing

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #154

### Changes
Add auto-pause behavior when the browser tab becomes hidden. Create a new helper module `src/visibility.ts` exporting `createVisibilityPauseController({ target, isHidden, onHide }: { target: Pick<Document, 'addEventListener' | 'removeEventListener'>; isHidden: () => boolean; onHide: () => void }): { dispose: () => void }`. The controller attaches a `visibilitychange` listener on `target`; when fired and `isHidden()` is true, it calls `onHide()`. Return a `dispose()` that removes the listener. Keep the module pure (no direct `document` reference — injected via `target`/`isHidden`) so it is unit-testable. In `src/visibility.test.ts`, cover: (a) fires `onHide` only when visibility event reports hidden, (b) does NOT fire when visibility event reports visible, (c) `dispose()` detaches the listener so subsequent events are ignored, (d) adds exactly one listener for `visibilitychange`. Use a minimal fake `EventTarget`-like object tracking added/removed listeners. In `src/main.ts`, import and wire the controller against `document`: when fired and the current `state.phase === 'playing'`, synthesize a pause by injecting a `pausePressed: true` input for the next step (same mechanism used elsewhere in main.ts for deriving pause) OR directly call `step(state, 0, { ...EMPTY_INPUT, pausePressed: true })`, mirroring how the existing keyboard pause flow transitions phase. Match the existing code style in main.ts — no duplication of the pause branch logic; reuse `step()` so phase, renderer, and sfx arming all stay in agreement on the next frame. Do not fire when phase is already `paused`, `start`, `gameOver`, `waveClear`, or `lifeLost` — only `playing` should transition.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*