### PR TITLE
feature: Extract runtime orchestration into tested src/runtime.ts module

### DIFF
--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveSfxEvents } from "./audio/events";
+import type { SfxName } from "./audio/sfx";
+import {
+  EMPTY_INPUT,
+  createInitialGameState,
+  createPlayerProjectile,
+  createPlayingState,
+  getProjectileSpawnX,
+  getProjectileSpawnY,
+  type GameState,
+  type Input
+} from "./game/state";
+import { createGameRuntime, type GameRuntime } from "./runtime";
+
+class FakeSfxController {
+  public armCalls = 0;
+  public readonly playCalls: SfxName[] = [];
+  public readonly setMutedCalls: boolean[] = [];
+
+  arm(): Promise<void> {
+    this.armCalls += 1;
+    return Promise.resolve();
+  }
+
+  play(name: SfxName): void {
+    this.playCalls.push(name);
+  }
+
+  setMuted(muted: boolean): void {
+    this.setMutedCalls.push(muted);
+  }
+}
+
+class FakeMuteStore {
+  private muted: boolean;
+
+  public toggleCalls = 0;
+
+  constructor(initialMuted = false) {
+    this.muted = initialMuted;
+  }
+
+  isMuted(): boolean {
+    return this.muted;
+  }
+
+  toggle(): boolean {
+    this.toggleCalls += 1;
+    this.muted = !this.muted;
+    return this.muted;
+  }
+}
+
+type RuntimeHarness = {
+  queueInput: (input?: Partial<Input>) => void;
+  runtime: GameRuntime;
+  sfxController: FakeSfxController;
+  stepCalls: Array<{ dtMs: number; input: Input }>;
+  writeHighScoreCalls: number[];
+  muteStore: FakeMuteStore;
+};
+
+type RuntimeHarnessOptions = {
+  deriveEvents?: (
+    previousState: GameState,
+    nextState: GameState
+  ) => readonly SfxName[];
+  initialHighScore?: number;
+  initialMuted?: boolean;
+  initialState?: GameState;
+  step?: (state: GameState, dtMs: number, input: Input) => GameState;
+};
+
+function createHarness(options: RuntimeHarnessOptions = {}): RuntimeHarness {
+  const sfxController = new FakeSfxController();
+  const muteStore = new FakeMuteStore(options.initialMuted);
+  const stepCalls: Array<{ dtMs: number; input: Input }> = [];
+  const writeHighScoreCalls: number[] = [];
+  let highScore = options.initialHighScore ?? 0;
+  let queuedInput = createInput();
+
+  const runtime = createGameRuntime({
+    deriveSfxEvents: options.deriveEvents ?? (() => []),
+    initialState: options.initialState ?? createInitialGameState(),
+    muteStore,
+    readHighScore: () => highScore,
+    readInput: () => {
+      const snapshot = queuedInput;
+      queuedInput = createInput();
+      return snapshot;
+    },
+    sfxController,
+    step: (state, dtMs, input) => {
+      stepCalls.push({ dtMs, input });
+
+      return options.step === undefined ? state : options.step(state, dtMs, input);
+    },
+    writeHighScore: (score) => {
+      writeHighScoreCalls.push(score);
+      highScore = score;
+    }
+  });
+
+  return {
+    queueInput: (input = {}) => {
+      queuedInput = createInput(input);
+    },
+    runtime,
+    sfxController,
+    stepCalls,
+    writeHighScoreCalls,
+    muteStore
+  };
+}
+
+function createInput(input: Partial<Input> = {}): Input {
+  return {
+    ...EMPTY_INPUT,
+    ...input
+  };
+}
+
+function withPlayerProjectileCount(state: GameState, count: number): GameState {
+  return {
+    ...state,
+    projectiles: Array.from({ length: count }, (_, index) => ({
+      ...createPlayerProjectile(
+        state,
+        getProjectileSpawnX(state.player),
+        getProjectileSpawnY(state.player)
+      ),
+      id: index + 1
+    }))
+  };
+}
+
+describe("createGameRuntime", () => {
+  it("arms audio exactly once on the first observed user input", () => {
+    const harness = createHarness();
+
+    harness.runtime.onUserInput();
+    harness.runtime.onUserInput();
+    harness.queueInput({ moveX: -1 });
+    harness.runtime.onRender();
+
+    expect(harness.sfxController.armCalls).toBe(1);
+  });
+
+  it("toggles mute on a mute edge and propagates the result to the sfx controller", () => {
+    const harness = createHarness();
+
+    harness.queueInput({ mutePressed: true });
+    harness.runtime.onRender();
+
+    expect(harness.muteStore.toggleCalls).toBe(1);
+    expect(harness.muteStore.isMuted()).toBe(true);
+    expect(harness.sfxController.setMutedCalls).toEqual([false, true]);
+  });
+
+  it("records the max of the stored and final score once per game-over transition", () => {
+    const finalScore = 220;
+    const storedHighScore = 260;
+    const harness = createHarness({
+      initialHighScore: storedHighScore,
+      initialState: createPlayingState(),
+      step: (state) =>
+        state.phase === "playing"
+          ? {
+              ...state,
+              phase: "gameOver",
+              hud: {
+                ...state.hud,
+                score: finalScore
+              }
+            }
+          : {
+              ...state,
+              frame: state.frame + 1
+            }
+    });
+
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+
+    expect(harness.writeHighScoreCalls).toEqual([storedHighScore]);
+  });
+
+  it("dispatches each derived event once across multiple fixed sub-steps in a frame", () => {
+    const initialState = createPlayingState();
+    const shootState = withPlayerProjectileCount(initialState, 1);
+    const hitState = {
+      ...shootState,
+      invaders: shootState.invaders.slice(1)
+    };
+    const duplicateShootState = withPlayerProjectileCount(shootState, 2);
+    let stepIndex = 0;
+    const harness = createHarness({
+      deriveEvents: deriveSfxEvents,
+      initialState,
+      step: (state, _dtMs, input) => {
+        const currentStep = stepIndex;
+        stepIndex += 1;
+
+        if (currentStep === 0) {
+          return input.firePressed ? shootState : state;
+        }
+
+        if (currentStep === 1) {
+          return input.firePressed ? duplicateShootState : hitState;
+        }
+
+        return state;
+      }
+    });
+
+    harness.queueInput({ firePressed: true });
+    harness.runtime.onRender();
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: false });
+
+    expect(harness.stepCalls.map((call) => call.input.firePressed)).toEqual([
+      true,
+      false
+    ]);
+    expect(harness.sfxController.playCalls).toEqual(["shoot", "hit"]);
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,119 @@
+import type { MuteStore } from "./audio/mute";
+import type { SfxController, SfxName } from "./audio/sfx";
+import type { GameState, Input } from "./game/state";
+import type { FixedStepLoopStepInput } from "./loop/fixedStep";
+
+export type GameRuntime = {
+  getDisplayHighScore: () => number;
+  getState: () => GameState;
+  isMuted: () => boolean;
+  onRender: () => void;
+  onStep: (input: FixedStepLoopStepInput) => void;
+  onUserInput: () => void;
+};
+
+export type GameRuntimeOptions = {
+  deriveSfxEvents: (
+    previousState: GameState,
+    nextState: GameState
+  ) => readonly SfxName[];
+  initialState: GameState;
+  muteStore: Pick<MuteStore, "isMuted" | "toggle">;
+  readHighScore: () => number;
+  readInput: () => Input;
+  sfxController: Pick<SfxController, "arm" | "play" | "setMuted">;
+  step: (state: GameState, dtMs: number, input: Input) => GameState;
+  writeHighScore: (score: number) => void;
+};
+
+export function createGameRuntime({
+  deriveSfxEvents,
+  initialState,
+  muteStore,
+  readHighScore,
+  readInput,
+  sfxController,
+  step,
+  writeHighScore
+}: GameRuntimeOptions): GameRuntime {
+  let audioArmed = false;
+  let frameInput = readInput();
+  let state = initialState;
+
+  sfxController.setMuted(muteStore.isMuted());
+
+  const armAudio = (): void => {
+    if (audioArmed) {
+      return;
+    }
+
+    audioArmed = true;
+    void sfxController.arm();
+  };
+
+  return {
+    getDisplayHighScore: () => Math.max(readHighScore(), state.hud.score),
+    getState: () => state,
+    isMuted: () => muteStore.isMuted(),
+    onRender: () => {
+      frameInput = readInput();
+
+      if (hasObservedUserInput(frameInput)) {
+        armAudio();
+      }
+
+      if (!frameInput.mutePressed) {
+        return;
+      }
+
+      sfxController.setMuted(muteStore.toggle());
+    },
+    onStep: ({ dtMs, firstStepOfFrame }) => {
+      const previousState = state;
+      const stepInput = firstStepOfFrame ? frameInput : clearEdgeInput(frameInput);
+
+      state = step(state, dtMs, stepInput);
+      maybeRecordHighScore(previousState, state, readHighScore, writeHighScore);
+
+      for (const event of deriveSfxEvents(previousState, state)) {
+        sfxController.play(event);
+      }
+    },
+    onUserInput: () => {
+      armAudio();
+    }
+  };
+}
+
+function clearEdgeInput(input: Input): Input {
+  return {
+    ...input,
+    firePressed: false,
+    mutePressed: false,
+    pausePressed: false
+  };
+}
+
+function hasObservedUserInput(input: Input): boolean {
+  return (
+    input.moveX !== 0 ||
+    input.firePressed ||
+    input.pausePressed ||
+    input.fireHeld === true ||
+    input.pauseHeld === true ||
+    input.mutePressed === true
+  );
+}
+
+function maybeRecordHighScore(
+  previousState: GameState,
+  nextState: GameState,
+  readHighScore: () => number,
+  writeHighScore: (score: number) => void
+): void {
+  if (previousState.phase === "gameOver" || nextState.phase !== "gameOver") {
+    return;
+  }
+
+  writeHighScore(Math.max(readHighScore(), nextState.hud.score));
+}


### PR DESCRIPTION
## Extract runtime orchestration into tested src/runtime.ts module

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #348

### Changes
Create a new module src/runtime.ts that factors the orchestration currently inlined in src/main.ts into a dependency-injected factory (e.g. createGameRuntime) that is fully unit-testable without a DOM. The factory should accept collaborators (sfx controller, mute store, persistence reader/writer, step fn, initial state, a per-frame event deriver such as deriveSfxEvents, and a way to observe input edges) and expose methods consumed by the fixed-step loop's onStep / onRender callbacks plus input listeners. It must encapsulate these four behaviors: (1) Audio arming — on the first observed user input of any kind, call sfxController.arm() exactly once; subsequent inputs must not re-arm. (2) Mute toggling — when a mute key edge is observed, toggle the mute store and propagate the result to the sfx controller via setMuted. (3) High-score recording — when state transitions into the gameOver phase, persist max(currentHighScore, finalScore) via the injected persistence writer, and only once per game-over transition. (4) One-shot event dispatch — when a single frame advances multiple fixed sub-steps (as fixedStep can do), derive events for each sub-step's (prev, next) transition and dispatch each event to the sfx controller exactly once, with no drops or duplicates, even when 2+ sub-steps each emit events. Then add src/runtime.test.ts with at least one focused test per behavior (4+ cases total). Use fake collaborators in the style of src/audio/mute.test.ts and src/audio/sfx.test.ts — no real AudioContext or localStorage. Do NOT modify src/main.ts in this task; a follow-up task will wire main.ts to this module.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*