### PR TITLE
feature: Display and persist high score during play, not only on game over

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
 import { step } from "./game/step";
 import { createKeyboardController } from "./input/keyboard";
 import { createFixedStepLoop } from "./loop/fixedStep";
-import { createHighScoreStore } from "./persistence";
+import { createHighScoreStore, pickDisplayHighScore } from "./persistence";
 import { createCanvasRenderer, type CanvasRenderer } from "./render/canvas";
 import { createVisibilityPauseController } from "./visibility";
 
@@ -109,7 +109,7 @@ function maybeArmAudio(phase: GameState["phase"], input: Input): void {
 function advanceState(dtMs: number, input: Input): void {
   const previousState = state;
   state = step(state, dtMs, input);
-  maybeRecordHighScore(previousState, state);
+  maybeRecordHighScore(state.hud.score);
   playDerivedEvents(previousState, state);
 }
 
@@ -119,22 +119,22 @@ function playDerivedEvents(previousState: GameState, nextState: GameState): void
   }
 }
 
-function maybeRecordHighScore(
-  previousState: GameState,
-  nextState: GameState
-): void {
-  if (previousState.phase === "gameOver" || nextState.phase !== "gameOver") {
+function maybeRecordHighScore(score: number): void {
+  if (score <= highScoreStore.getHighScore()) {
     return;
   }
 
-  highScoreStore.recordScore(nextState.hud.score);
+  highScoreStore.recordScore(score);
 }
 
 function createRenderFlags(muted: boolean): RuntimeRenderFlags {
   return {
     bootstrapping,
     muted,
-    highScore: highScoreStore.getHighScore()
+    highScore: pickDisplayHighScore(
+      highScoreStore.getHighScore(),
+      state.hud.score
+    )
   };
 }
 

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { createHighScoreStore } from "./persistence";
+import { createHighScoreStore, pickDisplayHighScore } from "./persistence";
 
 const HIGH_SCORE_STORAGE_KEY = "space-invaders-hd.highScore";
 
 class FakeStorage implements Storage {
   private readonly entries = new Map<string, string>();
 
+  public readonly setItemCalls: Array<{ key: string; value: string }> = [];
   public throwOnGet = false;
   public throwOnSet = false;
 
@@ -39,6 +40,7 @@ class FakeStorage implements Storage {
       throw new Error("setItem failed");
     }
 
+    this.setItemCalls.push({ key, value });
     this.entries.set(key, value);
   }
 
@@ -46,6 +48,13 @@ class FakeStorage implements Storage {
     this.entries.set(key, value);
   }
 }
+
+describe("pickDisplayHighScore", () => {
+  it("returns the larger of the stored and current score", () => {
+    expect(pickDisplayHighScore(220, 360)).toBe(360);
+    expect(pickDisplayHighScore(480, 360)).toBe(480);
+  });
+});
 
 describe("createHighScoreStore", () => {
   it("returns 0 when storage is empty", () => {
@@ -72,6 +81,7 @@ describe("createHighScoreStore", () => {
 
     expect(store.recordScore(100)).toBe(220);
     expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("220");
+    expect(storage.setItemCalls).toHaveLength(0);
   });
 
   it("persists scores above the stored high score", () => {
@@ -81,6 +91,34 @@ describe("createHighScoreStore", () => {
 
     expect(store.recordScore(360)).toBe(360);
     expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("360");
+  });
+
+  it("persists each new high score exactly once", () => {
+    const storage = new FakeStorage();
+    const store = createHighScoreStore(storage);
+
+    expect(store.recordScore(120)).toBe(120);
+    expect(store.recordScore(240)).toBe(240);
+    expect(store.recordScore(240)).toBe(240);
+    expect(store.recordScore(360)).toBe(360);
+
+    expect(storage.setItemCalls).toEqual([
+      { key: HIGH_SCORE_STORAGE_KEY, value: "120" },
+      { key: HIGH_SCORE_STORAGE_KEY, value: "240" },
+      { key: HIGH_SCORE_STORAGE_KEY, value: "360" }
+    ]);
+    expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("360");
+  });
+
+  it("surfaces the live high score before any final game-over write", () => {
+    const storage = new FakeStorage();
+    storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+    const store = createHighScoreStore(storage);
+
+    expect(store.recordScore(260)).toBe(260);
+    expect(store.getHighScore()).toBe(260);
+    expect(pickDisplayHighScore(store.getHighScore(), 320)).toBe(320);
+    expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("260");
   });
 
   it.each(["not-a-number", "-5", "NaN"])(

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -7,6 +7,16 @@ export type HighScoreStore = {
   recordScore: (score: number) => number;
 };
 
+export function pickDisplayHighScore(
+  storedHighScore: number,
+  currentScore: number
+): number {
+  return Math.max(
+    normalizeHighScore(storedHighScore),
+    normalizeHighScore(currentScore)
+  );
+}
+
 export function createHighScoreStore(
   storage: Storage = getDefaultStorage()
 ): HighScoreStore {
@@ -15,7 +25,7 @@ export function createHighScoreStore(
   return {
     getHighScore: () => highScore,
     recordScore: (score) => {
-      const nextHighScore = normalizeHighScore(score);
+      const nextHighScore = pickDisplayHighScore(highScore, score);
 
       if (nextHighScore <= highScore) {
         return highScore;


### PR DESCRIPTION
## Display and persist high score during play, not only on game over

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #267

### Changes
Currently src/main.ts only calls highScoreStore.recordScore() when the game transitions into gameOver, so the HIGH value passed through createRenderFlags() stays stale during a run. Make the new record visible immediately and survive an interrupted run:

1. In src/persistence.ts, expose a small helper (e.g. `pickDisplayHighScore(stored, current)` returning `Math.max(stored, current)`) or a tiny `highScore` accessor that always reflects the max of the stored score and the most recently recorded score. Keep the API minimal and pure where possible.
2. In src/main.ts, on every tick (or on score change) call highScoreStore.recordScore(state.hud.score) so increases are persisted as they happen, and compute the `highScore` passed into createRenderFlags() as max(storedHighScore, state.hud.score) so the HUD updates the instant the player beats the record. Avoid spamming localStorage writes when the score has not changed — only call recordScore when the current score exceeds the previously recorded high score.
3. Add/extend tests in src/persistence.test.ts that cover: the helper returns the larger value; recordScore is idempotent when called with a score below the stored value; repeated calls with increasing scores update storage each time; the helper/store reflects the new max before any explicit `recordScore(finalScore)` call at game over.

The canvas renderer already reads flags.highScore and the persistence module already handles storage quirks — this task is purely the wiring + a small helper, with tests. Do not alter rendering or game step logic.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*