### PR TITLE
feature: Move prepareSprite into sprites.ts and expose keyed registry lookups

### DIFF
--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -1,11 +1,7 @@
 import type { GameState, Invader, Projectile } from "../game/state";
 import {
-  INVADER_ROW_DESCRIPTORS,
-  PLAYER_PROJECTILE_DESCRIPTOR,
-  PLAYER_SHIP_DESCRIPTOR,
-  createSpriteSheet,
-  type SpriteDescriptor,
-  type SpriteSheet
+  getSprite,
+  type PreparedSprite
 } from "./sprites";
 import { applyViewport, computeViewport, type Viewport } from "./viewport";
 
@@ -25,22 +21,6 @@ const PLAYER_INVULNERABILITY_HALO_COLOR = "rgba(123, 229, 255, 0.22)";
 const PLAYER_INVULNERABILITY_HALO_MARGIN = 12;
 const HUD_MONOSPACE_FONT =
   '600 18px ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace';
-
-type PreparedSprite = {
-  frameCount: number;
-  height: number;
-  sheet: SpriteSheet;
-  width: number;
-};
-
-const PLAYER_SHIP_SPRITE = prepareSprite(PLAYER_SHIP_DESCRIPTOR);
-const HUD_PLAYER_SHIP_SPRITE = prepareSprite({
-  ...PLAYER_SHIP_DESCRIPTOR,
-  id: "hud-player-ship",
-  pixelSize: 2
-});
-const INVADER_ROW_SPRITES = INVADER_ROW_DESCRIPTORS.map(prepareSprite);
-const PLAYER_PROJECTILE_SPRITE = prepareSprite(PLAYER_PROJECTILE_DESCRIPTOR);
 
 export function createCanvasRenderer(canvas: HTMLCanvasElement): CanvasRenderer {
   const context = canvas.getContext("2d");
@@ -280,11 +260,7 @@ function drawInvaders(
   marchFrame: GameState["marchFrame"]
 ): void {
   for (const invader of invaders) {
-    const sprite = INVADER_ROW_SPRITES[invader.row];
-
-    if (sprite === undefined) {
-      continue;
-    }
+    const sprite = getSprite(`invader-row-${invader.row}`);
 
     const hue = 190 + invader.row * 18;
     const shadowFill = `hsla(${hue}, 100%, 60%, 0.18)`;
@@ -308,13 +284,15 @@ function drawProjectiles(
   context: CanvasRenderingContext2D,
   projectiles: Projectile[]
 ): void {
+  const projectileSprite = getSprite("player-projectile");
+
   for (const projectile of projectiles) {
     context.fillStyle = "rgba(114, 226, 255, 0.25)";
     roundRect(context, projectile.x - 3, projectile.y - 6, projectile.width + 6, projectile.height + 12, 6);
     context.fill();
     drawSpriteInBounds(
       context,
-      PLAYER_PROJECTILE_SPRITE,
+      projectileSprite,
       0,
       projectile.x,
       projectile.y,
@@ -327,6 +305,7 @@ function drawProjectiles(
 function drawPlayer(context: CanvasRenderingContext2D, state: GameState): void {
   const { player } = state;
   const playerIsInvulnerable = state.elapsedMs < player.invulnerableUntilMs;
+  const playerSprite = getSprite("player-ship");
 
   if (playerIsInvulnerable) {
     context.fillStyle = PLAYER_INVULNERABILITY_HALO_COLOR;
@@ -351,7 +330,7 @@ function drawPlayer(context: CanvasRenderingContext2D, state: GameState): void {
   context.fill();
   drawSpriteInBounds(
     context,
-    PLAYER_SHIP_SPRITE,
+    playerSprite,
     state.playerShootFrame > 0 ? 1 : 0,
     player.x,
     player.y,
@@ -463,6 +442,7 @@ function drawHudLives(
   hudRight: number
 ): void {
   const lifeCount = Math.max(0, state.hud.lives);
+  const hudPlayerShipSprite = getSprite("hud-player-ship");
 
   if (lifeCount === 0) {
     return;
@@ -470,13 +450,13 @@ function drawHudLives(
 
   const gap = 10;
   const totalWidth =
-    lifeCount * HUD_PLAYER_SHIP_SPRITE.width + (lifeCount - 1) * gap;
+    lifeCount * hudPlayerShipSprite.width + (lifeCount - 1) * gap;
   let x = hudRight - 22 - totalWidth;
   const y = 56;
 
   for (let index = 0; index < lifeCount; index += 1) {
-    HUD_PLAYER_SHIP_SPRITE.sheet.drawFrame(context, 0, x, y);
-    x += HUD_PLAYER_SHIP_SPRITE.width + gap;
+    hudPlayerShipSprite.sheet.drawFrame(context, 0, x, y);
+    x += hudPlayerShipSprite.width + gap;
   }
 }
 
@@ -490,22 +470,6 @@ function roundRect(
 ): void {
   context.beginPath();
   context.roundRect(x, y, width, height, radius);
-}
-
-function prepareSprite(descriptor: SpriteDescriptor): PreparedSprite {
-  const firstFrame = descriptor.frames[0];
-  const firstRow = firstFrame?.[0];
-
-  if (firstFrame === undefined || firstRow === undefined) {
-    throw new Error(`Sprite "${descriptor.id}" must include a non-empty frame.`);
-  }
-
-  return {
-    frameCount: descriptor.frames.length,
-    height: firstFrame.length * descriptor.pixelSize,
-    sheet: createSpriteSheet(descriptor),
-    width: firstRow.length * descriptor.pixelSize
-  };
 }
 
 function drawSpriteInBounds(

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -6,6 +6,7 @@ import {
   PLAYER_SHIP_DESCRIPTOR,
   SPRITE_DESCRIPTORS,
   createSpriteSheet,
+  getSprite,
   type SpriteCanvasContext,
   type SpriteDescriptor
 } from "./sprites";
@@ -46,6 +47,26 @@ class FakeSpriteContext implements SpriteCanvasContext {
       height
     });
   }
+}
+
+function expectPreparedSpriteToMatchDescriptor(
+  key: string,
+  descriptor: SpriteDescriptor,
+  pixelSize = descriptor.pixelSize
+): void {
+  const firstFrame = descriptor.frames[0];
+  const firstRow = firstFrame?.[0];
+
+  if (firstFrame === undefined || firstRow === undefined) {
+    throw new Error(`Test descriptor "${descriptor.id}" must include a frame.`);
+  }
+
+  const sprite = getSprite(key);
+
+  expect(sprite.frameCount).toBe(descriptor.frames.length);
+  expect(sprite.width).toBe(firstRow.length * pixelSize);
+  expect(sprite.height).toBe(firstFrame.length * pixelSize);
+  expect(sprite.sheet.getFrameCount()).toBe(sprite.frameCount);
 }
 
 describe("createSpriteSheet", () => {
@@ -165,5 +186,30 @@ describe("createSpriteSheet", () => {
     const context = new FakeSpriteContext();
 
     expect(() => spriteSheet.drawFrame(context, 99, 0, 0)).toThrow(RangeError);
+  });
+});
+
+describe("getSprite", () => {
+  it("returns a prepared sprite for each supported registry key", () => {
+    expectPreparedSpriteToMatchDescriptor("player-ship", PLAYER_SHIP_DESCRIPTOR);
+    expectPreparedSpriteToMatchDescriptor(
+      "hud-player-ship",
+      PLAYER_SHIP_DESCRIPTOR,
+      2
+    );
+    expectPreparedSpriteToMatchDescriptor(
+      "player-projectile",
+      PLAYER_PROJECTILE_DESCRIPTOR
+    );
+
+    for (const descriptor of INVADER_ROW_DESCRIPTORS) {
+      expectPreparedSpriteToMatchDescriptor(descriptor.id, descriptor);
+    }
+  });
+
+  it("throws for an unknown registry key", () => {
+    expect(() => getSprite("missing-sprite")).toThrowError(
+      'Unknown sprite key "missing-sprite".'
+    );
   });
 });

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -22,6 +22,13 @@ export type SpriteSheet = {
   getFrameCount: () => number;
 };
 
+export type PreparedSprite = {
+  sheet: SpriteSheet;
+  width: number;
+  height: number;
+  frameCount: number;
+};
+
 export const EMPTY_PIXEL = ".";
 
 const PLAYER_SHIP_FRAMES: readonly SpriteFrame[] = [
@@ -153,6 +160,29 @@ export const SPRITE_DESCRIPTORS = [
   PLAYER_PROJECTILE_DESCRIPTOR
 ] as const satisfies readonly SpriteDescriptor[];
 
+const HUD_PLAYER_SHIP_DESCRIPTOR = {
+  ...PLAYER_SHIP_DESCRIPTOR,
+  id: "hud-player-ship",
+  pixelSize: 2
+} satisfies SpriteDescriptor;
+
+const INVADER_ROW_SPRITES = {
+  "invader-row-0": prepareSprite(INVADER_ROW_DESCRIPTORS[0]),
+  "invader-row-1": prepareSprite(INVADER_ROW_DESCRIPTORS[1]),
+  "invader-row-2": prepareSprite(INVADER_ROW_DESCRIPTORS[2]),
+  "invader-row-3": prepareSprite(INVADER_ROW_DESCRIPTORS[3]),
+  "invader-row-4": prepareSprite(INVADER_ROW_DESCRIPTORS[4])
+} satisfies Record<(typeof INVADER_ROW_DESCRIPTORS)[number]["id"], PreparedSprite>;
+
+const SPRITE_REGISTRY = {
+  "player-ship": prepareSprite(PLAYER_SHIP_DESCRIPTOR),
+  "hud-player-ship": prepareSprite(HUD_PLAYER_SHIP_DESCRIPTOR),
+  "player-projectile": prepareSprite(PLAYER_PROJECTILE_DESCRIPTOR),
+  ...INVADER_ROW_SPRITES
+} satisfies Record<string, PreparedSprite>;
+
+export type SpriteKey = keyof typeof SPRITE_REGISTRY;
+
 export function createSpriteSheet(descriptor: SpriteDescriptor): SpriteSheet {
   validateDescriptor(descriptor);
 
@@ -196,6 +226,16 @@ export function createSpriteSheet(descriptor: SpriteDescriptor): SpriteSheet {
   };
 }
 
+export function getSprite(key: SpriteKey): PreparedSprite;
+export function getSprite(key: string): PreparedSprite;
+export function getSprite(key: string): PreparedSprite {
+  if (!isSpriteKey(key)) {
+    throw new Error(`Unknown sprite key "${key}".`);
+  }
+
+  return SPRITE_REGISTRY[key];
+}
+
 function validateDescriptor(descriptor: SpriteDescriptor): void {
   if (!Number.isFinite(descriptor.pixelSize) || descriptor.pixelSize <= 0) {
     throw new Error(`Sprite "${descriptor.id}" must use a positive pixelSize.`);
@@ -220,4 +260,24 @@ function validateDescriptor(descriptor: SpriteDescriptor): void {
       }
     }
   }
+}
+
+function prepareSprite(descriptor: SpriteDescriptor): PreparedSprite {
+  const firstFrame = descriptor.frames[0];
+  const firstRow = firstFrame?.[0];
+
+  if (firstFrame === undefined || firstRow === undefined) {
+    throw new Error(`Sprite "${descriptor.id}" must include a non-empty frame.`);
+  }
+
+  return {
+    frameCount: descriptor.frames.length,
+    height: firstFrame.length * descriptor.pixelSize,
+    sheet: createSpriteSheet(descriptor),
+    width: firstRow.length * descriptor.pixelSize
+  };
+}
+
+function isSpriteKey(key: string): key is SpriteKey {
+  return Object.prototype.hasOwnProperty.call(SPRITE_REGISTRY, key);
 }


### PR DESCRIPTION
## Move prepareSprite into sprites.ts and expose keyed registry lookups

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #271

### Changes
Refactor sprite handling so canvas.ts asks for sprites by entity key + state instead of importing raw descriptors and preparing them locally. In src/render/sprites.ts: (1) move the `prepareSprite()` logic (currently in canvas.ts) into sprites.ts and export a `PreparedSprite` type with `{ sheet: SpriteSheet; width: number; height: number; frameCount: number }`. (2) Build a keyed registry mapping entity kinds to prepared sprites — at minimum keys for `player-ship` (gameplay), `hud-player-ship` (HUD, pixelSize 2), `player-projectile`, and one entry per invader row (e.g. `invader-row-0`, `invader-row-1`, …) using INVADER_ROW_DESCRIPTORS. (3) Export a `getSprite(key)` lookup (or equivalent, e.g. `getSpriteFrame(key, frameIndex)`) that returns the PreparedSprite and throws on unknown keys. The existing SPRITE_DESCRIPTORS / PLAYER_SHIP_DESCRIPTOR / INVADER_ROW_DESCRIPTORS / PLAYER_PROJECTILE_DESCRIPTOR exports MUST remain exported (sprites.test.ts and canvas.test.ts already import some of them) — the registry is an additional layer, not a replacement. In src/render/canvas.ts: remove the local `prepareSprite` helper and the four module-level PreparedSprite constants; update drawPlayer(), drawInvaders(), drawProjectiles(), and drawHudLives() to call the new registry lookup. Add/adjust tests in src/render/sprites.test.ts that exercise the registry lookup (returns expected prepared sprite for each key; throws on unknown key). Keep src/render/canvas.test.ts green — adjust imports only if a removed symbol was being imported from canvas.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*