### PR TITLE
feature: Wire computeViewport/applyViewport into the canvas renderer

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -35,6 +35,8 @@ type FillTextCall = {
   y: number;
 };
 
+type SetTransformCall = [number, number, number, number, number, number];
+
 class FakeCanvasGradient {
   readonly colorStops: Array<{ color: string; offset: number }> = [];
 
@@ -46,6 +48,7 @@ class FakeCanvasGradient {
 class FakeCanvasContext {
   readonly fillRectCalls: FillRectCall[] = [];
   readonly fillTextCalls: FillTextCall[] = [];
+  readonly setTransformCalls: SetTransformCall[] = [];
 
   fillStyle: string | CanvasGradient | CanvasPattern = "";
   font = "";
@@ -97,17 +100,45 @@ class FakeCanvasContext {
 
   roundRect(): void {}
 
-  setTransform(): void {}
+  setTransform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number
+  ): void {
+    this.setTransformCalls.push([a, b, c, d, e, f]);
+  }
 
   stroke(): void {}
 }
 
-function createFakeCanvas(context: FakeCanvasContext): HTMLCanvasElement {
+function createFakeCanvas(
+  context: FakeCanvasContext,
+  overrides: Partial<{
+    clientHeight: number;
+    clientWidth: number;
+    height: number;
+    style: {
+      height: string;
+      width: string;
+    };
+    width: number;
+  }> = {}
+): HTMLCanvasElement {
   return {
+    clientHeight: 0,
+    clientWidth: 0,
     getContext: (contextId: string) =>
       contextId === "2d" ? (context as unknown as CanvasRenderingContext2D) : null,
     height: 0,
-    width: 0
+    style: {
+      height: "",
+      width: ""
+    },
+    width: 0,
+    ...overrides
   } as HTMLCanvasElement;
 }
 
@@ -162,6 +193,58 @@ function findPlayerInvulnerabilityHalo(
 describe("createCanvasRenderer", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("sizes the backing store for a wide DPR viewport and applies a letterboxed transform", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 2 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context, {
+      clientWidth: 1280,
+      clientHeight: 720
+    });
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(canvas.width).toBe(2560);
+    expect(canvas.height).toBe(1440);
+    expect(canvas.style.width).toBe("1280px");
+    expect(canvas.style.height).toBe("720px");
+    expect(context.setTransformCalls.at(-1)).toEqual([2, 0, 0, 2, 320, 0]);
+  });
+
+  it("keeps sprite draw calls in logical coordinates on a portrait viewport", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context, {
+      clientWidth: 360,
+      clientHeight: 720
+    });
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
   });
 
   it("renders the HUD score, wave, and one ship glyph per remaining life", () => {

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -7,6 +7,7 @@ import {
   type SpriteDescriptor,
   type SpriteSheet
 } from "./sprites";
+import { applyViewport, computeViewport, type Viewport } from "./viewport";
 
 export type RenderFlags = {
   bootstrapping: boolean;
@@ -48,30 +49,79 @@ export function createCanvasRenderer(canvas: HTMLCanvasElement): CanvasRenderer 
     throw new Error("Canvas 2D is unavailable.");
   }
 
+  const viewportContext = {
+    canvas: {
+      height: canvas.height,
+      width: canvas.width
+    },
+    setTransform: context.setTransform.bind(context)
+  };
+
   return {
     render: (state, flags) => {
-      syncCanvasSize(canvas, context, state.arena.width, state.arena.height);
+      const viewport = computeViewport(
+        getViewportWindow(canvas, state.arena.width, state.arena.height),
+        canvas,
+        state.arena.width,
+        state.arena.height
+      );
+
+      syncCanvasViewport(canvas, viewport);
+      clearViewport(context, viewport);
+      applyViewport(viewportContext, viewport);
       drawScene(context, state, flags);
     }
   };
 }
 
-function syncCanvasSize(
+function getViewportWindow(
   canvas: HTMLCanvasElement,
-  context: CanvasRenderingContext2D,
   logicalWidth: number,
   logicalHeight: number
-): void {
-  const dpr = window.devicePixelRatio || 1;
-  const renderWidth = Math.round(logicalWidth * dpr);
-  const renderHeight = Math.round(logicalHeight * dpr);
+): Parameters<typeof computeViewport>[0] {
+  const fallbackWidth = canvas.clientWidth > 0 ? canvas.clientWidth : logicalWidth;
+  const fallbackHeight =
+    canvas.clientHeight > 0 ? canvas.clientHeight : logicalHeight;
+  const viewportWindow =
+    typeof globalThis.window === "undefined" ? undefined : globalThis.window;
 
-  if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
-    canvas.width = renderWidth;
-    canvas.height = renderHeight;
+  return {
+    devicePixelRatio: viewportWindow?.devicePixelRatio,
+    innerWidth: viewportWindow?.innerWidth ?? fallbackWidth,
+    innerHeight: viewportWindow?.innerHeight ?? fallbackHeight
+  };
+}
+
+function syncCanvasViewport(
+  canvas: HTMLCanvasElement,
+  viewport: Viewport
+): void {
+  if (
+    canvas.width !== viewport.backingWidth ||
+    canvas.height !== viewport.backingHeight
+  ) {
+    canvas.width = viewport.backingWidth;
+    canvas.height = viewport.backingHeight;
   }
 
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  const cssWidth = `${viewport.cssWidth}px`;
+  const cssHeight = `${viewport.cssHeight}px`;
+
+  if (canvas.style.width !== cssWidth) {
+    canvas.style.width = cssWidth;
+  }
+
+  if (canvas.style.height !== cssHeight) {
+    canvas.style.height = cssHeight;
+  }
+}
+
+function clearViewport(
+  context: CanvasRenderingContext2D,
+  viewport: Viewport
+): void {
+  context.setTransform(1, 0, 0, 1, 0, 0);
+  context.clearRect(0, 0, viewport.backingWidth, viewport.backingHeight);
 }
 
 function drawScene(


### PR DESCRIPTION
## Wire computeViewport/applyViewport into the canvas renderer

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #266

### Changes
Replace the syncCanvasSize() path in src/render/canvas.ts with the existing viewport helper so the live renderer correctly letterboxes and DPR-scales on real browsers/devices. Import computeViewport and applyViewport from ./viewport. On each render call: (1) call computeViewport(window, canvas, state.arena.width, state.arena.height) to get the Viewport; (2) resize the canvas backing store (canvas.width/height) to viewport.backingWidth/backingHeight and set canvas.style.width/height to viewport.cssWidth/cssHeight only when the values actually change (avoid thrashing); (3) call applyViewport(context, viewport) which sets the transform so that subsequent draw calls operate in LOGICAL arena coordinates (0..arena.width, 0..arena.height); (4) clear using the full CSS/backing region before the transform is applied (or clear the logical arena plus letterbox bands), so letterbox bars render as solid background; (5) keep all existing drawing code (player, invaders, bullets, HUD) using logical coordinates unchanged. Remove the old syncCanvasSize helper if it becomes unused. Update src/render/canvas.test.ts: the FakeCanvasContext must accept/record setTransform calls so createCanvasRenderer does not throw, and add at least two focused test cases — one asserting that rendering on a wide viewport sets canvas.width/height to the DPR-scaled backing size and invokes setTransform with the expected letterbox offsets/scale, and one asserting that on a narrow (portrait) viewport the renderer still draws sprites in logical coordinates (existing fillRect assertions should continue to pass in logical space). Preserve all existing test expectations by keeping drawing in logical coordinates.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*