### PR TITLE
test: Add muted-badge render test to canvas.test.ts

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -6,6 +6,7 @@ import { PLAYER_SHIP_DESCRIPTOR } from "./sprites";
 
 const HUD_TOP = 18;
 const HUD_HEIGHT = 68;
+const MUTED_BADGE_LABEL = "Sound unavailable";
 const HUD_SHIP_COLORS = new Set(Object.values(PLAYER_SHIP_DESCRIPTOR.palette));
 
 type FillRectCall = {
@@ -203,5 +204,48 @@ describe("createCanvasRenderer", () => {
           call.y < HUD_TOP + HUD_HEIGHT
       )
     ).toBe(true);
+  });
+
+  it("renders the muted badge only when audio is muted", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+    const mutedContext = new FakeCanvasContext();
+    const mutedRenderer = createCanvasRenderer(createFakeCanvas(mutedContext));
+
+    mutedRenderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: true
+    });
+
+    const mutedBadgeCall = mutedContext.fillTextCalls.find(
+      (call) => call.text === MUTED_BADGE_LABEL
+    );
+
+    expect(mutedBadgeCall).toBeDefined();
+
+    if (mutedBadgeCall === undefined) {
+      throw new Error("Expected muted badge label to be rendered.");
+    }
+
+    expect(mutedBadgeCall.y).toBeGreaterThan(HUD_TOP + HUD_HEIGHT);
+
+    const unmutedContext = new FakeCanvasContext();
+    const unmutedRenderer = createCanvasRenderer(createFakeCanvas(unmutedContext));
+
+    unmutedRenderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(
+      unmutedContext.fillTextCalls.some((call) => call.text === MUTED_BADGE_LABEL)
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Add muted-badge render test to canvas.test.ts

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #175

### Changes
Add a new test case to src/render/canvas.test.ts that exercises the previously-unreached drawMutedBadge branch in src/render/canvas.ts. Use the existing FakeCanvasContext harness already defined in the file. Create a playing state via createPlayingState(), invoke renderer.render(state, { muted: true, bootstrapping: false, highScore: 0 }) (match the flags shape used by neighboring tests), and assert that a fillText call is emitted whose text contains the muted indicator drawn by drawMutedBadge — inspect src/render/canvas.ts to find the exact badge string (e.g. a literal containing 'MUTED') and match it. Also assert the badge is drawn inside the HUD band by checking the call's y coordinate falls within [HUD_TOP, HUD_TOP + HUD_HEIGHT]. Do NOT modify src/render/canvas.ts or any non-test file — the test must pass against the current implementation. Add a contrasting assertion (or rely on an existing muted:false test) to confirm the badge is absent when muted is false, if an equivalent assertion isn't already covered.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*