### PR TITLE
bug_fix: Spawn invader shots from post-collision formation state

### DIFF
--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -123,6 +123,13 @@ function getMarchAnimationIntervalMs(state: GameState): number {
   );
 }
 
+function getInvaderProjectileSpawnPosition(invader: GameState["invaders"][number]) {
+  return {
+    x: invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2,
+    y: invader.y + invader.height
+  };
+}
+
 describe("step", () => {
   it("keeps the start screen active without confirm input", () => {
     const state = createGameState({ phase: "start" });
@@ -321,6 +328,102 @@ describe("step", () => {
 
     expect(almost.projectiles.some((projectile) => projectile.owner === "invader")).toBe(false);
     expect(step(almost, 1, EMPTY_INPUT).projectiles.some((projectile) => projectile.owner === "invader")).toBe(true);
+  });
+
+  it("does not let an invader killed on the firing frame spawn the projectile", () => {
+    const base = createPlayingState();
+    const killedInvader = base.invaders.find(
+      (invader) => invader.row === INVADER_ROWS - 1 && invader.col === 0
+    );
+    const survivingInvader = base.invaders.find(
+      (invader) => invader.row === 0 && invader.col === 1
+    );
+
+    expect(killedInvader).toBeDefined();
+    expect(survivingInvader).toBeDefined();
+
+    const invaders =
+      killedInvader === undefined || survivingInvader === undefined
+        ? []
+        : [killedInvader, survivingInvader];
+    const stepX =
+      getFormationSpeed(invaders.length, base.formation.speed) *
+      (INVADER_FIRE_INTERVAL_MS / 1000) *
+      base.formation.direction;
+    const projectile = {
+      id: 1,
+      owner: "player" as const,
+      x: (killedInvader?.x ?? 0) + stepX,
+      y: killedInvader?.y ?? 0,
+      width: killedInvader?.width ?? 0,
+      height: killedInvader?.height ?? 0,
+      velocityY: 0,
+      active: true
+    };
+    const state = {
+      ...base,
+      invaders,
+      projectiles: [projectile],
+      nextProjectileId: 2
+    };
+
+    const next = step(state, INVADER_FIRE_INTERVAL_MS, EMPTY_INPUT);
+    const invaderProjectile = next.projectiles.find(
+      (candidate) => candidate.owner === "invader"
+    );
+    const remainingInvader = next.invaders[0];
+
+    expect(next.invaders).toHaveLength(1);
+    expect(next.invaders[0]?.id).toBe(survivingInvader?.id);
+    expect(invaderProjectile).toBeDefined();
+    expect(remainingInvader).toBeDefined();
+    if (
+      invaderProjectile === undefined ||
+      remainingInvader === undefined ||
+      killedInvader === undefined
+    ) {
+      throw new Error("Expected invader projectile and resolved invader positions");
+    }
+    expect(invaderProjectile).toMatchObject(
+      getInvaderProjectileSpawnPosition(remainingInvader)
+    );
+    expect(invaderProjectile).not.toMatchObject(
+      getInvaderProjectileSpawnPosition(killedInvader)
+    );
+  });
+
+  it("spawns invader projectiles from the firing invader's post-march position", () => {
+    const base = createPlayingState();
+    const firingInvader = base.invaders.find(
+      (invader) => invader.row === INVADER_ROWS - 1 && invader.col === 0
+    );
+    const state = {
+      ...base,
+      invaders: firingInvader === undefined ? [] : [firingInvader]
+    };
+
+    const next = step(state, INVADER_FIRE_INTERVAL_MS, EMPTY_INPUT);
+    const invaderProjectile = next.projectiles.find(
+      (candidate) => candidate.owner === "invader"
+    );
+    const movedInvader = next.invaders[0];
+
+    expect(firingInvader).toBeDefined();
+    expect(invaderProjectile).toBeDefined();
+    expect(movedInvader).toBeDefined();
+    if (
+      firingInvader === undefined ||
+      invaderProjectile === undefined ||
+      movedInvader === undefined
+    ) {
+      throw new Error("Expected invader projectile and moved invader");
+    }
+    expect(invaderProjectile).toMatchObject(
+      getInvaderProjectileSpawnPosition(movedInvader)
+    );
+    expect(invaderProjectile).not.toMatchObject(
+      getInvaderProjectileSpawnPosition(firingInvader)
+    );
   });
 
   it.each(["start", "waveClear", "gameOver", "paused"] as const)(

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -167,15 +167,14 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     shootCooldownMs: cooldown
   };
 
-  const projectileBundle = maybeSpawnProjectiles(
+  const playerProjectileBundle = maybeSpawnPlayerProjectile(
     state,
     movedPlayer,
     input.firePressed,
-    playerShootFrame,
-    invaderFireCooldownMs
+    playerShootFrame
   );
   const projectileShieldBundle = moveProjectilesThroughShields(
-    projectileBundle.projectiles,
+    playerProjectileBundle.projectiles,
     dtSeconds,
     state.arena.floorY,
     state.shields
@@ -186,19 +185,27 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     projectileShieldBundle.projectiles,
     formationBundle.invaders
   );
+  const invaderProjectileBundle = maybeSpawnInvaderProjectile(
+    state,
+    formationBundle.formation,
+    collisionBundle.invaders,
+    collisionBundle.projectiles,
+    invaderFireCooldownMs,
+    playerProjectileBundle.nextProjectileId
+  );
   const score = state.hud.score + collisionBundle.scoreDelta;
   const playerIsInvulnerable =
     movedPlayer.invulnerableUntilMs > nextElapsedMs;
   const playerHitProjectile = playerIsInvulnerable
     ? undefined
-    : collisionBundle.projectiles.find(
+    : invaderProjectileBundle.projectiles.find(
         (projectile) =>
           projectile.owner === "invader" && intersects(projectile, movedPlayer)
       );
   const remainingProjectiles =
     playerHitProjectile === undefined
-      ? collisionBundle.projectiles
-      : collisionBundle.projectiles.filter(
+      ? invaderProjectileBundle.projectiles
+      : invaderProjectileBundle.projectiles.filter(
           (projectile) => projectile.id !== playerHitProjectile.id
         );
 
@@ -226,10 +233,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         score,
         lives: Math.max(0, state.hud.lives - 1)
       },
-      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+      invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
       transitionTimerMs: LIFE_LOST_DURATION_MS,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId,
+      nextProjectileId: invaderProjectileBundle.nextProjectileId,
       elapsedMs: nextElapsedMs
     };
   }
@@ -240,10 +247,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       phase: "waveClear",
       marchAnimTimerMs: marchAnimation.marchAnimTimerMs,
       marchFrame: marchAnimation.marchFrame,
-      playerShootFrame: projectileBundle.playerShootFrame,
+      playerShootFrame: playerProjectileBundle.playerShootFrame,
       player: {
         ...movedPlayer,
-        shootCooldownMs: projectileBundle.playerShootCooldownMs
+        shootCooldownMs: playerProjectileBundle.playerShootCooldownMs
       },
       projectiles: [],
       shields: projectileShieldBundle.shields,
@@ -253,10 +260,10 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
         ...state.hud,
         score
       },
-      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+      invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
       transitionTimerMs: 0,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId,
+      nextProjectileId: invaderProjectileBundle.nextProjectileId,
       elapsedMs: nextElapsedMs
     };
   }
@@ -265,12 +272,12 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     ...state,
     marchAnimTimerMs: marchAnimation.marchAnimTimerMs,
     marchFrame: marchAnimation.marchFrame,
-    playerShootFrame: projectileBundle.playerShootFrame,
+    playerShootFrame: playerProjectileBundle.playerShootFrame,
     player: {
       ...movedPlayer,
-      shootCooldownMs: projectileBundle.playerShootCooldownMs
+      shootCooldownMs: playerProjectileBundle.playerShootCooldownMs
     },
-    projectiles: collisionBundle.projectiles,
+    projectiles: invaderProjectileBundle.projectiles,
     shields: projectileShieldBundle.shields,
     invaders: collisionBundle.invaders,
     formation: formationBundle.formation,
@@ -279,22 +286,20 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
       score
     },
     frame: nextFrame,
