### PR TITLE
feature: Emit typed gameplay events from step() return value

### DIFF
--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -27,11 +27,16 @@ import {
   getFormationSpeed,
   getPlayerMaxX,
   getPlayerMinX,
-  type GameState
+  type GameState,
+  type Input
 } from "./state";
-import { step } from "./step";
+import { step as stepWithEvents } from "./step";
 
 const SHIELD_HIT_DT_MS = 21;
+
+function step(state: GameState, dtMs: number, input: Input = EMPTY_INPUT) {
+  return stepWithEvents(state, dtMs, input).state;
+}
 
 function createRespawnedPlayingState(lifeLostState?: GameState & { phase: "lifeLost" }) {
   const lifeLost =
@@ -184,10 +189,11 @@ describe("step", () => {
   it("fires a projectile when the cooldown is ready", () => {
     const state = createPlayingState();
 
-    const next = step(state, 16, { ...EMPTY_INPUT, firePressed: true });
+    const next = stepWithEvents(state, 16, { ...EMPTY_INPUT, firePressed: true });
 
-    expect(next.projectiles).toHaveLength(1);
-    expect(next.player.shootCooldownMs).toBe(PLAYER_SHOOT_COOLDOWN_MS);
+    expect(next.events).toEqual([{ type: "playerShot" }]);
+    expect(next.state.projectiles).toHaveLength(1);
+    expect(next.state.player.shootCooldownMs).toBe(PLAYER_SHOOT_COOLDOWN_MS);
   });
 
   it("creates a full set of live shield cells for a fresh playing state", () => {
@@ -204,7 +210,7 @@ describe("step", () => {
   ])("%s", (_, targetRow, velocityY) => {
     const targetCol = 2;
     const base = createPlayingState();
-    const next = step(
+    const next = stepWithEvents(
       {
         ...base,
         projectiles: [createShieldProjectile(base, targetRow, targetCol, 1, velocityY)],
@@ -214,9 +220,17 @@ describe("step", () => {
       EMPTY_INPUT
     );
 
-    expect(next.projectiles).toHaveLength(0);
-    expect(getShieldCell(next, 0, targetRow, targetCol).alive).toBe(false);
-    expect(countAliveShieldCells(next)).toBe(countAliveShieldCells(base) - 1);
+    expect(next.events).toEqual([
+      {
+        type: "shieldHit",
+        shieldIndex: 0,
+        row: targetRow,
+        col: targetCol
+      }
+    ]);
+    expect(next.state.projectiles).toHaveLength(0);
+    expect(getShieldCell(next.state, 0, targetRow, targetCol).alive).toBe(false);
+    expect(countAliveShieldCells(next.state)).toBe(countAliveShieldCells(base) - 1);
   });
 
   it("lets a projectile continue through a dead shield-cell gap", () => {
@@ -359,11 +373,12 @@ describe("step", () => {
       nextProjectileId: 2
     };
 
-    const next = step(state, 0, EMPTY_INPUT);
+    const next = stepWithEvents(state, 0, EMPTY_INPUT);
 
-    expect(next.phase).toBe("lifeLost");
-    expect(next.hud.lives).toBe(base.hud.lives - 1);
-    expect(next.projectiles).toHaveLength(0);
+    expect(next.events).toEqual([{ type: "lifeLost" }]);
+    expect(next.state.phase).toBe("lifeLost");
+    expect(next.state.hud.lives).toBe(base.hud.lives - 1);
+    expect(next.state.projectiles).toHaveLength(0);
   });
 
   it("does not lose another life from an overlapping invader projectile during life lost", () => {
@@ -463,10 +478,17 @@ describe("step", () => {
       nextProjectileId: 3
     };
 
-    const next = step(state, 0, EMPTY_INPUT);
+    const next = stepWithEvents(state, 0, EMPTY_INPUT);
 
-    expect(next.invaders).toHaveLength(1);
-    expect(next.projectiles).toHaveLength(1);
+    expect(next.events).toEqual([
+      {
+        type: "invaderHit",
+        invaderId: invaderA?.id ?? 0,
+        points: invaderA?.points ?? 0
+      }
+    ]);
+    expect(next.state.invaders).toHaveLength(1);
+    expect(next.state.projectiles).toHaveLength(1);
   });
 
   it("enters wave clear when the last invader is destroyed", () => {
@@ -490,10 +512,18 @@ describe("step", () => {
       ]
     };
 
-    const next = step(state, 0, EMPTY_INPUT);
+    const next = stepWithEvents(state, 0, EMPTY_INPUT);
 
-    expect(next.phase).toBe("waveClear");
-    expect(next.projectiles).toHaveLength(0);
+    expect(next.events).toEqual([
+      {
+        type: "invaderHit",
+        invaderId: invader?.id ?? 0,
+        points: invader?.points ?? 0
+      },
+      { type: "waveClear" }
+    ]);
+    expect(next.state.phase).toBe("waveClear");
+    expect(next.state.projectiles).toHaveLength(0);
   });
 
   it("starts the next wave from wave clear and preserves score and lives", () => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -6,6 +6,7 @@ import {
   MARCH_FRAME_INTERVAL_MS,
   PLAYER_SHOOT_COOLDOWN_MS,
   RESPAWN_INVULNERABILITY_MS,
+  SHIELD_CELL_COLS,
   createInvaderProjectile,
   createGameState,
   createPlayerProjectile,
@@ -30,39 +31,80 @@ type Rect = {
 
 const PLAYER_SHOOT_FRAME_DURATION_MS = 120;
 
-export function step(state: GameState, dtMs: number, input: Input = EMPTY_INPUT): GameState {
+export type StepEvent =
+  | {
+      type: "playerShot";
+    }
+  | {
+      type: "invaderHit";
+      invaderId: number;
+      points: number;
+    }
+  | {
+      type: "shieldHit";
+      shieldIndex: number;
+      row: number;
+      col: number;
+    }
+  | {
+      type: "lifeLost";
+    }
+  | {
+      type: "waveClear";
+    };
+
+export type StepResult = GameState & {
+  state: GameState;
+  events: StepEvent[];
+};
+
+export function step(
+  inputState: GameState | StepResult,
+  dtMs: number,
+  input: Input = EMPTY_INPUT
+): StepResult {
+  const state = isStepResult(inputState) ? inputState.state : inputState;
   const dt = Math.max(0, dtMs);
+  const events: StepEvent[] = [];
 
   switch (state.phase) {
     case "start":
-      return input.firePressed
-        ? createGameState({ phase: "playing" })
-        : advanceFrame(state);
+      return createStepResult(
+        input.firePressed
+          ? createGameState({ phase: "playing" })
+          : advanceFrame(state)
+      );
     case "waveClear":
-      return input.firePressed
-        ? createGameState({
-            phase: "playing",
-            wave: state.hud.wave + 1,
-            score: state.hud.score,
-            lives: state.hud.lives,
-            elapsedMs: state.elapsedMs
-          })
-        : advanceFrame(state);
+      return createStepResult(
+        input.firePressed
+          ? createGameState({
+              phase: "playing",
+              wave: state.hud.wave + 1,
+              score: state.hud.score,
+              lives: state.hud.lives,
+              elapsedMs: state.elapsedMs
+            })
+          : advanceFrame(state)
+      );
     case "gameOver":
-      return input.firePressed
-        ? createGameState({ phase: "playing" })
-        : advanceFrame(state);
+      return createStepResult(
+        input.firePressed
+          ? createGameState({ phase: "playing" })
+          : advanceFrame(state)
+      );
     case "paused":
-      return input.pausePressed
-        ? {
-            ...state,
-            phase: "playing"
-          }
-        : state;
+      return createStepResult(
+        input.pausePressed
+          ? {
+              ...state,
+              phase: "playing"
+            }
+          : state
+      );
     case "lifeLost":
-      return advanceLifeLost(state, dt);
+      return createStepResult(advanceLifeLost(state, dt, events), events);
     case "playing":
-      return advancePlaying(state, dt, input);
+      return createStepResult(advancePlaying(state, dt, input, events), events);
   }
 }
 
@@ -73,13 +115,18 @@ function advanceFrame(state: GameState): GameState {
   };
 }
 
-function advanceLifeLost(state: GameState, dtMs: number): GameState {
+function advanceLifeLost(
+  state: GameState,
+  dtMs: number,
+  events: StepEvent[]
+): GameState {
   const simulatedDtMs = Math.min(dtMs, state.transitionTimerMs);
   const projectileShieldBundle = moveProjectilesThroughShields(
     state.projectiles,
     simulatedDtMs / 1000,
     state.arena.floorY,
-    state.shields
+    state.shields,
+    events
   );
   const invaderFireCooldownMs = Math.max(
     0,
@@ -140,7 +187,12 @@ function advanceLifeLost(state: GameState, dtMs: number): GameState {
   };
 }
 
-function advancePlaying(state: GameState, dtMs: number, input: Input): GameState {
+function advancePlaying(
+  state: GameState,
+  dtMs: number,
+  input: Input,
+  events: StepEvent[]
+): GameState {
   if (input.pausePressed) {
     return {
       ...state,
@@ -172,19 +224,22 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     movedPlayer,
     input.firePressed,
     playerShootFrame,
-    invaderFireCooldownMs
+    invaderFireCooldownMs,
+    events
   );
   const projectileShieldBundle = moveProjectilesThroughShields(
     projectileBundle.projectiles,
     dtSeconds,
     state.arena.floorY,
-    state.shields
+    state.shields,
+    events
   );
   const formationBundle = moveInvaders(state, dtSeconds);
   const marchAnimation = advanceMarchAnimation(state, dtMs);
   const collisionBundle = resolveProjectileHits(
     projectileShieldBundle.projectiles,
-    formationBundle.invaders
+    formationBundle.invaders,
+    events
   );
   const score = state.hud.score + collisionBundle.scoreDelta;
   const playerIsInvulnerable =
@@ -207,6 +262,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
     (playerHitProjectile !== undefined ||
       hasInvaderBreached(collisionBundle.invaders, movedPlayer))
   ) {
+    events.push({ type: "lifeLost" });
     return {
       ...state,
       phase: "lifeLost",
@@ -235,6 +291,7 @@ function advancePlaying(state: GameState, dtMs: number, input: Input): GameState
   }
 
   if (collisionBundle.invaders.length === 0) {
+    events.push({ type: "waveClear" });
     return {
       ...state,
       phase: "waveClear",
@@ -291,7 +348,8 @@ function maybeSpawnProjectiles(
   player: GameState["player"],
   firePressed: boolean,
   playerShootFrame: number,
-  invaderFireCooldownMs: number
+  invaderFireCooldownMs: number,
+  events: StepEvent[]
 ): {
   nextProjectileId: number;
   invaderFireCooldownMs: number;
@@ -320,6 +378,7 @@ function maybeSpawnProjectiles(
     nextProjectileId += 1;
     nextPlayerShootCooldownMs = PLAYER_SHOOT_COOLDOWN_MS;
     nextPlayerShootFrame = PLAYER_SHOOT_FRAME_DURATION_MS;
+    events.push({ type: "playerShot" });
   }
 
   if (nextInvaderFireCooldownMs <= 0) {
@@ -361,7 +420,8 @@ function moveProjectilesThroughShields(
   projectiles: Projectile[],
   dtSeconds: number,
   arenaFloorY: number,
-  shields: Shield[]
+  shields: Shield[],
+  events: StepEvent[]
 ): {
   projectiles: Projectile[];
   shields: Shield[];
@@ -392,6 +452,12 @@ function moveProjectilesThroughShields(
               )
             }
       );
+      events.push({
+        type: "shieldHit",
+        shieldIndex: collision.shieldIndex,
+        row: collision.row,
+        col: collision.col
+      });
       continue;
     }
 
@@ -502,7 +568,8 @@ function getMarchFrameIntervalMs(
 
 function resolveProjectileHits(
   projectiles: Projectile[],
-  invaders: Invader[]
+  invaders: Invader[],
+  events: StepEvent[]
 ): {
   invaders: Invader[];
   projectiles: Projectile[];
@@ -524,6 +591,11 @@ function resolveProjectileHits(
       if (intersects(invader, projectile)) {
         consumedProjectileIds.add(projectile.id);
         scoreDelta += invader.points;
+        events.push({
+          type: "invaderHit",
+          invaderId: invader.id,
+          points: invader.points
+        });
         hit = true;
         break;
       }
@@ -549,7 +621,10 @@ function findShieldCollision(
 ):
   | {
       shieldId: number;
+      shieldIndex: number;
       cellId: number;
+      row: number;
+      col: number;
     }
   | undefined {
   const path = getProjectilePath(projectile, movedProjectile);
@@ -557,13 +632,16 @@ function findShieldCollision(
   let collision:
     | {
         shieldId: number;
+        shieldIndex: number;
         cellId: number;
+        row: number;
+        col: number;
         edge: number;
       }
     | undefined;
 
-  for (const shield of shields) {
-    for (const cell of shield.cells) {
+  for (const [shieldIndex, shield] of shields.entries()) {
+    for (const [cellIndex, cell] of shield.cells.entries()) {
       if (!cell.alive || !intersects(cell, path)) {
         continue;
       }
@@ -576,7 +654,10 @@ function findShieldCollision(
       ) {
         collision = {
           shieldId: shield.id,
+          shieldIndex,
           cellId: cell.id,
+          row: Math.floor(cellIndex / SHIELD_CELL_COLS),
+          col: cellIndex % SHIELD_CELL_COLS,
           edge
         };
       }
@@ -585,7 +666,13 @@ function findShieldCollision(
 
   return collision === undefined
     ? undefined
-    : { shieldId: collision.shieldId, cellId: collision.cellId };
+    : {
+        shieldId: collision.shieldId,
+        shieldIndex: collision.shieldIndex,
+        cellId: collision.cellId,
+        row: collision.row,
+        col: collision.col
+      };
 }
 
 function getProjectilePath(
@@ -637,4 +724,19 @@ function clamp(value: number, min: number, max: number): number {
 
 function toggleMarchFrame(marchFrame: GameState["marchFrame"]): GameState["marchFrame"] {
   return marchFrame === 0 ? 1 : 0;
+}
+
+function createStepResult(
+  state: GameState,
+  events: StepEvent[] = []
+): StepResult {
+  return {
+    ...state,
+    state,
+    events
+  };
+}
+
+function isStepResult(state: GameState | StepResult): state is StepResult {
+  return "state" in state && "events" in state;
 }


### PR DESCRIPTION
## Emit typed gameplay events from step() return value

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #273

### Changes
Change step() so its return value includes a typed event stream alongside the next GameState, removing the need for consumers to diff whole states. Define a `StepEvent` discriminated union in src/game/step.ts (or re-export the existing one if the events module task has landed) covering at minimum: `playerShot`, `invaderHit` (with invader id and points), `shieldHit` (with shield/cell coords), `lifeLost`, and `waveClear`. Update step()'s signature to `step(state, dtMs, input?) => { state: GameState, events: StepEvent[] }`, and push events at the precise points in the existing branches (player shoot spawn, projectile-vs-invader collision, projectile-vs-shield collision, phase transitions into lifeLost and waveClear). Keep the simulation pure — events are data, not callbacks. Update src/game/step.test.ts so existing cases read `.state` from the new return shape, and add focused assertions that the right events fire for: firing a player projectile, destroying an invader (including the points), a projectile chewing a shield cell, losing a life, and clearing a wave. Do NOT modify src/audio/events.ts, src/audio/events.test.ts, src/main.ts, src/game/events.ts, or src/game/events.test.ts in this task — those belong to the separate 'Introduce typed game events module' task, which will consume this new return shape. If that task lands first and already defines a shared GameEvent union, import from it rather than duplicating.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*