### PR TITLE
bug_fix: Spawn invader shots from post-collision formation state

### DIFF
--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -311,6 +311,73 @@ describe("step", () => {
     expect(step(almost, 1, EMPTY_INPUT).projectiles.some((projectile) => projectile.owner === "invader")).toBe(true);
   });
 
+  it("does not spawn an invader projectile when the firing invader dies on that frame", () => {
+    const base = createPlayingState({
+      invaderFireCooldownMs: INVADER_FIRE_INTERVAL_MS
+    });
+    const invader = base.invaders[0];
+    expect(invader).toBeDefined();
+    const state = {
+      ...base,
+      invaders: invader === undefined ? [] : [invader],
+      projectiles:
+        invader === undefined
+          ? []
+          : [
+              {
+                id: 1,
+                owner: "player" as const,
+                x:
+                  invader.x +
+                  getFormationSpeed(1, base.formation.speed) *
+                    (INVADER_FIRE_INTERVAL_MS / 1000) *
+                    base.formation.direction,
+                y: invader.y,
+                width: invader.width,
+                height: invader.height,
+                velocityY: 0,
+                active: true
+              }
+            ],
+      nextProjectileId: 2
+    };
+
+    const next = step(state, INVADER_FIRE_INTERVAL_MS, EMPTY_INPUT);
+
+    expect(next.phase).toBe("waveClear");
+    expect(next.projectiles).toHaveLength(0);
+    expect(next.invaderFireCooldownMs).toBe(0);
+  });
+
+  it("spawns invader projectiles from the marched invader position", () => {
+    const base = createPlayingState({
+      invaderFireCooldownMs: INVADER_FIRE_INTERVAL_MS
+    });
+    const invader = base.invaders[0];
+    expect(invader).toBeDefined();
+    const state = {
+      ...base,
+      invaders: invader === undefined ? [] : [invader]
+    };
+
+    const next = step(state, INVADER_FIRE_INTERVAL_MS, EMPTY_INPUT);
+    const invaderProjectile = next.projectiles.find(
+      (projectile) => projectile.owner === "invader"
+    );
+    const marchedInvader = next.invaders[0];
+
+    expect(invaderProjectile).toBeDefined();
+    expect(next.invaderFireCooldownMs).toBe(INVADER_FIRE_INTERVAL_MS);
+    expect(invaderProjectile?.x).toBe(
+      (marchedInvader?.x ?? 0) +
+        (marchedInvader?.width ?? 0) / 2 -
+        INVADER_PROJECTILE_WIDTH / 2
+    );
+    expect(invaderProjectile?.y).toBe(
+      (marchedInvader?.y ?? 0) + (marchedInvader?.height ?? 0)
+    );
+  });
+
   it.each(["start", "waveClear", "gameOver", "paused"] as const)(
     "does not spawn invader projectiles while %s",
     (phase) => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -164,15 +164,14 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     shootCooldownMs: cooldown
   };
 