-    invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+    invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
     transitionTimerMs: 0,
-    nextProjectileId: projectileBundle.nextProjectileId,
+    nextProjectileId: invaderProjectileBundle.nextProjectileId,
     elapsedMs: nextElapsedMs
   };
 }
 
-function maybeSpawnProjectiles(
+function maybeSpawnPlayerProjectile(
   state: GameState,
   player: GameState["player"],
   firePressed: boolean,
-  playerShootFrame: number,
-  invaderFireCooldownMs: number
+  playerShootFrame: number
 ): {
   nextProjectileId: number;
-  invaderFireCooldownMs: number;
   playerShootCooldownMs: number;
   playerShootFrame: number;
   projectiles: Projectile[];
@@ -303,8 +308,6 @@ function maybeSpawnProjectiles(
   let nextPlayerShootCooldownMs = player.shootCooldownMs;
   let nextPlayerShootFrame = playerShootFrame;
   let nextProjectiles = state.projectiles;
-  let nextInvaderFireCooldownMs = invaderFireCooldownMs;
-  let firingInvader: Invader | undefined;
 
   if (firePressed && player.shootCooldownMs <= 0) {
     const playerProjectile = createPlayerProjectile(
@@ -322,38 +325,68 @@ function maybeSpawnProjectiles(
     nextPlayerShootFrame = PLAYER_SHOOT_FRAME_DURATION_MS;
   }
 
-  if (nextInvaderFireCooldownMs <= 0) {
-    for (const invader of state.invaders) {
-      if (
-        firingInvader === undefined ||
-        invader.col < firingInvader.col ||
-        (invader.col === firingInvader.col && invader.row > firingInvader.row)
-      ) {
-        firingInvader = invader;
-      }
-    }
-
-    if (firingInvader !== undefined) {
-      const invaderProjectile = createInvaderProjectile(
-        {
-          ...state,
-          nextProjectileId
-        },
-        firingInvader
-      );
-
-      nextProjectiles = [...nextProjectiles, invaderProjectile];
-      nextProjectileId += 1;
-      nextInvaderFireCooldownMs = INVADER_FIRE_INTERVAL_MS;
-    }
-  }
-
   return {
     nextProjectileId,
-    invaderFireCooldownMs: nextInvaderFireCooldownMs,
     playerShootCooldownMs: nextPlayerShootCooldownMs,
     playerShootFrame: nextPlayerShootFrame,
     projectiles: nextProjectiles
+  };
+}
+
+function maybeSpawnInvaderProjectile(
+  state: GameState,
+  formation: GameState["formation"],
+  invaders: Invader[],
+  projectiles: Projectile[],
+  invaderFireCooldownMs: number,
+  nextProjectileId: number
+): {
+  nextProjectileId: number;
+  invaderFireCooldownMs: number;
+  projectiles: Projectile[];
+} {
+  if (invaderFireCooldownMs > 0) {
+    return {
+      nextProjectileId,
+      invaderFireCooldownMs,
+      projectiles
+    };
+  }
+
+  let firingInvader: Invader | undefined;
+
+  for (const invader of invaders) {
+    if (
+      firingInvader === undefined ||
+      invader.col < firingInvader.col ||
+      (invader.col === firingInvader.col && invader.row > firingInvader.row)
+    ) {
+      firingInvader = invader;
+    }
+  }
+
+  if (firingInvader === undefined) {
+    return {
+      nextProjectileId,
+      invaderFireCooldownMs,
+      projectiles
+    };
+  }
+
+  const invaderProjectile = createInvaderProjectile(
+    {
+      ...state,
+      formation,
+      invaders,
+      nextProjectileId
+    },
+    firingInvader
+  );
+
+  return {
+    nextProjectileId: nextProjectileId + 1,
+    invaderFireCooldownMs: INVADER_FIRE_INTERVAL_MS,
+    projectiles: [...projectiles, invaderProjectile]
   };
 }
 


### PR DESCRIPTION
## Spawn invader shots from post-collision formation state

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #281

### Changes
In src/game/step.ts, refactor the tick so `maybeSpawnInvaderProjectile` is invoked against the post-move, post-collision invader list and formation — not a stale `{ ...state }`. Today the call reads `state.invaders` and passes the pre-collision state to `createInvaderProjectile`, which means a freshly-killed invader can still fire on the same frame, and any invader that moved during the march step fires from its prior x/y. Thread the formation-and-collision results (the bundles already computed in the tick — e.g. `collisionBundle.invaders` and `formationBundle`) into the fire-selection path, so the firing-target candidate list and the resulting projectile's origin both come from the final invader positions. Update any helper signatures as needed so the function no longer closes over the stale `state.invaders`. Add regression tests to src/game/step.test.ts that: (1) assert an invader killed by the player's projectile on the same frame cannot spawn an invader projectile; (2) assert a spawned invader projectile's x/y match the post-march position of its firing invader, not the pre-march position. Use `INVADER_FIRE_INTERVAL_MS` and the existing step helpers/factories (`createPlayingState`, etc.) in tests — do not introduce new public constants. Keep scope tight: only change the call site and its direct helpers; do not reshuffle unrelated tick logic.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*