### PR TITLE
feature: Wire computeViewport/applyViewport into the canvas renderer

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createPlayingState } from "../game/state";
+import {
+  ARENA_HEIGHT,
+  ARENA_WIDTH,
+  createPlayingState
+} from "../game/state";
 import { createCanvasRenderer } from "./canvas";
 import { PLAYER_SHIP_DESCRIPTOR } from "./sprites";
 
@@ -35,6 +39,8 @@ type FillTextCall = {
   y: number;
 };
 
+type SetTransformCall = [number, number, number, number, number, number];
+
 class FakeCanvasGradient {
   readonly colorStops: Array<{ color: string; offset: number }> = [];
 
@@ -46,6 +52,7 @@ class FakeCanvasGradient {
 class FakeCanvasContext {
   readonly fillRectCalls: FillRectCall[] = [];
   readonly fillTextCalls: FillTextCall[] = [];
+  readonly setTransformCalls: SetTransformCall[] = [];
 
   fillStyle: string | CanvasGradient | CanvasPattern = "";
   font = "";
@@ -97,16 +104,39 @@ class FakeCanvasContext {
 
   roundRect(): void {}
 
-  setTransform(): void {}
+  setTransform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number
+  ): void {
+    this.setTransformCalls.push([a, b, c, d, e, f]);
+  }
 
   stroke(): void {}
 }
 
-function createFakeCanvas(context: FakeCanvasContext): HTMLCanvasElement {
+type FakeCanvasOptions = {
+  clientHeight?: number;
+  clientWidth?: number;
+};
+
+function createFakeCanvas(
+  context: FakeCanvasContext,
+  options: FakeCanvasOptions = {}
+): HTMLCanvasElement {
   return {
     getContext: (contextId: string) =>
       contextId === "2d" ? (context as unknown as CanvasRenderingContext2D) : null,
+    clientHeight: options.clientHeight ?? ARENA_HEIGHT,
+    clientWidth: options.clientWidth ?? ARENA_WIDTH,
     height: 0,
+    style: {
+      height: "",
+      width: ""
+    } as CSSStyleDeclaration,
     width: 0
   } as HTMLCanvasElement;
 }
@@ -162,6 +192,69 @@ function findPlayerInvulnerabilityHalo(
 describe("createCanvasRenderer", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("sets a DPR-scaled letterboxed viewport on wide canvases", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 2 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context, {
+      clientWidth: 1200,
+      clientHeight: 600
+    });
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(canvas.width).toBe(2400);
+    expect(canvas.height).toBe(1200);
+    expect(canvas.style.width).toBe("1200px");
+    expect(canvas.style.height).toBe("600px");
+    expect(context.setTransformCalls).toHaveLength(2);
+    expect(context.setTransformCalls[0]).toEqual([1, 0, 0, 1, 0, 0]);
+
+    const viewportTransform = context.setTransformCalls[1];
+
+    expect(viewportTransform).toBeDefined();
+    expect(viewportTransform?.[0]).toBeCloseTo(5 / 3);
+    expect(viewportTransform?.[1]).toBe(0);
+    expect(viewportTransform?.[2]).toBe(0);
+    expect(viewportTransform?.[3]).toBeCloseTo(5 / 3);
+    expect(viewportTransform?.[4]).toBeCloseTo(400);
+    expect(viewportTransform?.[5]).toBe(0);
+  });
+
+  it("keeps sprite drawing in logical coordinates on portrait canvases", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 3 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context, {
+      clientWidth: 600,
+      clientHeight: 1200
+    });
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
   });
 
   it("renders the HUD score, wave, and one ship glyph per remaining life", () => {

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -7,6 +7,11 @@ import {
   type SpriteDescriptor,
   type SpriteSheet
 } from "./sprites";
+import {
+  applyViewport,
+  computeViewport,
+  type Viewport
+} from "./viewport";
 
 export type RenderFlags = {
   bootstrapping: boolean;
@@ -40,6 +45,9 @@ const HUD_PLAYER_SHIP_SPRITE = prepareSprite({
 });
 const INVADER_ROW_SPRITES = INVADER_ROW_DESCRIPTORS.map(prepareSprite);
 const PLAYER_PROJECTILE_SPRITE = prepareSprite(PLAYER_PROJECTILE_DESCRIPTOR);
+const LETTERBOX_BACKGROUND_COLOR = "#02050e";
+
+type ViewportContext = Parameters<typeof applyViewport>[0];
 
 export function createCanvasRenderer(canvas: HTMLCanvasElement): CanvasRenderer {
   const context = canvas.getContext("2d");
@@ -48,30 +56,104 @@ export function createCanvasRenderer(canvas: HTMLCanvasElement): CanvasRenderer 
     throw new Error("Canvas 2D is unavailable.");
   }
 
+  const viewportContext = createViewportContext(canvas, context);
+
   return {
     render: (state, flags) => {
-      syncCanvasSize(canvas, context, state.arena.width, state.arena.height);
+      const viewport = computeViewport(
+        getViewportWindow(canvas, state.arena.width, state.arena.height),
+        canvas,
+        state.arena.width,
+        state.arena.height
+      );
+
+      syncCanvasViewport(canvas, viewport);
+      clearViewport(context, viewport);
+      applyViewport(viewportContext, viewport);
       drawScene(context, state, flags);
     }
   };
 }
 
-function syncCanvasSize(
+function createViewportContext(
   canvas: HTMLCanvasElement,
-  context: CanvasRenderingContext2D,
+  context: CanvasRenderingContext2D
+): ViewportContext {
+  return {
+    canvas: {
+      get width() {
+        return canvas.width;
+      },
+      set width(width: number) {
+        if (canvas.width !== width) {
+          canvas.width = width;
+        }
+      },
+      get height() {
+        return canvas.height;
+      },
+      set height(height: number) {
+        if (canvas.height !== height) {
+          canvas.height = height;
+        }
+      }
+    },
+    setTransform: (a, b, c, d, e, f) => {
+      context.setTransform(a, b, c, d, e, f);
+    }
+  };
+}
+
+function getViewportWindow(
+  canvas: HTMLCanvasElement,
   logicalWidth: number,
   logicalHeight: number
-): void {
-  const dpr = window.devicePixelRatio || 1;
-  const renderWidth = Math.round(logicalWidth * dpr);
-  const renderHeight = Math.round(logicalHeight * dpr);
+): Parameters<typeof computeViewport>[0] {
+  const currentWindow = typeof window === "undefined" ? undefined : window;
 
-  if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
-    canvas.width = renderWidth;
-    canvas.height = renderHeight;
+  return {
+    devicePixelRatio: currentWindow?.devicePixelRatio,
+    innerWidth:
+      currentWindow?.innerWidth ??
+      (canvas.clientWidth > 0 ? canvas.clientWidth : logicalWidth),
+    innerHeight:
+      currentWindow?.innerHeight ??
+      (canvas.clientHeight > 0 ? canvas.clientHeight : logicalHeight)
+  };
+}
+
+function syncCanvasViewport(
+  canvas: HTMLCanvasElement,
+  viewport: Viewport
+): void {
+  if (canvas.width !== viewport.backingWidth) {
+    canvas.width = viewport.backingWidth;
   }
 
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  if (canvas.height !== viewport.backingHeight) {
+    canvas.height = viewport.backingHeight;
+  }
+
+  const cssWidth = `${viewport.cssWidth}px`;
+  const cssHeight = `${viewport.cssHeight}px`;
+
+  if (canvas.style.width !== cssWidth) {
+    canvas.style.width = cssWidth;
+  }
+
+  if (canvas.style.height !== cssHeight) {
+    canvas.style.height = cssHeight;
+  }
+}
+
+function clearViewport(
+  context: CanvasRenderingContext2D,
+  viewport: Viewport
+): void {
+  context.setTransform(1, 0, 0, 1, 0, 0);
+  context.clearRect(0, 0, viewport.backingWidth, viewport.backingHeight);
+  context.fillStyle = LETTERBOX_BACKGROUND_COLOR;
+  context.fillRect(0, 0, viewport.backingWidth, viewport.backingHeight);
 }
 
 function drawScene(


### PR DESCRIPTION
## Wire computeViewport/applyViewport into the canvas renderer

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #266

### Changes
Replace the syncCanvasSize() path in src/render/canvas.ts with the existing viewport helper so the live renderer correctly letterboxes and DPR-scales on real browsers/devices. Import computeViewport and applyViewport from ./viewport. On each render call: (1) call computeViewport(window, canvas, state.arena.width, state.arena.height) to get the Viewport; (2) resize the canvas backing store (canvas.width/height) to viewport.backingWidth/backingHeight and set canvas.style.width/height to viewport.cssWidth/cssHeight only when the values actually change (avoid thrashing); (3) call applyViewport(context, viewport) which sets the transform so that subsequent draw calls operate in LOGICAL arena coordinates (0..arena.width, 0..arena.height); (4) clear using the full CSS/backing region before the transform is applied (or clear the logical arena plus letterbox bands), so letterbox bars render as solid background; (5) keep all existing drawing code (player, invaders, bullets, HUD) using logical coordinates unchanged. Remove the old syncCanvasSize helper if it becomes unused. Update src/render/canvas.test.ts: the FakeCanvasContext must accept/record setTransform calls so createCanvasRenderer does not throw, and add at least two focused test cases — one asserting that rendering on a wide viewport sets canvas.width/height to the DPR-scaled backing size and invokes setTransform with the expected letterbox offsets/scale, and one asserting that on a narrow (portrait) viewport the renderer still draws sprites in logical coordinates (existing fillRect assertions should continue to pass in logical space). Preserve all existing test expectations by keeping drawing in logical coordinates.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*