### PR TITLE
feature: Add shared control bindings + overlay prompts module

### DIFF
--- a/src/input/bindings.test.ts
+++ b/src/input/bindings.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTROL_BINDINGS, CONTROL_FOOTER, OVERLAY_PROMPTS } from "./bindings";
+
+describe("CONTROL_BINDINGS", () => {
+  it("defines non-empty codes and labels for each action", () => {
+    for (const binding of Object.values(CONTROL_BINDINGS)) {
+      expect(binding.code.length).toBeGreaterThan(0);
+      expect(binding.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("maps restart to Enter", () => {
+    expect(CONTROL_BINDINGS.restart.code).toBe("Enter");
+  });
+});
+
+describe("OVERLAY_PROMPTS", () => {
+  it("uses Enter for the game over restart prompt", () => {
+    expect(OVERLAY_PROMPTS.gameOver).toContain("Enter");
+    expect(OVERLAY_PROMPTS.gameOver).not.toContain("Space");
+  });
+});
+
+describe("CONTROL_FOOTER", () => {
+  it("mentions Enter", () => {
+    expect(CONTROL_FOOTER).toContain("Enter");
+  });
+});

--- a/src/input/bindings.ts
+++ b/src/input/bindings.ts
@@ -1,0 +1,55 @@
+export type ControlAction =
+  | "moveLeft"
+  | "moveRight"
+  | "fire"
+  | "pause"
+  | "mute"
+  | "restart";
+
+type ControlBinding = {
+  readonly code: string;
+  readonly label: string;
+};
+
+export const CONTROL_BINDINGS = {
+  moveLeft: {
+    code: "ArrowLeft",
+    label: "Left Arrow"
+  },
+  moveRight: {
+    code: "ArrowRight",
+    label: "Right Arrow"
+  },
+  fire: {
+    code: "Space",
+    label: "Space"
+  },
+  pause: {
+    code: "KeyP",
+    label: "P"
+  },
+  mute: {
+    code: "KeyM",
+    label: "M"
+  },
+  restart: {
+    code: "Enter",
+    label: "Enter"
+  }
+} as const satisfies Record<ControlAction, ControlBinding>;
+
+export type OverlayPrompt =
+  | "start"
+  | "pause"
+  | "waveClear"
+  | "gameOver";
+
+export const OVERLAY_PROMPTS = {
+  start: "Press Space to Start",
+  pause: "Press P to Resume",
+  waveClear: "Press Space to Continue",
+  gameOver: "Press Enter to Restart"
+} as const satisfies Record<OverlayPrompt, string>;
+
+export const CONTROL_FOOTER =
+  "Controls: Left Arrow / Right Arrow move  |  Space fires  |  P pauses  |  M mutes  |  Enter restarts";


### PR DESCRIPTION
## Add shared control bindings + overlay prompts module

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #275

### Changes
Create `src/input/bindings.ts` as the single source of truth for gameplay key bindings and overlay prompt text. Export a typed `CONTROL_BINDINGS` map keyed by action name (`moveLeft`, `moveRight`, `fire`, `pause`, `mute`, `restart`) where each entry has a `code` (e.g. `ArrowLeft`, `Space`, `KeyP`, `KeyM`, `Enter`) matching what `src/input/keyboard.ts` already handles and a human-readable `label`. Export an `OVERLAY_PROMPTS` record with entries for `start`, `pause`, `waveClear`, and `gameOver` — e.g. `gameOver` must read `Press Enter to Restart` to match the `restartPressed`-on-Enter binding, `start` reads `Press Space to Start`, `pause` reads `Press P to Resume`, `waveClear` reads `Press Space to Continue`. Export a `CONTROL_FOOTER` string that describes the mapped controls and mentions Enter for restart (replacing any `Space fires / confirms` phrasing). Use `as const` so labels are string literal types and downstream consumers stay type-safe. Add `src/input/bindings.test.ts` asserting: (1) every `CONTROL_BINDINGS` entry has a non-empty `code` and `label`; (2) the `restart` binding's `code` equals `Enter`; (3) `OVERLAY_PROMPTS.gameOver` includes `Enter` and does NOT include the word `Space`; (4) `CONTROL_FOOTER` mentions Enter. Do NOT touch `src/input/keyboard.ts` in this task — a separate queued task owns it.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*