### PR TITLE
feature: Persist high score on score change events in runtime

### DIFF
--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -53,6 +53,25 @@ class FakeMuteStore {
   }
 }
 
+class FakeHighScoreWriter {
+  private highScore: number;
+
+  public readonly writeCalls: number[] = [];
+
+  constructor(initialHighScore = 0) {
+    this.highScore = initialHighScore;
+  }
+
+  readHighScore(): number {
+    return this.highScore;
+  }
+
+  writeHighScore(score: number): void {
+    this.writeCalls.push(score);
+    this.highScore = Math.max(this.highScore, score);
+  }
+}
+
 type RuntimeHarness = {
   queueInput: (input?: Partial<Input>) => void;
   runtime: GameRuntime;
@@ -76,16 +95,15 @@ type RuntimeHarnessOptions = {
 function createHarness(options: RuntimeHarnessOptions = {}): RuntimeHarness {
   const sfxController = new FakeSfxController();
   const muteStore = new FakeMuteStore(options.initialMuted);
+  const highScoreWriter = new FakeHighScoreWriter(options.initialHighScore);
   const stepCalls: Array<{ dtMs: number; input: Input }> = [];
-  const writeHighScoreCalls: number[] = [];
-  let highScore = options.initialHighScore ?? 0;
   let queuedInput = createInput();
 
   const runtime = createGameRuntime({
     deriveSfxEvents: options.deriveEvents ?? (() => []),
     initialState: options.initialState ?? createInitialGameState(),
     muteStore,
-    readHighScore: () => highScore,
+    readHighScore: () => highScoreWriter.readHighScore(),
     readInput: () => {
       const snapshot = queuedInput;
       queuedInput = createInput();
@@ -97,10 +115,7 @@ function createHarness(options: RuntimeHarnessOptions = {}): RuntimeHarness {
 
       return options.step === undefined ? state : options.step(state, dtMs, input);
     },
-    writeHighScore: (score) => {
-      writeHighScoreCalls.push(score);
-      highScore = score;
-    }
+    writeHighScore: (score) => highScoreWriter.writeHighScore(score)
   });
 
   return {
@@ -110,7 +125,7 @@ function createHarness(options: RuntimeHarnessOptions = {}): RuntimeHarness {
     runtime,
     sfxController,
     stepCalls,
-    writeHighScoreCalls,
+    writeHighScoreCalls: highScoreWriter.writeCalls,
     muteStore
   };
 }
@@ -159,32 +174,91 @@ describe("createGameRuntime", () => {
     expect(harness.sfxController.setMutedCalls).toEqual([false, true]);
   });
 
-  it("records the max of the stored and final score once per game-over transition", () => {
-    const finalScore = 220;
-    const storedHighScore = 260;
+  it("writes the updated score each time play increases it", () => {
+    let stepIndex = 0;
     const harness = createHarness({
-      initialHighScore: storedHighScore,
-      initialState: createPlayingState(),
-      step: (state) =>
-        state.phase === "playing"
-          ? {
-              ...state,
-              phase: "gameOver",
-              hud: {
-                ...state.hud,
-                score: finalScore
-              }
-            }
-          : {
-              ...state,
-              frame: state.frame + 1
-            }
+      initialHighScore: 260,
+      initialState: createPlayingState({ score: 200 }),
+      step: (state) => {
+        stepIndex += 1;
+
+        return {
+          ...state,
+          frame: state.frame + 1,
+          hud: {
+            ...state.hud,
+            score: stepIndex === 1 ? 220 : 250
+          }
+        };
+      }
     });
 
     harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
     harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
 
-    expect(harness.writeHighScoreCalls).toEqual([storedHighScore]);
+    expect(harness.writeHighScoreCalls).toEqual([220, 250]);
+  });
+
+  it("does not write when the score is unchanged", () => {
+    const harness = createHarness({
+      initialState: createPlayingState({ score: 120 }),
+      step: (state) => ({
+        ...state,
+        frame: state.frame + 1
+      })
+    });
+
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+
+    expect(harness.writeHighScoreCalls).toEqual([]);
+  });
+
+  it("does not write for non-score events such as shooting or mute toggles", () => {
+    const initialState = createPlayingState({ score: 90 });
+    const harness = createHarness({
+      initialState,
+      step: () => withPlayerProjectileCount(initialState, 1)
+    });
+
+    harness.queueInput({ firePressed: true, mutePressed: true });
+    harness.runtime.onRender();
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+
+    expect(harness.muteStore.isMuted()).toBe(true);
+    expect(harness.writeHighScoreCalls).toEqual([]);
+  });
+
+  it("does not duplicate a write at the game-over boundary when score is unchanged", () => {
+    let stepIndex = 0;
+    const harness = createHarness({
+      initialState: createPlayingState({ score: 100 }),
+      step: (state) => {
+        stepIndex += 1;
+
+        if (stepIndex === 1) {
+          return {
+            ...state,
+            frame: state.frame + 1,
+            phase: "lifeLost",
+            hud: {
+              ...state.hud,
+              score: 150
+            }
+          };
+        }
+
+        return {
+          ...state,
+          frame: state.frame + 1,
+          phase: "gameOver"
+        };
+      }
+    });
+
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+
+    expect(harness.writeHighScoreCalls).toEqual([150]);
   });
 
   it("dispatches each derived event once across multiple fixed sub-steps in a frame", () => {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -73,7 +73,7 @@ export function createGameRuntime({
       const stepInput = firstStepOfFrame ? frameInput : clearEdgeInput(frameInput);
 
       state = step(state, dtMs, stepInput);
-      maybeRecordHighScore(previousState, state, readHighScore, writeHighScore);
+      maybeRecordHighScore(previousState, state, writeHighScore);
 
       for (const event of deriveSfxEvents(previousState, state)) {
         sfxController.play(event);
@@ -108,12 +108,11 @@ function hasObservedUserInput(input: Input): boolean {
 function maybeRecordHighScore(
   previousState: GameState,
   nextState: GameState,
-  readHighScore: () => number,
   writeHighScore: (score: number) => void
 ): void {
-  if (previousState.phase === "gameOver" || nextState.phase !== "gameOver") {
+  if (nextState.hud.score <= previousState.hud.score) {
     return;
   }
 
-  writeHighScore(Math.max(readHighScore(), nextState.hud.score));
+  writeHighScore(nextState.hud.score);
 }


### PR DESCRIPTION
## Persist high score on score change events in runtime

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #388

### Changes
Today `src/runtime.ts` only writes a high score on the `gameOver` transition, but `src/main.ts` already calls the high-score writer on every score-increase `GameEvent`. That divergence is the blocker called out in the proposal rationale and must be closed before main.ts can safely become a thin shell over `createGameRuntime`. Update `createGameRuntime` so that whenever stepping the simulation produces a score-increase game event (use the same `GameEvent` channel main.ts uses, or an equivalent score-delta check on the previous vs. next state), the runtime invokes the injected high-score writer with the new score. Preserve any existing gameOver write only if it is still required to avoid a regression; otherwise rely on the score-change path so we do not double-write. Extend `src/runtime.test.ts` with a fake high-score writer that records calls, and assert: (1) score increases during play trigger writes with the correct values, (2) writes do not happen when the score is unchanged, (3) writes do not happen on non-score events (e.g. shoot, mute toggle), and (4) there is no duplicate write at the gameOver boundary if the score did not change there. Keep the public `GameRuntime` shape backwards compatible for the in-flight main.ts refactor task.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*