### PR TITLE
bug_fix: Preserve bunker damage when respawning after a lost life

### DIFF
--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -31,17 +31,19 @@ import { step } from "./step";
 
 const SHIELD_HIT_DT_MS = 21;
 
-function createRespawnedPlayingState() {
-  const lifeLost = {
-    ...createPlayingState({
-      elapsedMs: 2_000,
-      lives: 2,
-      score: 440,
-      wave: 2
-    }),
-    phase: "lifeLost" as const,
-    transitionTimerMs: 50
-  };
+function createRespawnedPlayingState(lifeLostState?: GameState & { phase: "lifeLost" }) {
+  const lifeLost =
+    lifeLostState ??
+    {
+      ...createPlayingState({
+        elapsedMs: 2_000,
+        lives: 2,
+        score: 440,
+        wave: 2
+      }),
+      phase: "lifeLost" as const,
+      transitionTimerMs: 50
+    };
 
   return step(lifeLost, 60, EMPTY_INPUT);
 }
@@ -485,12 +487,14 @@ describe("step", () => {
   });
 
   it("starts the next wave from wave clear and preserves score and lives", () => {
-    const state = createGameState({
+    const base = createGameState({
       phase: "waveClear",
       wave: 2,
       score: 310,
       lives: 2
     });
+    const damagedCell = getShieldCell(base, 0, SHIELD_CELL_ROWS - 1, 2);
+    const state = setShieldCellAlive(base, damagedCell.id, false);
 
     const next = step(state, 16, { ...EMPTY_INPUT, firePressed: true });
 
@@ -498,6 +502,8 @@ describe("step", () => {
     expect(next.hud.wave).toBe(3);
     expect(next.hud.score).toBe(310);
     expect(next.hud.lives).toBe(2);
+    expect(getShieldCell(next, 0, SHIELD_CELL_ROWS - 1, 2).alive).toBe(true);
+    expect(countAliveShieldCells(next)).toBe(SHIELD_COUNT * SHIELD_CELL_ROWS * SHIELD_CELL_COLS);
   });
 
   it("pauses from active play", () => {
@@ -683,6 +689,41 @@ describe("step", () => {
     expect(next.projectiles).toHaveLength(0);
   });
 
+  it("preserves shield damage when respawning after a lost life", () => {
+    const damagedRow = SHIELD_CELL_ROWS - 1;
+    const damagedCol = 2;
+    const intactRow = 0;
+    const intactCol = 0;
+    const base = createPlayingState({
+      elapsedMs: 2_000,
+      lives: 2,
+      score: 440,
+      wave: 2
+    });
+    const damagedPlaying = step(
+      {
+        ...base,
+        projectiles: [
+          createShieldProjectile(base, damagedRow, damagedCol, 1, PROJECTILE_SPEED)
+        ],
+        nextProjectileId: 2
+      },
+      SHIELD_HIT_DT_MS,
+      EMPTY_INPUT
+    );
+    const respawned = createRespawnedPlayingState({
+      ...damagedPlaying,
+      phase: "lifeLost",
+      transitionTimerMs: 50
+    });
+
+    expect(getShieldCell(damagedPlaying, 0, damagedRow, damagedCol).alive).toBe(false);
+    expect(respawned.phase).toBe("playing");
+    expect(getShieldCell(respawned, 0, damagedRow, damagedCol).alive).toBe(false);
+    expect(getShieldCell(respawned, 0, intactRow, intactCol).alive).toBe(true);
+    expect(countAliveShieldCells(respawned)).toBe(countAliveShieldCells(damagedPlaying));
+  });
+
   it("sets respawn invulnerability ahead of the current simulation time", () => {
     const next = createRespawnedPlayingState();
 
@@ -777,12 +818,14 @@ describe("step", () => {
   });
 
   it("restarts a fresh run from game over", () => {
-    const state = createGameState({
+    const base = createGameState({
       phase: "gameOver",
       wave: 4,
       score: 650,
       lives: 0
     });
+    const damagedCell = getShieldCell(base, 0, SHIELD_CELL_ROWS - 1, 2);
+    const state = setShieldCellAlive(base, damagedCell.id, false);
 
     const next = step(state, 16, { ...EMPTY_INPUT, firePressed: true });
 
@@ -790,6 +833,8 @@ describe("step", () => {
     expect(next.hud.score).toBe(0);
     expect(next.hud.wave).toBe(1);
     expect(next.hud.lives).toBe(STARTING_LIVES);
+    expect(getShieldCell(next, 0, SHIELD_CELL_ROWS - 1, 2).alive).toBe(true);
+    expect(countAliveShieldCells(next)).toBe(SHIELD_COUNT * SHIELD_CELL_ROWS * SHIELD_CELL_COLS);
   });
 
   it("keeps wave clear active without confirm input", () => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -112,6 +112,7 @@ function advanceLifeLost(state: GameState, dtMs: number): GameState {
 
     return {
       ...respawnedState,
+      shields: projectileShieldBundle.shields,
       player: {
         ...respawnedState.player,
         invulnerableUntilMs:


### PR DESCRIPTION
## Preserve bunker damage when respawning after a lost life

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #279

### Changes
In src/game/step.ts, the lifeLost → playing transition (advanceLifeLost, or wherever the respawn rebuild happens) currently calls createGameState() which goes through createShields() and resets all bunker cells. Change the respawn path so the existing state.shields array (with whatever damage cells have already taken) is carried into the rebuilt playing state instead of being recreated. Do NOT preserve shields on full restart from gameOver, on the start→playing transition, or on waveClear→next-wave transitions — those should still go through createGameState() and produce fresh shields. Add at least one regression case in src/game/step.test.ts that: (1) damages a specific shield cell during play, (2) drives the player through a lifeLost→playing respawn (similar to the existing createRespawnedPlayingState helper), and (3) asserts the damaged cell is still destroyed/damaged after respawn while a different untouched cell is still intact. Also add or extend a test that proves shields ARE freshly rebuilt on the next-wave transition (waveClear → playing with wave+1) and on a full restart from gameOver.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*