-  const projectileBundle = maybeSpawnProjectiles(
+  const playerProjectileBundle = maybeSpawnPlayerProjectile(
     state,
     movedPlayer,
     input.firePressed,
-    playerShootFrame,
-    invaderFireCooldownMs
+    playerShootFrame
   );
   const projectileShieldBundle = moveProjectilesThroughShields(
-    projectileBundle.projectiles,
+    playerProjectileBundle.projectiles,
     dtSeconds,
     state.arena.floorY,
     state.shields
@@ -182,6 +181,17 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     projectileShieldBundle.projectiles,
     formationBundle.invaders
   );
+  const invaderProjectileBundle = maybeSpawnInvaderProjectile(
+    {
+      ...state,
+      player: movedPlayer,
+      projectiles: collisionBundle.projectiles,
+      invaders: collisionBundle.invaders,
+      formation: formationBundle.formation,
+      nextProjectileId: playerProjectileBundle.nextProjectileId
+    },
+    invaderFireCooldownMs
+  );
   const score = state.hud.score + collisionBundle.scoreDelta;
   const marchFrame = formationBundle.didAdvance
     ? toggleMarchFrame(state.marchFrame)
@@ -190,14 +200,14 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     movedPlayer.invulnerableUntilMs > nextElapsedMs;
   const playerHitProjectile = playerIsInvulnerable
     ? undefined
-    : collisionBundle.projectiles.find(
+    : invaderProjectileBundle.projectiles.find(
         (projectile) =>
           projectile.owner === "invader" && intersects(projectile, movedPlayer)
       );
   const remainingProjectiles =
     playerHitProjectile === undefined
-      ? collisionBundle.projectiles
-      : collisionBundle.projectiles.filter(
+      ? invaderProjectileBundle.projectiles
+      : invaderProjectileBundle.projectiles.filter(
           (projectile) => projectile.id !== playerHitProjectile.id
         );
 
@@ -224,10 +234,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         score,
         lives: Math.max(0, state.hud.lives - 1)
       },
-      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+      invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
       transitionTimerMs: LIFE_LOST_DURATION_MS,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId,
+      nextProjectileId: invaderProjectileBundle.nextProjectileId,
       elapsedMs: nextElapsedMs
     };
   }
@@ -237,10 +247,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       ...state,
       phase: "waveClear",
       marchFrame,
-      playerShootFrame: projectileBundle.playerShootFrame,
+      playerShootFrame: playerProjectileBundle.playerShootFrame,
       player: {
         ...movedPlayer,
-        shootCooldownMs: projectileBundle.playerShootCooldownMs
+        shootCooldownMs: playerProjectileBundle.playerShootCooldownMs
       },
       projectiles: [],
       shields: projectileShieldBundle.shields,
@@ -250,10 +260,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         ...state.hud,
         score
       },
-      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+      invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
       transitionTimerMs: 0,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId,
+      nextProjectileId: invaderProjectileBundle.nextProjectileId,
       elapsedMs: nextElapsedMs
     };
   }
@@ -261,12 +271,12 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
   return {
     ...state,
     marchFrame,
-    playerShootFrame: projectileBundle.playerShootFrame,
+    playerShootFrame: playerProjectileBundle.playerShootFrame,
     player: {
       ...movedPlayer,
-      shootCooldownMs: projectileBundle.playerShootCooldownMs
+      shootCooldownMs: playerProjectileBundle.playerShootCooldownMs
     },
-    projectiles: collisionBundle.projectiles,
+    projectiles: invaderProjectileBundle.projectiles,
     shields: projectileShieldBundle.shields,
     invaders: collisionBundle.invaders,
     formation: formationBundle.formation,
@@ -275,22 +285,20 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       score
     },
     frame: nextFrame,
-    invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+    invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
     transitionTimerMs: 0,
-    nextProjectileId: projectileBundle.nextProjectileId,
+    nextProjectileId: invaderProjectileBundle.nextProjectileId,
     elapsedMs: nextElapsedMs
   };
 }
 
