### PR TITLE
feature: Add invader projectile spawning, downward motion, and player-hit collision

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -45,7 +45,7 @@ export type Invader = {
 
 export type Projectile = {
   id: number;
-  owner: "player";
+  owner: "player" | "invader";
   x: number;
   y: number;
   width: number;
@@ -95,6 +95,7 @@ export type GameState = {
   marchFrame: 0 | 1;
   playerShootFrame: number;
   nextProjectileId: number;
+  invaderFireCooldownMs: number;
   transitionTimerMs: number;
   elapsedMs: number;
 };
@@ -106,6 +107,7 @@ export type GameStateSeed = {
   phase?: GamePhase;
   frame?: number;
   nextProjectileId?: number;
+  invaderFireCooldownMs?: number;
   transitionTimerMs?: number;
   elapsedMs?: number;
 };
@@ -122,6 +124,10 @@ export const STARTING_LIVES = 3;
 export const PROJECTILE_WIDTH = 6;
 export const PROJECTILE_HEIGHT = 18;
 export const PROJECTILE_SPEED = -720;
+export const INVADER_PROJECTILE_WIDTH = 8;
+export const INVADER_PROJECTILE_HEIGHT = 18;
+export const INVADER_PROJECTILE_SPEED = 360;
+export const INVADER_FIRE_INTERVAL_MS = 900;
 export const SHIELD_COUNT = 4;
 export const SHIELD_CELL_ROWS = 4;
 export const SHIELD_CELL_COLS = 6;
@@ -174,6 +180,8 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
   const invaders = createInvaders(arena, wave);
   const shields = createShields(arena);
   const nextProjectileId = seed.nextProjectileId ?? 1;
+  const invaderFireCooldownMs =
+    seed.invaderFireCooldownMs ?? INVADER_FIRE_INTERVAL_MS;
 
   return {
     phase: seed.phase ?? "start",
@@ -192,6 +200,7 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
     marchFrame: 0,
     playerShootFrame: 0,
     nextProjectileId,
+    invaderFireCooldownMs,
     transitionTimerMs: seed.transitionTimerMs ?? 0,
     elapsedMs: seed.elapsedMs ?? 0
   };
@@ -320,6 +329,22 @@ export function createPlayerProjectile(
     width: PROJECTILE_WIDTH,
     height: PROJECTILE_HEIGHT,
     velocityY: PROJECTILE_SPEED,
+    active: true
+  };
+}
+
+export function createInvaderProjectile(
+  state: GameState,
+  invader: Invader
+): Projectile {
+  return {
+    id: state.nextProjectileId,
+    owner: "invader",
+    x: invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2,
+    y: invader.y + invader.height,
+    width: INVADER_PROJECTILE_WIDTH,
+    height: INVADER_PROJECTILE_HEIGHT,
+    velocityY: INVADER_PROJECTILE_SPEED,
     active: true
   };
 }

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -4,7 +4,11 @@ import {
   EMPTY_INPUT,
   FORMATION_SPEED_MAX,
   INVADER_COLS,
+  INVADER_FIRE_INTERVAL_MS,
   INVADER_HEIGHT,
+  INVADER_PROJECTILE_HEIGHT,
+  INVADER_PROJECTILE_SPEED,
+  INVADER_PROJECTILE_WIDTH,
   INVADER_ROWS,
   LIFE_LOST_DURATION_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
@@ -87,6 +91,22 @@ function createShieldProjectile(
     width: PROJECTILE_WIDTH,
     height: PROJECTILE_HEIGHT,
     velocityY,
+    active: true
+  };
+}
+
+function createInvaderTestProjectile(
+  state: GameState,
+  y = state.player.y - INVADER_PROJECTILE_HEIGHT
+) {
+  return {
+    id: 1,
+    owner: "invader" as const,
+    x: state.player.x + (state.player.width - INVADER_PROJECTILE_WIDTH) / 2,
+    y,
+    width: INVADER_PROJECTILE_WIDTH,
+    height: INVADER_PROJECTILE_HEIGHT,
+    velocityY: INVADER_PROJECTILE_SPEED,
     active: true
   };
 }
@@ -282,6 +302,89 @@ describe("step", () => {
     const next = step(state, 16, EMPTY_INPUT);
 
     expect(next.projectiles).toHaveLength(0);
+  });
+
+  it("spawns an invader projectile once the firing cadence elapses", () => {
+    const almost = step(createPlayingState(), INVADER_FIRE_INTERVAL_MS - 1, EMPTY_INPUT);
+
+    expect(almost.projectiles.some((projectile) => projectile.owner === "invader")).toBe(false);
+    expect(step(almost, 1, EMPTY_INPUT).projectiles.some((projectile) => projectile.owner === "invader")).toBe(true);
+  });
+
+  it.each(["start", "waveClear", "gameOver", "paused"] as const)(
+    "does not spawn invader projectiles while %s",
+    (phase) => {
+      expect(
+        step(createGameState({ phase, invaderFireCooldownMs: 0 }), INVADER_FIRE_INTERVAL_MS, EMPTY_INPUT)
+          .projectiles.some((projectile) => projectile.owner === "invader")
+      ).toBe(false);
+    }
+  );
+
+  it("moves invader projectiles downward", () => {
+    const base = createPlayingState();
+    const projectile = createInvaderTestProjectile(base, 120);
+
+    const next = step({ ...base, projectiles: [projectile], nextProjectileId: 2 }, 100, EMPTY_INPUT);
+
+    expect(next.projectiles[0]?.y).toBeGreaterThan(projectile.y);
+  });
+
+  it("removes invader projectiles that leave the arena floor", () => {
+    const base = createPlayingState();
+    const projectile = createInvaderTestProjectile(base, base.arena.floorY - 1);
+
+    const next = step({ ...base, projectiles: [projectile], nextProjectileId: 2 }, 16, EMPTY_INPUT);
+
+    expect(next.projectiles).toHaveLength(0);
+  });
+
+  it("loses a life and enters life lost when an invader projectile hits the player", () => {
+    const base = createPlayingState();
+    const state = {
+      ...base,
+      projectiles: [createInvaderTestProjectile(base, base.player.y)],
+      nextProjectileId: 2
+    };
+
+    const next = step(state, 0, EMPTY_INPUT);
+
+    expect(next.phase).toBe("lifeLost");
+    expect(next.hud.lives).toBe(base.hud.lives - 1);
+    expect(next.projectiles).toHaveLength(0);
+  });
+
+  it("does not lose another life from an overlapping invader projectile during life lost", () => {
+    const base = createPlayingState({ lives: 2 });
+    const lifeLost = {
+      ...base,
+      phase: "lifeLost" as const,
+      transitionTimerMs: LIFE_LOST_DURATION_MS,
+      projectiles: [createInvaderTestProjectile(base, base.player.y)],
+      nextProjectileId: 2
+    };
+
+    const next = step(lifeLost, 16, EMPTY_INPUT);
+
+    expect(next.phase).toBe("lifeLost");
+    expect(next.hud.lives).toBe(lifeLost.hud.lives);
+    expect(next.projectiles).toHaveLength(1);
+  });
+
+  it("reaches game over after the last life is lost to an invader projectile", () => {
+    const base = createPlayingState({ lives: 1 });
+    const state = {
+      ...base,
+      projectiles: [createInvaderTestProjectile(base, base.player.y)],
+      nextProjectileId: 2
+    };
+
+    const lifeLost = step(state, 0, EMPTY_INPUT);
+    const gameOver = step(lifeLost, LIFE_LOST_DURATION_MS, EMPTY_INPUT);
+
+    expect(lifeLost.phase).toBe("lifeLost");
+    expect(lifeLost.hud.lives).toBe(0);
+    expect(gameOver.phase).toBe("gameOver");
   });
 
   it("destroys an invader and adds score on hit", () => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -1,8 +1,10 @@
 import {
   EMPTY_INPUT,
+  INVADER_FIRE_INTERVAL_MS,
   LIFE_LOST_DURATION_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
   RESPAWN_INVULNERABILITY_MS,
+  createInvaderProjectile,
   createGameState,
   createPlayerProjectile,
   getFormationSpeed,
@@ -70,17 +72,31 @@ function advanceFrame(state: GameState): GameState {
 }
 
 function advanceLifeLost(state: GameState, dtMs: number): GameState {
+  const simulatedDtMs = Math.min(dtMs, state.transitionTimerMs);
+  const projectileShieldBundle = moveProjectilesThroughShields(
+    state.projectiles,
+    simulatedDtMs / 1000,
+    state.arena.floorY,
+    state.shields
+  );
+  const invaderFireCooldownMs = Math.max(
+    0,
+    state.invaderFireCooldownMs - simulatedDtMs
+  );
   const remaining = state.transitionTimerMs - dtMs;
 
   if (remaining > 0) {
     return {
       ...state,
+      projectiles: projectileShieldBundle.projectiles,
+      shields: projectileShieldBundle.shields,
+      invaderFireCooldownMs,
       transitionTimerMs: remaining,
-      elapsedMs: state.elapsedMs + dtMs
+      elapsedMs: state.elapsedMs + simulatedDtMs
     };
   }
 
-  const resolvedElapsedMs = state.elapsedMs + state.transitionTimerMs;
+  const resolvedElapsedMs = state.elapsedMs + simulatedDtMs;
 
   if (state.hud.lives > 0) {
     const respawnedState = createGameState({
@@ -90,6 +106,7 @@ function advanceLifeLost(state: GameState, dtMs: number): GameState {
       lives: state.hud.lives,
       frame: state.frame + 1,
       nextProjectileId: state.nextProjectileId,
+      invaderFireCooldownMs,
       elapsedMs: resolvedElapsedMs
     });
 
@@ -107,7 +124,9 @@ function advanceLifeLost(state: GameState, dtMs: number): GameState {
     ...state,
     phase: "gameOver",
     projectiles: [],
+    shields: projectileShieldBundle.shields,
     playerShootFrame: 0,
+    invaderFireCooldownMs,
     transitionTimerMs: 0,
     player: {
       ...state.player,
@@ -131,6 +150,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
   const nextElapsedMs = state.elapsedMs + dtMs;
   const cooldown = Math.max(0, state.player.shootCooldownMs - dtMs);
   const playerShootFrame = Math.max(0, state.playerShootFrame - dtMs);
+  const invaderFireCooldownMs = Math.max(
+    0,
+    state.invaderFireCooldownMs - dtMs
+  );
   const movedPlayer = {
     ...state.player,
     x: clamp(
@@ -141,16 +164,17 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     shootCooldownMs: cooldown
   };
 
-  const projectileBundle = maybeSpawnProjectile(
+  const projectileBundle = maybeSpawnProjectiles(
     state,
     movedPlayer,
     input.firePressed,
-    playerShootFrame
+    playerShootFrame,
+    invaderFireCooldownMs
   );
   const projectileShieldBundle = moveProjectilesThroughShields(
     projectileBundle.projectiles,
     dtSeconds,
-    state.arena.height,
+    state.arena.floorY,
     state.shields
   );
   const formationBundle = moveInvaders(state, dtSeconds);
@@ -164,8 +188,24 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     : state.marchFrame;
   const playerIsInvulnerable =
     movedPlayer.invulnerableUntilMs > nextElapsedMs;
+  const playerHitProjectile = playerIsInvulnerable
+    ? undefined
+    : collisionBundle.projectiles.find(
+        (projectile) =>
+          projectile.owner === "invader" && intersects(projectile, movedPlayer)
+      );
+  const remainingProjectiles =
+    playerHitProjectile === undefined
+      ? collisionBundle.projectiles
+      : collisionBundle.projectiles.filter(
+          (projectile) => projectile.id !== playerHitProjectile.id
+        );
 
-  if (!playerIsInvulnerable && hasInvaderBreached(collisionBundle.invaders, movedPlayer)) {
+  if (
+    !playerIsInvulnerable &&
+    (playerHitProjectile !== undefined ||
+      hasInvaderBreached(collisionBundle.invaders, movedPlayer))
+  ) {
     return {
       ...state,
       phase: "lifeLost",
@@ -175,7 +215,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         ...movedPlayer,
         shootCooldownMs: 0
       },
-      projectiles: [],
+      projectiles: remainingProjectiles,
       shields: projectileShieldBundle.shields,
       invaders: collisionBundle.invaders,
       formation: formationBundle.formation,
@@ -184,6 +224,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         score,
         lives: Math.max(0, state.hud.lives - 1)
       },
+      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
       transitionTimerMs: LIFE_LOST_DURATION_MS,
       frame: nextFrame,
       nextProjectileId: projectileBundle.nextProjectileId,
@@ -209,6 +250,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         ...state.hud,
         score
       },
+      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
       transitionTimerMs: 0,
       frame: nextFrame,
       nextProjectileId: projectileBundle.nextProjectileId,
@@ -233,50 +275,88 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       score
     },
     frame: nextFrame,
+    invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
     transitionTimerMs: 0,
     nextProjectileId: projectileBundle.nextProjectileId,
     elapsedMs: nextElapsedMs
   };
 }
 
-function maybeSpawnProjectile(
+function maybeSpawnProjectiles(
   state: GameState,
   player: GameState["player"],
   firePressed: boolean,
-  playerShootFrame: number
+  playerShootFrame: number,
+  invaderFireCooldownMs: number
 ): {
   nextProjectileId: number;
+  invaderFireCooldownMs: number;
   playerShootCooldownMs: number;
   playerShootFrame: number;
   projectiles: Projectile[];
 } {
-  if (!firePressed || player.shootCooldownMs > 0) {
-    return {
-      nextProjectileId: state.nextProjectileId,
-      playerShootCooldownMs: player.shootCooldownMs,
-      playerShootFrame,
-      projectiles: state.projectiles
-    };
+  let nextProjectileId = state.nextProjectileId;
+  let nextPlayerShootCooldownMs = player.shootCooldownMs;
+  let nextPlayerShootFrame = playerShootFrame;
+  let nextProjectiles = state.projectiles;
+  let nextInvaderFireCooldownMs = invaderFireCooldownMs;
+  let firingInvader: Invader | undefined;
+
+  if (firePressed && player.shootCooldownMs <= 0) {
+    const playerProjectile = createPlayerProjectile(
+      {
+        ...state,
+        nextProjectileId
+      },
+      getProjectileSpawnX(player),
+      getProjectileSpawnY(player)
+    );
+
+    nextProjectiles = [...nextProjectiles, playerProjectile];
+    nextProjectileId += 1;
+    nextPlayerShootCooldownMs = PLAYER_SHOOT_COOLDOWN_MS;
+    nextPlayerShootFrame = PLAYER_SHOOT_FRAME_DURATION_MS;
   }
 
-  const projectile = createPlayerProjectile(
-    state,
-    getProjectileSpawnX(player),
-    getProjectileSpawnY(player)
-  );
+  if (nextInvaderFireCooldownMs <= 0) {
+    for (const invader of state.invaders) {
+      if (
+        firingInvader === undefined ||
+        invader.col < firingInvader.col ||
+        (invader.col === firingInvader.col && invader.row > firingInvader.row)
+      ) {
+        firingInvader = invader;
+      }
+    }
+
+    if (firingInvader !== undefined) {
+      const invaderProjectile = createInvaderProjectile(
+        {
+          ...state,
+          nextProjectileId
+        },
+        firingInvader
+      );
+
+      nextProjectiles = [...nextProjectiles, invaderProjectile];
+      nextProjectileId += 1;
+      nextInvaderFireCooldownMs = INVADER_FIRE_INTERVAL_MS;
+    }
+  }
 
   return {
-    nextProjectileId: state.nextProjectileId + 1,
-    playerShootCooldownMs: PLAYER_SHOOT_COOLDOWN_MS,
-    playerShootFrame: PLAYER_SHOOT_FRAME_DURATION_MS,
-    projectiles: [...state.projectiles, projectile]
+    nextProjectileId,
+    invaderFireCooldownMs: nextInvaderFireCooldownMs,
+    playerShootCooldownMs: nextPlayerShootCooldownMs,
+    playerShootFrame: nextPlayerShootFrame,
+    projectiles: nextProjectiles
   };
 }
 
 function moveProjectilesThroughShields(
   projectiles: Projectile[],
   dtSeconds: number,
-  arenaHeight: number,
+  arenaFloorY: number,
   shields: Shield[]
 ): {
   projectiles: Projectile[];
@@ -313,8 +393,8 @@ function moveProjectilesThroughShields(
 
     if (
       movedProjectile.active &&
-      movedProjectile.y + movedProjectile.height >= 0 &&
-      movedProjectile.y <= arenaHeight
+      movedProjectile.y >= 0 &&
+      movedProjectile.y <= arenaFloorY
     ) {
       nextProjectiles.push(movedProjectile);
     }
@@ -391,7 +471,10 @@ function resolveProjectileHits(
   for (const invader of invaders) {
     let hit = false;
     for (const projectile of projectiles) {
-      if (consumedProjectileIds.has(projectile.id)) {
+      if (
+        projectile.owner !== "player" ||
+        consumedProjectileIds.has(projectile.id)
+      ) {
         continue;
       }
       if (intersects(invader, projectile)) {


### PR DESCRIPTION
## Add invader projectile spawning, downward motion, and player-hit collision

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #94

### Changes
Extend the pure simulation so invaders fire projectiles that travel downward and can damage the player.

1. state.ts changes:
   - Extend the Projectile type's `owner` field to accept both "player" and "invader" (e.g. `owner: "player" | "invader"`). Keep width/height/velocityY usable for both.
   - Add tunable constants (exported) such as INVADER_PROJECTILE_SPEED (downward, px/s), INVADER_FIRE_INTERVAL_MS (base cadence between shots across the formation), INVADER_PROJECTILE_WIDTH, INVADER_PROJECTILE_HEIGHT. Pick reasonable values consistent with existing arena dimensions.
   - Add a helper `createInvaderProjectile(invader)` mirroring `createPlayerProjectile`, spawning at the bottom-center of the firing invader and moving DOWN (positive velocityY).
   - Add whatever bookkeeping field(s) are needed on GameState to drive cadence (e.g. `invaderFireCooldownMs: number`). Initialize it in `createGameState`/`createPlayingState` and reset appropriately on new waves / new games.
   - Ensure the existing `projectiles` array on GameState is reused for both owners (do not introduce a separate array) so the renderer can iterate once.

2. step.ts changes:
   - During the `playing` phase, decrement the invader fire cooldown by dt. When it hits zero, pick a random column that still has at least one invader alive and spawn an invader projectile from the BOTTOM-most alive invader in that column. Reset the cooldown to INVADER_FIRE_INTERVAL_MS (a deterministic function of state is fine — e.g. use a simple LCG seeded from a counter on state, OR accept an optional `rng` in Input, OR pick the leftmost-eligible column deterministically in a way that is testable). Whatever approach you pick, tests MUST be able to drive it deterministically.
   - Move all projectiles each tick. Player-owned projectiles continue to move up; invader-owned projectiles move down. Deactivate/despawn projectiles that leave the arena (y > floorY or y < 0).
   - Add collision detection between invader projectiles and the player using the existing rectangle overlap helper. On hit: decrement lives, enter the `lifeLost` phase for LIFE_LOST_DURATION_MS, consume the projectile. If lives reach 0, transition to `gameOver` per existing convention.
   - While in `lifeLost` phase, the player is invulnerable: invader projectiles still travel/despawn but cannot deal damage. Cadence tracking can still advance.

3. step.test.ts additions (ADD at least these cases, do not remove existing ones):
   a. Invader projectile spawn cadence: after INVADER_FIRE_INTERVAL_MS of simulated time in `playing`, the projectiles array contains a new invader-owned projectile.
   b. No invader projectiles spawn during `start` / `waveClear` / `gameOver` / `paused`.
   c. Invader projectiles travel downward (y increases) over successive ticks.
   d. Invader projectiles are removed when they leave the arena floor.
   e. Invader projectile overlapping the player decrements lives by 1 and enters `lifeLost` phase.
   f. During `lifeLost` invulnerability, an overlapping invader projectile does NOT further decrement lives.
   g. Losing the last life from an invader projectile transitions to `gameOver`.

   Use `createPlayingState` and direct state mutation (as existing tests do) to set up scenarios deterministically. Advance `step` with small dt values to isolate each behavior.

4. canvas.ts: no rendering changes are required for this task, but if the renderer iterates projectiles and you added a new owner variant, ensure the type still compiles. Do not modify canvas.ts unless strictly needed for typecheck.

The goal is to fill the missing return-fire mechanic of the Space Invaders core loop while keeping all logic deterministic and unit-testable.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*