### PR TITLE
feature: Add shared control bindings + overlay prompts module

### DIFF
--- a/src/input/bindings.test.ts
+++ b/src/input/bindings.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTROL_BINDINGS,
+  CONTROL_FOOTER,
+  OVERLAY_PROMPTS
+} from "./bindings";
+
+describe("CONTROL_BINDINGS", () => {
+  it("defines non-empty codes and labels for every action", () => {
+    for (const binding of Object.values(CONTROL_BINDINGS)) {
+      expect(binding.code).not.toHaveLength(0);
+      expect(binding.label).not.toHaveLength(0);
+    }
+  });
+
+  it("uses Enter as the restart binding contract", () => {
+    expect(CONTROL_BINDINGS.restart.code).toBe("Enter");
+  });
+});
+
+describe("OVERLAY_PROMPTS", () => {
+  it("exports the expected gameplay prompts", () => {
+    expect(OVERLAY_PROMPTS.start).toBe("Press Space to Start");
+    expect(OVERLAY_PROMPTS.pause).toBe("Press P to Resume");
+    expect(OVERLAY_PROMPTS.waveClear).toBe("Press Space to Continue");
+  });
+
+  it("uses Enter for the game-over restart prompt", () => {
+    expect(OVERLAY_PROMPTS.gameOver).toContain("Enter");
+    expect(OVERLAY_PROMPTS.gameOver).not.toContain("Space");
+  });
+});
+
+describe("CONTROL_FOOTER", () => {
+  it("mentions Enter for restart instructions", () => {
+    expect(CONTROL_FOOTER).toContain("Enter");
+  });
+});

--- a/src/input/bindings.ts
+++ b/src/input/bindings.ts
@@ -1,0 +1,35 @@
+export type ControlAction =
+  | "moveLeft"
+  | "moveRight"
+  | "fire"
+  | "pause"
+  | "mute"
+  | "restart";
+
+type ControlBinding = Readonly<{
+  code: string;
+  label: string;
+}>;
+
+export const CONTROL_BINDINGS = {
+  moveLeft: { code: "ArrowLeft", label: "Left" },
+  moveRight: { code: "ArrowRight", label: "Right" },
+  fire: { code: "Space", label: "Space" },
+  pause: { code: "KeyP", label: "P" },
+  mute: { code: "KeyM", label: "M" },
+  restart: { code: "Enter", label: "Enter" }
+} as const satisfies Record<ControlAction, ControlBinding>;
+
+export type OverlayPrompt = "start" | "pause" | "waveClear" | "gameOver";
+
+export const OVERLAY_PROMPTS = {
+  start: `Press ${CONTROL_BINDINGS.fire.label} to Start`,
+  pause: `Press ${CONTROL_BINDINGS.pause.label} to Resume`,
+  waveClear: `Press ${CONTROL_BINDINGS.fire.label} to Continue`,
+  gameOver: `Press ${CONTROL_BINDINGS.restart.label} to Restart`
+} as const satisfies Record<OverlayPrompt, string>;
+
+const MOVE_LABEL = `${CONTROL_BINDINGS.moveLeft.label}/${CONTROL_BINDINGS.moveRight.label}` as const;
+
+export const CONTROL_FOOTER =
+  `Controls: ${MOVE_LABEL} move  |  ${CONTROL_BINDINGS.fire.label} fires  |  ${CONTROL_BINDINGS.pause.label} pauses  |  ${CONTROL_BINDINGS.mute.label} mutes  |  ${CONTROL_BINDINGS.restart.label} restarts` as const;

--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createPlayingState } from "../game/state";
+import { createGameState, createPlayingState } from "../game/state";
+import { CONTROL_FOOTER, OVERLAY_PROMPTS } from "../input/bindings";
 import { createCanvasRenderer } from "./canvas";
 import { PLAYER_SHIP_DESCRIPTOR } from "./sprites";
 
