### PR TITLE
feature: Add march animation timer to decouple invader marchFrame from tick rate

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -93,6 +93,7 @@ export type GameState = {
   hud: HudState;
   frame: number;
   marchFrame: 0 | 1;
+  marchAnimTimerMs: number;
   playerShootFrame: number;
   nextProjectileId: number;
   invaderFireCooldownMs: number;
@@ -148,6 +149,7 @@ export const INVADER_WAVE_SPEED_STEP =
   FORMATION_SPEED_BASE * FORMATION_SPEED_PER_WAVE;
 export const INVADER_DESCEND_STEP = 24;
 export const LIFE_LOST_DURATION_MS = 900;
+export const MARCH_FRAME_INTERVAL_MS = 500;
 export const RESPAWN_INVULNERABILITY_MS = 1500;
 
 export const EMPTY_INPUT: Input = {
@@ -198,6 +200,7 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
     },
     frame: seed.frame ?? 0,
     marchFrame: 0,
+    marchAnimTimerMs: 0,
     playerShootFrame: 0,
     nextProjectileId,
     invaderFireCooldownMs,

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   EMPTY_INPUT,
+  FORMATION_SPEED_BASE,
   FORMATION_SPEED_MAX,
   INVADER_COLS,
   INVADER_FIRE_INTERVAL_MS,
@@ -11,6 +12,7 @@ import {
   INVADER_PROJECTILE_WIDTH,
   INVADER_ROWS,
   LIFE_LOST_DURATION_MS,
+  MARCH_FRAME_INTERVAL_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
   PROJECTILE_HEIGHT,
   PROJECTILE_SPEED,
@@ -109,6 +111,14 @@ function createInvaderTestProjectile(
     velocityY: INVADER_PROJECTILE_SPEED,
     active: true
   };
+}
+
+function getMarchAnimationIntervalMs(state: GameState): number {
+  return (
+    MARCH_FRAME_INTERVAL_MS *
+    (FORMATION_SPEED_BASE /
+      getFormationSpeed(state.invaders.length, state.formation.speed))
+  );
 }
 
 describe("step", () => {
@@ -523,6 +533,68 @@ describe("step", () => {
 
     expect(next.phase).toBe("playing");
   });
+
+  it("does not change marchFrame after a single 1/60s tick from a fresh playing state", () => {
+    const state = createPlayingState();
+    const next = step(state, 1000 / 60, EMPTY_INPUT);
+
+    expect(next.marchFrame).toBe(state.marchFrame);
+    expect(next.marchAnimTimerMs).toBeCloseTo(1000 / 60);
+  });
+
+  it("toggles marchFrame after enough cumulative dt at the starting formation speed", () => {
+    const state = createPlayingState();
+    const almost = step(state, MARCH_FRAME_INTERVAL_MS - 1, EMPTY_INPUT);
+    const next = step(almost, 1, EMPTY_INPUT);
+
+    expect(almost.marchFrame).toBe(state.marchFrame);
+    expect(next.marchFrame).toBe(1);
+    expect(next.marchAnimTimerMs).toBe(0);
+  });
+
+  it("speeds up the march animation cadence as the formation speed increases", () => {
+    const full = createPlayingState();
+    const reduced = {
+      ...createPlayingState(),
+      invaders: createPlayingState().invaders.slice(0, 5)
+    };
+    const reducedIntervalMs = Math.ceil(getMarchAnimationIntervalMs(reduced));
+
+    expect(reducedIntervalMs).toBeLessThan(getMarchAnimationIntervalMs(full));
+    expect(step(full, reducedIntervalMs, EMPTY_INPUT).marchFrame).toBe(0);
+    expect(step(reduced, reducedIntervalMs, EMPTY_INPUT).marchFrame).toBe(1);
+  });
+
+  it("preserves leftover march animation time across step calls", () => {
+    const state = createPlayingState();
+    const almost = step(state, MARCH_FRAME_INTERVAL_MS - 10, EMPTY_INPUT);
+    const toggled = step(almost, 20, EMPTY_INPUT);
+    const almostAgain = step(toggled, MARCH_FRAME_INTERVAL_MS - 11, EMPTY_INPUT);
+    const toggledAgain = step(almostAgain, 1, EMPTY_INPUT);
+
+    expect(almost.marchAnimTimerMs).toBe(MARCH_FRAME_INTERVAL_MS - 10);
+    expect(toggled.marchFrame).toBe(1);
+    expect(toggled.marchAnimTimerMs).toBe(10);
+    expect(almostAgain.marchFrame).toBe(1);
+    expect(almostAgain.marchAnimTimerMs).toBe(MARCH_FRAME_INTERVAL_MS - 1);
+    expect(toggledAgain.marchFrame).toBe(0);
+    expect(toggledAgain.marchAnimTimerMs).toBe(0);
+  });
+
+  it.each(["start", "gameOver", "waveClear", "paused"] as const)(
+    "does not advance marchFrame while %s",
+    (phase) => {
+      const state = {
+        ...createGameState({ phase }),
+        marchFrame: 1 as const,
+        marchAnimTimerMs: MARCH_FRAME_INTERVAL_MS - 1
+      };
+      const next = step(state, MARCH_FRAME_INTERVAL_MS * 2, EMPTY_INPUT);
+
+      expect(next.marchFrame).toBe(1);
+      expect(next.marchAnimTimerMs).toBe(state.marchAnimTimerMs);
+    }
+  );
 
   it("marches invaders horizontally", () => {
     const state = createPlayingState();

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -1,7 +1,9 @@
 import {
   EMPTY_INPUT,
+  FORMATION_SPEED_BASE,
   INVADER_FIRE_INTERVAL_MS,
   LIFE_LOST_DURATION_MS,
+  MARCH_FRAME_INTERVAL_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
   RESPAWN_INVULNERABILITY_MS,
   createInvaderProjectile,
@@ -178,14 +180,12 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     state.shields
   );
   const formationBundle = moveInvaders(state, dtSeconds);
+  const marchAnimation = advanceMarchAnimation(state, dtMs);
   const collisionBundle = resolveProjectileHits(
     projectileShieldBundle.projectiles,
     formationBundle.invaders
   );
   const score = state.hud.score + collisionBundle.scoreDelta;
-  const marchFrame = formationBundle.didAdvance
-    ? toggleMarchFrame(state.marchFrame)
-    : state.marchFrame;
   const playerIsInvulnerable =
     movedPlayer.invulnerableUntilMs > nextElapsedMs;
   const playerHitProjectile = playerIsInvulnerable
@@ -209,7 +209,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     return {
       ...state,
       phase: "lifeLost",
-      marchFrame,
+      marchAnimTimerMs: marchAnimation.marchAnimTimerMs,
+      marchFrame: marchAnimation.marchFrame,
       playerShootFrame: 0,
       player: {
         ...movedPlayer,
@@ -236,7 +237,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     return {
       ...state,
       phase: "waveClear",
-      marchFrame,
+      marchAnimTimerMs: marchAnimation.marchAnimTimerMs,
+      marchFrame: marchAnimation.marchFrame,
       playerShootFrame: projectileBundle.playerShootFrame,
       player: {
         ...movedPlayer,
@@ -260,7 +262,8 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
 
   return {
     ...state,
-    marchFrame,
+    marchAnimTimerMs: marchAnimation.marchAnimTimerMs,
+    marchFrame: marchAnimation.marchFrame,
     playerShootFrame: projectileBundle.playerShootFrame,
     player: {
       ...movedPlayer,
@@ -410,7 +413,6 @@ function moveInvaders(
   state: GameState,
   dtSeconds: number
 ): {
-  didAdvance: boolean;
   formation: GameState["formation"];
   invaders: Invader[];
 } {
@@ -447,13 +449,54 @@ function moveInvaders(
   }
 
   return {
-    didAdvance: dtSeconds > 0 && state.invaders.length > 0,
     formation: {
       ...state.formation,
       direction
     },
     invaders
   };
+}
+
+function advanceMarchAnimation(
+  state: GameState,
+  dtMs: number
+): {
+  marchAnimTimerMs: number;
+  marchFrame: GameState["marchFrame"];
+} {
+  if (dtMs <= 0 || state.invaders.length === 0) {
+    return {
+      marchAnimTimerMs: state.marchAnimTimerMs,
+      marchFrame: state.marchFrame
+    };
+  }
+
+  const intervalMs = getMarchFrameIntervalMs(
+    state.invaders.length,
+    state.formation.speed
+  );
+  let marchAnimTimerMs = state.marchAnimTimerMs + dtMs;
+  let marchFrame = state.marchFrame;
+
+  while (marchAnimTimerMs >= intervalMs) {
+    marchAnimTimerMs -= intervalMs;
+    marchFrame = toggleMarchFrame(marchFrame);
+  }
+
+  return {
+    marchAnimTimerMs,
+    marchFrame
+  };
+}
+
+function getMarchFrameIntervalMs(
+  invaderCount: number,
+  waveStartSpeed: number
+): number {
+  const currentSpeed = getFormationSpeed(invaderCount, waveStartSpeed);
+
+  // Keep the sprite flip cadence proportional to the formation's live speed.
+  return MARCH_FRAME_INTERVAL_MS * (FORMATION_SPEED_BASE / currentSpeed);
 }
 
 function resolveProjectileHits(


### PR DESCRIPTION
## Add march animation timer to decouple invader marchFrame from tick rate

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #277

### Changes
Currently `advancePlaying()` in src/game/step.ts toggles `marchFrame` every step (60 Hz) whenever `moveInvaders()` returns `didAdvance: true`, and `moveInvaders()` returns `didAdvance` whenever `dtSeconds > 0` and invaders exist. That makes the sprites flip every simulation tick rather than at a deliberate march cadence. Decouple the animation from the tick:

1. In `src/game/state.ts`, add a `marchAnimTimerMs: number` (or similar) field to `GameState`, initialized to 0 in `createGameState`/`createPlayingState`/`createInitialGameState`. Export a tunable interval constant such as `MARCH_FRAME_INTERVAL_MS`. Choose a value that scales sensibly with formation speed — either a fixed cadence near ~500 ms at the slowest speed scaling down as formation speed increases (e.g. interval = baseIntervalMs * (FORMATION_SPEED_MIN / currentSpeed)), or accumulate by distance traveled per step using `getFormationSpeed` so faster formations animate faster. Pick the simplest formulation that makes the cadence proportional to march speed, document the choice in a single short comment if non-obvious, and keep it pure/deterministic.
2. In `src/game/step.ts`, accumulate `dtMs` into the new timer inside `advancePlaying()` (or wherever invaders are advanced during `playing`/`lifeLost` phases). Only toggle `marchFrame` when the accumulated timer crosses the interval threshold, then subtract the interval (do not reset to 0, to avoid drift). Stop incrementing the timer / leave `marchFrame` alone when there are no invaders or when the game is not in an active phase. Remove the existing per-tick toggle behavior driven by `didAdvance`.
3. Add Vitest cases in `src/game/step.test.ts` covering: (a) `marchFrame` does NOT change after a single 1/60s tick from a fresh playing state, (b) `marchFrame` toggles after enough cumulative dt to cross the interval at the starting formation speed, (c) the cadence speeds up as formation speed increases (e.g. when invaders are killed down to fewer remaining), (d) the timer/marchFrame state is preserved across `step` calls and not reset every frame, (e) `marchFrame` does not change in non-playing phases (start, gameOver, waveClear, paused).

Update any existing tests in `src/game/step.test.ts` that asserted `marchFrame` toggling on every tick — those assertions must be revised to match the new cadence. Do NOT touch renderer code (`src/render/canvas.ts`, `src/render/sprites.ts`); the renderer already reads `marchFrame` and should keep working unchanged.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*