### PR TITLE
bug_fix: Spawn invader shots from post-collision formation state

### DIFF
--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -337,6 +337,105 @@ describe("step", () => {
     expect(step(almost, 1, EMPTY_INPUT).projectiles.some((projectile) => projectile.owner === "invader")).toBe(true);
   });
 
+  it("does not let an invader killed by the player in the same frame fire", () => {
+    const base = createPlayingState();
+    const invader = base.invaders.find(
+      (candidate) => candidate.col === 0 && candidate.row === INVADER_ROWS - 1
+    );
+    expect(invader).toBeDefined();
+    const state = {
+      ...base,
+      invaders: invader === undefined ? [] : [invader],
+      projectiles: [
+        {
+          id: 1,
+          owner: "player" as const,
+          x: invader?.x ?? 0,
+          y: invader?.y ?? 0,
+          width: invader?.width ?? 0,
+          height: invader?.height ?? 0,
+          velocityY: 0,
+          active: true
+        }
+      ],
+      nextProjectileId: 2,
+      invaderFireCooldownMs: 0
+    };
+
+    const next = stepWithEvents(state, 0, EMPTY_INPUT);
+
+    expect(next.events).toEqual([
+      {
+        type: "invaderHit",
+        invaderId: invader?.id ?? 0,
+        points: invader?.points ?? 0
+      },
+      { type: "waveClear" }
+    ]);
+    expect(next.state.phase).toBe("waveClear");
+    expect(next.state.projectiles).toHaveLength(0);
+    expect(next.state.invaderFireCooldownMs).toBe(0);
+    expect(next.state.invaderFireCooldownMs).not.toBe(INVADER_FIRE_INTERVAL_MS);
+  });
+
+  it("spawns invader projectiles from the firing invader's post-march position", () => {
+    const base = createPlayingState();
+    const invader = base.invaders[0];
+    expect(invader).toBeDefined();
+    const state = {
+      ...base,
+      invaders: invader === undefined ? [] : [invader],
+      invaderFireCooldownMs: 0
+    };
+    const dtMs = 100;
+    const next = step(state, dtMs, EMPTY_INPUT);
+    const projectile = next.projectiles.find(
+      (candidate) => candidate.owner === "invader"
+    );
+    const movedInvader = next.invaders[0];
+
+    expect(projectile).toBeDefined();
+    expect(movedInvader).toBeDefined();
+    expect(next.invaderFireCooldownMs).toBe(INVADER_FIRE_INTERVAL_MS);
+    expect(projectile?.x).toBe(
+      (movedInvader?.x ?? 0) +
+        (movedInvader?.width ?? 0) / 2 -
+        INVADER_PROJECTILE_WIDTH / 2
+    );
+    expect(projectile?.y).toBe(
+      (movedInvader?.y ?? 0) +
+        (movedInvader?.height ?? 0) +
+        (INVADER_PROJECTILE_SPEED * dtMs) / 1000
+    );
+  });
+
+  it("moves and collides a newly spawned invader projectile in the same tick", () => {
+    const base = createPlayingState();
+    const invader = base.invaders[0];
+    expect(invader).toBeDefined();
+    const state = {
+      ...base,
+      invaders:
+        invader === undefined
+          ? []
+          : [
+              {
+                ...invader,
+                x: base.player.x + (base.player.width - invader.width) / 2,
+                y: base.player.y - invader.height - INVADER_PROJECTILE_HEIGHT
+              }
+            ],
+      invaderFireCooldownMs: 0
+    };
+
+    const next = stepWithEvents(state, 16, EMPTY_INPUT);
+
+    expect(next.events).toEqual([{ type: "lifeLost" }]);
+    expect(next.state.phase).toBe("lifeLost");
+    expect(next.state.hud.lives).toBe(base.hud.lives - 1);
+    expect(next.state.projectiles).toHaveLength(0);
+  });
+
   it.each(["start", "waveClear", "gameOver", "paused"] as const)(
     "does not spawn invader projectiles while %s",
     (phase) => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -219,12 +219,11 @@ function advancePlaying(
     shootCooldownMs: cooldown
   };
 
-  const projectileBundle = maybeSpawnProjectiles(
+  const projectileBundle = maybeSpawnPlayerProjectile(
     state,
     movedPlayer,
     input.firePressed,
     playerShootFrame,
-    invaderFireCooldownMs,
     events
   );
   const projectileShieldBundle = moveProjectilesThroughShields(
@@ -241,19 +240,44 @@ function advancePlaying(
     formationBundle.invaders,
     events
   );
+  const invaderProjectileBundle = maybeSpawnInvaderProjectile(
+    state,
+    collisionBundle.invaders,
+    projectileBundle.nextProjectileId,
+    invaderFireCooldownMs
+  );
+  let remainingActiveProjectiles = collisionBundle.projectiles;
+  let resolvedShields = projectileShieldBundle.shields;
+
+  if (invaderProjectileBundle.projectile !== undefined) {
+    const spawnedInvaderProjectileShieldBundle = moveProjectilesThroughShields(
+      [invaderProjectileBundle.projectile],
+      dtSeconds,
+      state.arena.floorY,
+      resolvedShields,
+      events
+    );
+
+    remainingActiveProjectiles = [
+      ...remainingActiveProjectiles,
+      ...spawnedInvaderProjectileShieldBundle.projectiles
+    ];
+    resolvedShields = spawnedInvaderProjectileShieldBundle.shields;
+  }
+
   const score = state.hud.score + collisionBundle.scoreDelta;
   const playerIsInvulnerable =
     movedPlayer.invulnerableUntilMs > nextElapsedMs;
   const playerHitProjectile = playerIsInvulnerable
     ? undefined
-    : collisionBundle.projectiles.find(
+    : remainingActiveProjectiles.find(
         (projectile) =>
           projectile.owner === "invader" && intersects(projectile, movedPlayer)
       );
   const remainingProjectiles =
     playerHitProjectile === undefined
-      ? collisionBundle.projectiles
-      : collisionBundle.projectiles.filter(
+      ? remainingActiveProjectiles
+      : remainingActiveProjectiles.filter(
           (projectile) => projectile.id !== playerHitProjectile.id
         );
 
@@ -274,7 +298,7 @@ function advancePlaying(
         shootCooldownMs: 0
       },
       projectiles: remainingProjectiles,
-      shields: projectileShieldBundle.shields,
+      shields: resolvedShields,
       invaders: collisionBundle.invaders,
       formation: formationBundle.formation,
       hud: {
@@ -282,10 +306,10 @@ function advancePlaying(
         score,
         lives: Math.max(0, state.hud.lives - 1)
       },
-      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+      invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
       transitionTimerMs: LIFE_LOST_DURATION_MS,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId,
+      nextProjectileId: invaderProjectileBundle.nextProjectileId,
       elapsedMs: nextElapsedMs
     };
   }
@@ -303,17 +327,17 @@ function advancePlaying(
         shootCooldownMs: projectileBundle.playerShootCooldownMs
       },
       projectiles: [],
-      shields: projectileShieldBundle.shields,
+      shields: resolvedShields,
       invaders: [],
       formation: formationBundle.formation,
       hud: {
         ...state.hud,
         score
       },
-      invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+      invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
       transitionTimerMs: 0,
       frame: nextFrame,
-      nextProjectileId: projectileBundle.nextProjectileId,
+      nextProjectileId: invaderProjectileBundle.nextProjectileId,
       elapsedMs: nextElapsedMs
     };
   }
@@ -327,8 +351,8 @@ function advancePlaying(
       ...movedPlayer,
       shootCooldownMs: projectileBundle.playerShootCooldownMs
     },
-    projectiles: collisionBundle.projectiles,
-    shields: projectileShieldBundle.shields,
+    projectiles: remainingProjectiles,
+    shields: resolvedShields,
     invaders: collisionBundle.invaders,
     formation: formationBundle.formation,
     hud: {
@@ -336,23 +360,21 @@ function advancePlaying(
       score
     },
     frame: nextFrame,
-    invaderFireCooldownMs: projectileBundle.invaderFireCooldownMs,
+    invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
     transitionTimerMs: 0,
-    nextProjectileId: projectileBundle.nextProjectileId,
+    nextProjectileId: invaderProjectileBundle.nextProjectileId,
     elapsedMs: nextElapsedMs
   };
 }
 
-function maybeSpawnProjectiles(
+function maybeSpawnPlayerProjectile(
   state: GameState,
   player: GameState["player"],
   firePressed: boolean,
   playerShootFrame: number,
-  invaderFireCooldownMs: number,
   events: StepEvent[]
 ): {
   nextProjectileId: number;
-  invaderFireCooldownMs: number;
   playerShootCooldownMs: number;
   playerShootFrame: number;
   projectiles: Projectile[];
@@ -361,8 +383,6 @@ function maybeSpawnProjectiles(
   let nextPlayerShootCooldownMs = player.shootCooldownMs;
   let nextPlayerShootFrame = playerShootFrame;
   let nextProjectiles = state.projectiles;
-  let nextInvaderFireCooldownMs = invaderFireCooldownMs;
-  let firingInvader: Invader | undefined;
 
   if (firePressed && player.shootCooldownMs <= 0) {
     const playerProjectile = createPlayerProjectile(
@@ -381,38 +401,52 @@ function maybeSpawnProjectiles(
     events.push({ type: "playerShot" });
   }
 
-  if (nextInvaderFireCooldownMs <= 0) {
-    for (const invader of state.invaders) {
-      if (
-        firingInvader === undefined ||
-        invader.col < firingInvader.col ||
-        (invader.col === firingInvader.col && invader.row > firingInvader.row)
-      ) {
-        firingInvader = invader;
-      }
-    }
-
-    if (firingInvader !== undefined) {
-      const invaderProjectile = createInvaderProjectile(
-        {
-          ...state,
-          nextProjectileId
-        },
-        firingInvader
-      );
-
-      nextProjectiles = [...nextProjectiles, invaderProjectile];
-      nextProjectileId += 1;
-      nextInvaderFireCooldownMs = INVADER_FIRE_INTERVAL_MS;
-    }
-  }
-
   return {
     nextProjectileId,
-    invaderFireCooldownMs: nextInvaderFireCooldownMs,
     playerShootCooldownMs: nextPlayerShootCooldownMs,
     playerShootFrame: nextPlayerShootFrame,
     projectiles: nextProjectiles
+  };
+}
+
+function maybeSpawnInvaderProjectile(
+  state: GameState,
+  invaders: Invader[],
+  nextProjectileId: number,
+  invaderFireCooldownMs: number
+): {
+  nextProjectileId: number;
+  invaderFireCooldownMs: number;
+  projectile: Projectile | undefined;
+} {
+  if (invaderFireCooldownMs > 0) {
+    return {
+      nextProjectileId,
+      invaderFireCooldownMs,
+      projectile: undefined
+    };
+  }
+
+  const firingInvader = selectFiringInvader(invaders);
+
+  if (firingInvader === undefined) {
+    return {
+      nextProjectileId,
+      invaderFireCooldownMs,
+      projectile: undefined
+    };
+  }
+
+  return {
+    nextProjectileId: nextProjectileId + 1,
+    invaderFireCooldownMs: INVADER_FIRE_INTERVAL_MS,
+    projectile: createInvaderProjectile(
+      {
+        ...state,
+        nextProjectileId
+      },
+      firingInvader
+    )
   };
 }
 
@@ -707,6 +741,22 @@ function hasInvaderBreached(invaders: Invader[], player: GameState["player"]): b
   }
 
   return false;
+}
+
+function selectFiringInvader(invaders: Invader[]): Invader | undefined {
+  let firingInvader: Invader | undefined;
+
+  for (const invader of invaders) {
+    if (
+      firingInvader === undefined ||
+      invader.col < firingInvader.col ||
+      (invader.col === firingInvader.col && invader.row > firingInvader.row)
+    ) {
+      firingInvader = invader;
+    }
+  }
+
+  return firingInvader;
 }
 
 function intersects(a: Rect, b: Rect): boolean {


### PR DESCRIPTION
## Spawn invader shots from post-collision formation state

**Category:** `bug_fix` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #281

### Changes
In `src/game/step.ts`, refactor invader projectile spawning so the selected shooter and projectile origin come from the post-move, post-collision invader list rather than stale `state.invaders`. Today the firing path can select an invader that is killed in the same frame and can spawn from a pre-march x/y. Thread the already-computed formation/collision results into the shooter-selection path so only surviving, final-position invaders can fire. Important: preserve the old projectile lifecycle for newly spawned invader shots. The fix must not delay invader projectile movement/collision by one tick; a projectile spawned this frame should still be advanced through the current frame projectile/shield/player collision path just as it was before this bug fix. Add regression tests in `src/game/step.test.ts` that: (1) an invader killed by the player projectile on the same frame cannot spawn an invader projectile; (2) a spawned invader projectile x/y matches the post-march position of its firing invader; and (3) a newly spawned invader projectile still moves/collides during the same tick rather than waiting until the next tick. Use `INVADER_FIRE_INTERVAL_MS` and existing step helpers/factories; do not introduce public constants. Keep scope tight: change only `src/game/step.ts` and `src/game/step.test.ts`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*