@@ -378,5 +379,54 @@ describe("createCanvasRenderer", () => {
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeUndefined();
     expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
+  });
+
+  it("renders the shared control footer", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(
+      context.fillTextCalls.some((call) => call.text === CONTROL_FOOTER)
+    ).toBe(true);
+  });
+
+  it("renders the shared game-over prompt", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createGameState({ phase: "gameOver", score: 440, wave: 3 }),
+      invaders: [],
+      projectiles: []
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(
+      context.fillTextCalls.some((call) => call.text === OVERLAY_PROMPTS.gameOver)
+    ).toBe(true);
+    expect(
+      context.fillTextCalls.some((call) => call.text === "Press Space to Restart")
+    ).toBe(false);
   });
 });

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -1,4 +1,5 @@
 import type { GameState, Invader, Projectile } from "../game/state";
+import { CONTROL_FOOTER, OVERLAY_PROMPTS } from "../input/bindings";
 import {
   getSprite,
   type PreparedSprite
@@ -134,7 +135,7 @@ function drawScene(
         state,
         "Space Invaders MVP",
         "Arrow keys move  |  Space fires  |  P pauses",
-        "Press Space to Start"
+        OVERLAY_PROMPTS.start
       );
       break;
     case "paused":
@@ -143,7 +144,7 @@ function drawScene(
         state,
         "Paused",
         "Simulation is frozen",
-        "Press P to Resume"
+        OVERLAY_PROMPTS.pause
       );
       break;
     case "waveClear":
@@ -152,7 +153,7 @@ function drawScene(
         state,
         "Wave Clear",
         `Score ${padScore(state.hud.score)}  |  Lives ${state.hud.lives}`,
-        "Press Space for Next Wave"
+        OVERLAY_PROMPTS.waveClear
       );
       break;
     case "gameOver":
@@ -161,7 +162,7 @@ function drawScene(
         state,
         "Game Over",
         `Final Score ${padScore(state.hud.score)}  |  Wave ${state.hud.wave}`,
-        "Press Space to Restart"
+        OVERLAY_PROMPTS.gameOver
       );
       break;
     case "lifeLost":
@@ -358,11 +359,7 @@ function drawControlHints(
 ): void {
   context.font = '500 14px "Arial Narrow", "Avenir Next Condensed", sans-serif';
   context.fillStyle = "rgba(215, 239, 255, 0.64)";
-  context.fillText(
-    "Controls: Arrow keys move  |  Space fires / confirms  |  P pauses",
-    44,
-    state.arena.height - 24
-  );
+  context.fillText(CONTROL_FOOTER, 44, state.arena.height - 24);
 }
 
 function drawMutedBadge(


### PR DESCRIPTION
## Add shared control bindings + overlay prompts module

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #275

### Changes
Create `src/input/bindings.ts` as the single source of truth for gameplay key bindings and overlay prompt text. Export a typed `CONTROL_BINDINGS` map keyed by action name (`moveLeft`, `moveRight`, `fire`, `pause`, `mute`, `restart`) where each entry has a `code` and human-readable `label`; include `restart.code === "Enter"` as the restart binding contract even though keyboard wiring is handled by a separate task. Export `OVERLAY_PROMPTS` for `start`, `pause`, `waveClear`, and `gameOver`; `gameOver` must read `Press Enter to Restart`, `start` reads `Press Space to Start`, `pause` reads `Press P to Resume`, and `waveClear` reads `Press Space to Continue`. Export `CONTROL_FOOTER` that describes the mapped controls and mentions Enter for restart, replacing any `Space fires / confirms` phrasing. Use `as const` so labels are string literal types. Add `src/input/bindings.test.ts` asserting non-empty codes/labels, restart code equals Enter, the game-over prompt includes Enter and not Space, and the footer mentions Enter. Also update `src/render/canvas.ts` to import and consume `OVERLAY_PROMPTS`/`CONTROL_FOOTER` for the actual overlay/footer rendering; update canvas tests only if existing string expectations need to change. Do NOT modify `src/input/keyboard.ts` in this task.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*