### PR TITLE
feature: Require distinct restart key (Enter) on gameOver

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -9,6 +9,7 @@ export type GamePhase =
 export type Input = {
   moveX: -1 | 0 | 1;
   firePressed: boolean;
+  restartPressed: boolean;
   pausePressed: boolean;
   fireHeld?: boolean;
   pauseHeld?: boolean;
@@ -147,6 +148,7 @@ export const RESPAWN_INVULNERABILITY_MS = 1500;
 export const EMPTY_INPUT: Input = {
   moveX: 0,
   firePressed: false,
+  restartPressed: false,
   pausePressed: false,
   fireHeld: false,
   pauseHeld: false,

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -408,7 +408,11 @@ describe("step", () => {
   it("keeps the paused state frozen without resume input", () => {
     const state = createGameState({ phase: "paused", score: 55, lives: 2 });
 
-    const next = step(state, 200, { moveX: 1, firePressed: true, pausePressed: false });
+    const next = step(state, 200, {
+      ...EMPTY_INPUT,
+      moveX: 1,
+      firePressed: true
+    });
 
     expect(next).toEqual(state);
   });
@@ -538,6 +542,7 @@ describe("step", () => {
     };
 
     const next = step(lifeLost, 100, {
+      ...EMPTY_INPUT,
       moveX: 1,
       firePressed: true,
       pausePressed: true
@@ -681,12 +686,28 @@ describe("step", () => {
       lives: 0
     });
 
-    const next = step(state, 16, { ...EMPTY_INPUT, firePressed: true });
+    const next = step(state, 16, { ...EMPTY_INPUT, restartPressed: true });
 
     expect(next.phase).toBe("playing");
     expect(next.hud.score).toBe(0);
     expect(next.hud.wave).toBe(1);
     expect(next.hud.lives).toBe(STARTING_LIVES);
+  });
+
+  it("does not restart from game over when only fire is pressed", () => {
+    const state = createGameState({
+      phase: "gameOver",
+      wave: 4,
+      score: 650,
+      lives: 0
+    });
+
+    const next = step(state, 16, { ...EMPTY_INPUT, firePressed: true });
+
+    expect(next.phase).toBe("gameOver");
+    expect(next.hud.score).toBe(650);
+    expect(next.hud.wave).toBe(4);
+    expect(next.hud.lives).toBe(0);
   });
 
   it("keeps wave clear active without confirm input", () => {
@@ -765,7 +786,7 @@ describe("step", () => {
       expect(gameOver.hud.lives).toBe(0);
     });
 
-    it("resets to a fresh first wave when fire is pressed from game over", () => {
+    it("resets to a fresh first wave when Enter is pressed from game over", () => {
       const state = createGameState({
         phase: "gameOver",
         wave: 4,
@@ -773,7 +794,7 @@ describe("step", () => {
         lives: 0
       });
 
-      const next = step(state, 16, { ...EMPTY_INPUT, firePressed: true });
+      const next = step(state, 16, { ...EMPTY_INPUT, restartPressed: true });
 
       expect(next.phase).toBe("playing");
       expect(next.hud.score).toBe(0);

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -45,7 +45,7 @@ export function step(state: GameState, dtMs: number, input: Input = EMPTY_INPUT)
           })
         : advanceFrame(state);
     case "gameOver":
-      return input.firePressed
+      return input.restartPressed
         ? createGameState({ phase: "playing" })
         : advanceFrame(state);
     case "paused":

--- a/src/input/keyboard.ts
+++ b/src/input/keyboard.ts
@@ -10,9 +10,11 @@ export function createKeyboardController(target: Window = window): KeyboardContr
     left: false,
     right: false,
     fire: false,
+    restart: false,
     pause: false,
     mute: false,
     fireEdge: false,
+    restartEdge: false,
     pauseEdge: false,
     muteEdge: false
   };
@@ -32,6 +34,13 @@ export function createKeyboardController(target: Window = window): KeyboardContr
           held.fireEdge = true;
         }
         held.fire = true;
+        event.preventDefault();
+        break;
+      case "Enter":
+        if (!held.restart) {
+          held.restartEdge = true;
+        }
+        held.restart = true;
         event.preventDefault();
         break;
       case "KeyP":
@@ -67,6 +76,10 @@ export function createKeyboardController(target: Window = window): KeyboardContr
         held.fire = false;
         event.preventDefault();
         break;
+      case "Enter":
+        held.restart = false;
+        event.preventDefault();
+        break;
       case "KeyP":
         held.pause = false;
         event.preventDefault();
@@ -84,6 +97,7 @@ export function createKeyboardController(target: Window = window): KeyboardContr
     held.left = false;
     held.right = false;
     held.fire = false;
+    held.restart = false;
     held.pause = false;
     held.mute = false;
   };
@@ -103,6 +117,7 @@ export function createKeyboardController(target: Window = window): KeyboardContr
       const snapshot: Input = {
         moveX,
         firePressed: held.fireEdge,
+        restartPressed: held.restartEdge,
         pausePressed: held.pauseEdge,
         fireHeld: held.fire,
         pauseHeld: held.pause,
@@ -110,6 +125,7 @@ export function createKeyboardController(target: Window = window): KeyboardContr
       };
 
       held.fireEdge = false;
+      held.restartEdge = false;
       held.pauseEdge = false;
       held.muteEdge = false;
 


### PR DESCRIPTION
## Require distinct restart key (Enter) on gameOver

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #160

### Changes
Add a dedicated restart confirmation edge so the `gameOver` phase no longer restarts on any Space press. Extend the `Input` type in `src/game/state.ts` with a `restartPressed` boolean edge and include it in `EMPTY_INPUT`. In `src/input/keyboard.ts`, track the Enter key (`event.code === 'Enter'`) with the same held/edge pattern used for `firePressed` (edge set on the keydown that transitions from not-held to held, cleared after snapshot like the other `*Edge` fields), and emit `restartPressed` in the `Input` snapshot. In `src/game/step.ts`, change the `case "gameOver":` branch so it transitions to a fresh playing state only when `input.restartPressed` is true; otherwise fall through to `advanceFrame(state)`. Leave the `start` and `waveClear` branches on `firePressed`. Extend `src/game/step.test.ts` with at least two cases: (a) from `gameOver`, a tick where `firePressed` is true but `restartPressed` is false does NOT restart (phase stays `gameOver`); (b) a tick where `restartPressed` is true restarts the game (phase becomes `playing`, score/lives reset to initial values). Preserve all existing tests — adjust any case that previously used `firePressed` on `gameOver` to use `restartPressed`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*