### PR TITLE
feature: Render respawn invulnerability blink/halo on the player ship

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -7,6 +7,17 @@ import { PLAYER_SHIP_DESCRIPTOR } from "./sprites";
 const HUD_TOP = 18;
 const HUD_HEIGHT = 68;
 const HUD_SHIP_COLORS = new Set(Object.values(PLAYER_SHIP_DESCRIPTOR.palette));
+const PLAYER_INVULNERABILITY_HALO_COLOR = "rgba(123, 229, 255, 0.22)";
+const PLAYER_INVULNERABILITY_HALO_MARGIN = 12;
+const PLAYER_SHIP_PIXEL_COUNT = PLAYER_SHIP_DESCRIPTOR.frames.reduce(
+  (frameCount, frame) =>
+    frameCount +
+    frame.reduce(
+      (rowCount, row) => rowCount + [...row].filter((pixel) => pixel !== ".").length,
+      0
+    ),
+  0
+);
 
 type FillRectCall = {
   fillStyle: string | CanvasGradient | CanvasPattern;
@@ -119,6 +130,35 @@ function countClusters(values: number[]): number {
   return clusterCount;
 }
 
+function getPlayerShipFillRects(
+  context: FakeCanvasContext,
+  state: ReturnType<typeof createPlayingState>
+): FillRectCall[] {
+  return context.fillRectCalls.filter(
+    (call) =>
+      typeof call.fillStyle === "string" &&
+      HUD_SHIP_COLORS.has(call.fillStyle) &&
+      call.x >= state.player.x &&
+      call.x < state.player.x + state.player.width &&
+      call.y >= state.player.y &&
+      call.y < state.player.y + state.player.height
+  );
+}
+
+function findPlayerInvulnerabilityHalo(
+  context: FakeCanvasContext,
+  state: ReturnType<typeof createPlayingState>
+): FillRectCall | undefined {
+  return context.fillRectCalls.find(
+    (call) =>
+      call.fillStyle === PLAYER_INVULNERABILITY_HALO_COLOR &&
+      call.x === state.player.x - PLAYER_INVULNERABILITY_HALO_MARGIN &&
+      call.y === state.player.y - PLAYER_INVULNERABILITY_HALO_MARGIN &&
+      call.width === state.player.width + PLAYER_INVULNERABILITY_HALO_MARGIN * 2 &&
+      call.height === state.player.height + PLAYER_INVULNERABILITY_HALO_MARGIN * 2
+  );
+}
+
 describe("createCanvasRenderer", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -203,5 +243,57 @@ describe("createCanvasRenderer", () => {
           call.y < HUD_TOP + HUD_HEIGHT
       )
     ).toBe(true);
+  });
+
+  it("renders the invulnerability halo and blinks the ship off on deterministic off frames", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState({ elapsedMs: 180 }),
+      invaders: [],
+      projectiles: [],
+      player: {
+        ...createPlayingState().player,
+        invulnerableUntilMs: 360
+      }
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(findPlayerInvulnerabilityHalo(context, state)).toBeDefined();
+    expect(getPlayerShipFillRects(context, state)).toHaveLength(0);
+  });
+
+  it("renders the normal ship without invulnerability halo artifacts once the timer expires", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState({ elapsedMs: 360 }),
+      invaders: [],
+      projectiles: [],
+      player: {
+        ...createPlayingState().player,
+        invulnerableUntilMs: 360
+      }
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(findPlayerInvulnerabilityHalo(context, state)).toBeUndefined();
+    expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
   });
 });

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -19,6 +19,9 @@ export type CanvasRenderer = {
 };
 
 const HUD_HEIGHT = 68;
+const PLAYER_INVULNERABILITY_BLINK_PERIOD_MS = 120;
+const PLAYER_INVULNERABILITY_HALO_COLOR = "rgba(123, 229, 255, 0.22)";
+const PLAYER_INVULNERABILITY_HALO_MARGIN = 12;
 const HUD_MONOSPACE_FONT =
   '600 18px ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace';
 
@@ -273,6 +276,21 @@ function drawProjectiles(
 
 function drawPlayer(context: CanvasRenderingContext2D, state: GameState): void {
   const { player } = state;
+  const playerIsInvulnerable = state.elapsedMs < player.invulnerableUntilMs;
+
+  if (playerIsInvulnerable) {
+    context.fillStyle = PLAYER_INVULNERABILITY_HALO_COLOR;
+    context.fillRect(
+      player.x - PLAYER_INVULNERABILITY_HALO_MARGIN,
+      player.y - PLAYER_INVULNERABILITY_HALO_MARGIN,
+      player.width + PLAYER_INVULNERABILITY_HALO_MARGIN * 2,
+      player.height + PLAYER_INVULNERABILITY_HALO_MARGIN * 2
+    );
+
+    if (!isInvulnerabilityBlinkVisible(state.elapsedMs, player.invulnerableUntilMs)) {
+      return;
+    }
+  }
 
   context.fillStyle = "rgba(56, 184, 255, 0.18)";
   context.beginPath();
@@ -459,4 +477,13 @@ function drawSpriteInBounds(
 
 function getFrameIndex(sprite: PreparedSprite, frameIndex: number): number {
   return Math.max(0, Math.min(frameIndex, sprite.frameCount - 1));
+}
+
+function isInvulnerabilityBlinkVisible(
+  elapsedMs: number,
+  invulnerableUntilMs: number
+): boolean {
+  const remainingInvulnerabilityMs = Math.max(0, invulnerableUntilMs - elapsedMs);
+
+  return Math.floor(remainingInvulnerabilityMs / PLAYER_INVULNERABILITY_BLINK_PERIOD_MS) % 2 === 0;
 }


### PR DESCRIPTION
## Render respawn invulnerability blink/halo on the player ship

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #278

### Changes
Update drawPlayer() in src/render/canvas.ts so that when state.elapsedMs < player.invulnerableUntilMs, the player ship is rendered with a clear visual indicator that respawn invulnerability is active. Use a deterministic blink cadence derived from state.elapsedMs (e.g. toggle visibility on a fixed period like every ~120ms) and/or draw a protective halo/outline around the ship. The cadence MUST be a pure function of state.elapsedMs and player.invulnerableUntilMs so it stays deterministic and testable. When state.elapsedMs >= player.invulnerableUntilMs (no invulnerability), rendering must match current behavior exactly. Add at least two test cases in src/render/canvas.test.ts: (1) when player.invulnerableUntilMs > state.elapsedMs the renderer produces the new visual branch (e.g. extra halo fillRect at expected coordinates, or the ship sprite's fill calls are skipped on a 'blink off' frame), and (2) when player.invulnerableUntilMs <= state.elapsedMs the renderer matches the current ship-drawing behavior with no halo/blink artifacts. Use createPlayingState() and tweak elapsedMs / player.invulnerableUntilMs to construct deterministic scenarios. Do not change the simulation in src/game/ — only rendering.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*