-function maybeSpawnProjectiles(
+function maybeSpawnPlayerProjectile(
   state: GameState,
   player: GameState["player"],
   firePressed: boolean,
-  playerShootFrame: number,
-  invaderFireCooldownMs: number
+  playerShootFrame: number
 ): {
   nextProjectileId: number;
-  invaderFireCooldownMs: number;
   playerShootCooldownMs: number;
   playerShootFrame: number;
   projectiles: Projectile[];
@@ -299,8 +307,6 @@ function maybeSpawnProjectiles(
   let nextPlayerShootCooldownMs = player.shootCooldownMs;
   let nextPlayerShootFrame = playerShootFrame;
   let nextProjectiles = state.projectiles;
-  let nextInvaderFireCooldownMs = invaderFireCooldownMs;
-  let firingInvader: Invader | undefined;
 
   if (firePressed && player.shootCooldownMs <= 0) {
     const playerProjectile = createPlayerProjectile(
@@ -318,38 +324,57 @@ function maybeSpawnProjectiles(
     nextPlayerShootFrame = PLAYER_SHOOT_FRAME_DURATION_MS;
   }
 
-  if (nextInvaderFireCooldownMs <= 0) {
-    for (const invader of state.invaders) {
-      if (
-        firingInvader === undefined ||
-        invader.col < firingInvader.col ||
-        (invader.col === firingInvader.col && invader.row > firingInvader.row)
-      ) {
-        firingInvader = invader;
-      }
-    }
-
-    if (firingInvader !== undefined) {
-      const invaderProjectile = createInvaderProjectile(
-        {
-          ...state,
-          nextProjectileId
-        },
-        firingInvader
-      );
-
-      nextProjectiles = [...nextProjectiles, invaderProjectile];
-      nextProjectileId += 1;
-      nextInvaderFireCooldownMs = INVADER_FIRE_INTERVAL_MS;
-    }
-  }
-
   return {
     nextProjectileId,
-    invaderFireCooldownMs: nextInvaderFireCooldownMs,
     playerShootCooldownMs: nextPlayerShootCooldownMs,
     playerShootFrame: nextPlayerShootFrame,
     projectiles: nextProjectiles
+  };
+}
+
+function maybeSpawnInvaderProjectile(
+  state: GameState,
+  invaderFireCooldownMs: number
+): {
+  nextProjectileId: number;
+  invaderFireCooldownMs: number;
+  projectiles: Projectile[];
+} {
+  if (invaderFireCooldownMs > 0) {
+    return {
+      nextProjectileId: state.nextProjectileId,
+      invaderFireCooldownMs,
+      projectiles: state.projectiles
+    };
+  }
+
+  let firingInvader: Invader | undefined;
+
+  for (const invader of state.invaders) {
+    if (
+      firingInvader === undefined ||
+      invader.col < firingInvader.col ||
+      (invader.col === firingInvader.col && invader.row > firingInvader.row)
+    ) {
+      firingInvader = invader;
+    }
+  }
+
+  if (firingInvader === undefined) {
+    return {
+      nextProjectileId: state.nextProjectileId,
+      invaderFireCooldownMs,
+      projectiles: state.projectiles
+    };
+  }
+
+  return {
+    nextProjectileId: state.nextProjectileId + 1,
+    invaderFireCooldownMs: INVADER_FIRE_INTERVAL_MS,
+    projectiles: [
+      ...state.projectiles,
+      createInvaderProjectile(state, firingInvader)
+    ]
   };
 }
 


### PR DESCRIPTION
## Spawn invader shots from post-collision formation state

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #281

### Changes
In src/game/step.ts, refactor the tick so `maybeSpawnInvaderProjectile` is invoked against the post-move, post-collision invader list and formation — not a stale `{ ...state }`. Today the call reads `state.invaders` and passes the pre-collision state to `createInvaderProjectile`, which means a freshly-killed invader can still fire on the same frame, and any invader that moved during the march step fires from its prior x/y. Thread the formation-and-collision results (the bundles already computed in the tick — e.g. `collisionBundle.invaders` and `formationBundle`) into the fire-selection path, so the firing-target candidate list and the resulting projectile's origin both come from the final invader positions. Update any helper signatures as needed so the function no longer closes over the stale `state.invaders`. Add regression tests to src/game/step.test.ts that: (1) assert an invader killed by the player's projectile on the same frame cannot spawn an invader projectile; (2) assert a spawned invader projectile's x/y match the post-march position of its firing invader, not the pre-march position. Use `INVADER_FIRE_INTERVAL_MS` and the existing step helpers/factories (`createPlayingState`, etc.) in tests — do not introduce new public constants. Keep scope tight: only change the call site and its direct helpers; do not reshuffle unrelated tick logic.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*