### PR TITLE
feature: Wire computeViewport/applyViewport into the canvas renderer

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -35,6 +35,8 @@ type FillTextCall = {
   y: number;
 };
 
+type SetTransformCall = [number, number, number, number, number, number];
+
 class FakeCanvasGradient {
   readonly colorStops: Array<{ color: string; offset: number }> = [];
 
@@ -46,6 +48,7 @@ class FakeCanvasGradient {
 class FakeCanvasContext {
   readonly fillRectCalls: FillRectCall[] = [];
   readonly fillTextCalls: FillTextCall[] = [];
+  readonly setTransformCalls: SetTransformCall[] = [];
 
   fillStyle: string | CanvasGradient | CanvasPattern = "";
   font = "";
@@ -97,17 +100,45 @@ class FakeCanvasContext {
 
   roundRect(): void {}
 
-  setTransform(): void {}
+  setTransform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number
+  ): void {
+    this.setTransformCalls.push([a, b, c, d, e, f]);
+  }
 
   stroke(): void {}
 }
 
-function createFakeCanvas(context: FakeCanvasContext): HTMLCanvasElement {
+function createFakeCanvas(
+  context: FakeCanvasContext,
+  overrides: Partial<{
+    clientHeight: number;
+    clientWidth: number;
+    height: number;
+    style: {
+      height: string;
+      width: string;
+    };
+    width: number;
+  }> = {}
+): HTMLCanvasElement {
   return {
     getContext: (contextId: string) =>
       contextId === "2d" ? (context as unknown as CanvasRenderingContext2D) : null,
+    clientHeight: 0,
+    clientWidth: 0,
     height: 0,
-    width: 0
+    style: {
+      height: "",
+      width: ""
+    },
+    width: 0,
+    ...overrides
   } as HTMLCanvasElement;
 }
 
@@ -245,6 +276,38 @@ describe("createCanvasRenderer", () => {
     ).toBe(true);
   });
 
+  it("sizes the backing store and applies a letterboxed viewport transform on wide screens", () => {
+    vi.stubGlobal("window", {
+      devicePixelRatio: 2,
+      innerHeight: 600,
+      innerWidth: 1200
+    });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context, {
+      clientHeight: 600,
+      clientWidth: 1200
+    });
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(canvas.width).toBe(2400);
+    expect(canvas.height).toBe(1200);
+    expect(canvas.style.width).toBe("1200px");
+    expect(canvas.style.height).toBe("600px");
+    expect(context.setTransformCalls).toContainEqual([5 / 3, 0, 0, 5 / 3, 400, 0]);
+  });
+
   it("renders the invulnerability halo and blinks the ship off on deterministic off frames", () => {
     vi.stubGlobal("window", { devicePixelRatio: 1 });
 
@@ -269,6 +332,35 @@ describe("createCanvasRenderer", () => {
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeDefined();
     expect(getPlayerShipFillRects(context, state)).toHaveLength(0);
+  });
+
+  it("keeps sprite drawing in logical coordinates on portrait viewports", () => {
+    vi.stubGlobal("window", {
+      devicePixelRatio: 1,
+      innerHeight: 1200,
+      innerWidth: 600
+    });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context, {
+      clientHeight: 1200,
+      clientWidth: 600
+    });
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState({ elapsedMs: 360 }),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(context.setTransformCalls).toContainEqual([0.625, 0, 0, 0.625, 0, 375]);
+    expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
   });
 
   it("renders the normal ship without invulnerability halo artifacts once the timer expires", () => {

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -7,6 +7,11 @@ import {
   type SpriteDescriptor,
   type SpriteSheet
 } from "./sprites";
+import {
+  applyViewport,
+  computeViewport,
+  type Viewport
+} from "./viewport";
 
 export type RenderFlags = {
   bootstrapping: boolean;
@@ -48,30 +53,120 @@ export function createCanvasRenderer(canvas: HTMLCanvasElement): CanvasRenderer 
     throw new Error("Canvas 2D is unavailable.");
   }
 
+  const viewportContext = createViewportContext(canvas, context);
+
   return {
     render: (state, flags) => {
-      syncCanvasSize(canvas, context, state.arena.width, state.arena.height);
+      const viewport = computeViewport(
+        getViewportWindow(canvas, state.arena.width, state.arena.height),
+        canvas,
+        state.arena.width,
+        state.arena.height
+      );
+
+      resizeCanvas(canvas, viewport);
+      clearViewport(context, viewport);
+      applyViewport(viewportContext, viewport);
       drawScene(context, state, flags);
     }
   };
 }
 
-function syncCanvasSize(
+function resizeCanvas(
   canvas: HTMLCanvasElement,
-  context: CanvasRenderingContext2D,
-  logicalWidth: number,
-  logicalHeight: number
+  viewport: Viewport
 ): void {
-  const dpr = window.devicePixelRatio || 1;
-  const renderWidth = Math.round(logicalWidth * dpr);
-  const renderHeight = Math.round(logicalHeight * dpr);
-
-  if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
-    canvas.width = renderWidth;
-    canvas.height = renderHeight;
+  if (canvas.width !== viewport.backingWidth) {
+    canvas.width = viewport.backingWidth;
   }
 
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  if (canvas.height !== viewport.backingHeight) {
+    canvas.height = viewport.backingHeight;
+  }
+
+  const cssWidth = `${viewport.cssWidth}px`;
+
+  if (canvas.style.width !== cssWidth) {
+    canvas.style.width = cssWidth;
+  }
+
+  const cssHeight = `${viewport.cssHeight}px`;
+
+  if (canvas.style.height !== cssHeight) {
+    canvas.style.height = cssHeight;
+  }
+}
+
+function clearViewport(
+  context: CanvasRenderingContext2D,
+  viewport: Viewport
+): void {
+  context.setTransform(1, 0, 0, 1, 0, 0);
+  context.fillStyle = "#02050e";
+  context.fillRect(0, 0, viewport.backingWidth, viewport.backingHeight);
+}
+
+function createViewportContext(
+  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D
+): {
+  canvas: {
+    height: number;
+    width: number;
+  };
+  setTransform: (
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number
+  ) => void;
+} {
+  return {
+    canvas: {
+      get height() {
+        return canvas.height;
+      },
+      set height(value: number) {
+        if (canvas.height !== value) {
+          canvas.height = value;
+        }
+      },
+      get width() {
+        return canvas.width;
+      },
+      set width(value: number) {
+        if (canvas.width !== value) {
+          canvas.width = value;
+        }
+      }
+    },
+    setTransform: (a, b, c, d, e, f) => {
+      context.setTransform(a, b, c, d, e, f);
+    }
+  };
+}
+
+function getViewportWindow(
+  canvas: HTMLCanvasElement,
+  logicalWidth: number,
+  logicalHeight: number
+): Parameters<typeof computeViewport>[0] {
+  const viewportWindow =
+    typeof globalThis.window === "object" ? globalThis.window : undefined;
+
+  return {
+    devicePixelRatio: viewportWindow?.devicePixelRatio,
+    innerWidth:
+      viewportWindow?.innerWidth ??
+      (canvas.clientWidth > 0 ? canvas.clientWidth : (canvas.width || logicalWidth)),
+    innerHeight:
+      viewportWindow?.innerHeight ??
+      (canvas.clientHeight > 0
+        ? canvas.clientHeight
+        : (canvas.height || logicalHeight))
+  };
 }
 
 function drawScene(


### PR DESCRIPTION
## Wire computeViewport/applyViewport into the canvas renderer

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #266

### Changes
Replace the syncCanvasSize() path in src/render/canvas.ts with the existing viewport helper so the live renderer correctly letterboxes and DPR-scales on real browsers/devices. Import computeViewport and applyViewport from ./viewport. On each render call: (1) call computeViewport(window, canvas, state.arena.width, state.arena.height) to get the Viewport; (2) resize the canvas backing store (canvas.width/height) to viewport.backingWidth/backingHeight and set canvas.style.width/height to viewport.cssWidth/cssHeight only when the values actually change (avoid thrashing); (3) call applyViewport(context, viewport) which sets the transform so that subsequent draw calls operate in LOGICAL arena coordinates (0..arena.width, 0..arena.height); (4) clear using the full CSS/backing region before the transform is applied (or clear the logical arena plus letterbox bands), so letterbox bars render as solid background; (5) keep all existing drawing code (player, invaders, bullets, HUD) using logical coordinates unchanged. Remove the old syncCanvasSize helper if it becomes unused. Update src/render/canvas.test.ts: the FakeCanvasContext must accept/record setTransform calls so createCanvasRenderer does not throw, and add at least two focused test cases — one asserting that rendering on a wide viewport sets canvas.width/height to the DPR-scaled backing size and invokes setTransform with the expected letterbox offsets/scale, and one asserting that on a narrow (portrait) viewport the renderer still draws sprites in logical coordinates (existing fillRect assertions should continue to pass in logical space). Preserve all existing test expectations by keeping drawing in logical coordinates.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*