### PR TITLE
feature: Extract sprite pixel data into JSON-shaped descriptor modules

### DIFF
--- a/src/render/sprite-data/index.ts
+++ b/src/render/sprite-data/index.ts
@@ -1,0 +1,20 @@
+import type { SpriteDescriptor } from "../sprites";
+import { INVADER_ROW_DESCRIPTORS } from "./invaders";
+import { PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
+import { PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
+
+export { INVADER_ROW_DESCRIPTORS } from "./invaders";
+export { PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
+export { PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
+
+export const SPRITE_DESCRIPTORS = [
+  PLAYER_SHIP_DESCRIPTOR,
+  ...INVADER_ROW_DESCRIPTORS,
+  PLAYER_PROJECTILE_DESCRIPTOR
+] as const satisfies readonly SpriteDescriptor[];
+
+type SpriteDescriptorId = (typeof SPRITE_DESCRIPTORS)[number]["id"];
+
+export const SPRITE_DESCRIPTOR_REGISTRY = Object.fromEntries(
+  SPRITE_DESCRIPTORS.map((descriptor) => [descriptor.id, descriptor] as const)
+) as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>;

--- a/src/render/sprite-data/invaders.ts
+++ b/src/render/sprite-data/invaders.ts
@@ -1,0 +1,77 @@
+import type { SpriteDescriptor } from "../sprites";
+
+const INVADER_SQUID_FRAMES = [
+  [
+    "..xx....xx..", "...xxxxxx...", "..xxxxxxxx..", ".xx.xxxx.xx.",
+    ".xxxxxxxxxx.", "...xx..xx...", "..xx....xx..", ".xx......xx."
+  ],
+  [
+    "..xx....xx..", "...xxxxxx...", "..xxxxxxxx..", ".xx.xxxx.xx.",
+    ".xxxxxxxxxx.", "..xx.xx.xx..", ".xx......xx.", "xx........xx"
+  ]
+] as const;
+
+const INVADER_CRAB_FRAMES = [
+  [
+    "...xx..xx...", "..xxxxxxxx..", ".xxxxxxxxxx.", "xx..xxxx..xx",
+    "xxxxxxxxxxxx", "..xx.xx.xx..", ".xx..xx..xx.", "xx........xx"
+  ],
+  [
+    "...xx..xx...", "..xxxxxxxx..", ".xxxxxxxxxx.", "xx..xxxx..xx",
+    "xxxxxxxxxxxx", "...xx..xx...", "..xx.xx.xx..", ".xx......xx."
+  ]
+] as const;
+
+const INVADER_BOMBER_FRAMES = [
+  [
+    "...xxxxxx...", "..xxxxxxxx..", ".xxxxxxxxxx.", "xxxx.xx.xxxx",
+    "xxxxxxxxxxxx", "..xx.xx.xx..", ".xx......xx.", "xx........xx"
+  ],
+  [
+    "...xxxxxx...", "..xxxxxxxx..", ".xxxxxxxxxx.", "xxxx.xx.xxxx",
+    "xxxxxxxxxxxx", ".xx..xx..xx.", "xx..xx..xx..", "..xx....xx.."
+  ]
+] as const;
+
+export const INVADER_ROW_DESCRIPTORS = [
+  {
+    id: "invader-row-0",
+    frames: INVADER_SQUID_FRAMES,
+    palette: {
+      x: "#8bf3ff"
+    },
+    pixelSize: 4
+  },
+  {
+    id: "invader-row-1",
+    frames: INVADER_CRAB_FRAMES,
+    palette: {
+      x: "#7ad7ff"
+    },
+    pixelSize: 4
+  },
+  {
+    id: "invader-row-2",
+    frames: INVADER_CRAB_FRAMES,
+    palette: {
+      x: "#5fbbff"
+    },
+    pixelSize: 4
+  },
+  {
+    id: "invader-row-3",
+    frames: INVADER_BOMBER_FRAMES,
+    palette: {
+      x: "#62f4c3"
+    },
+    pixelSize: 4
+  },
+  {
+    id: "invader-row-4",
+    frames: INVADER_BOMBER_FRAMES,
+    palette: {
+      x: "#ffe37a"
+    },
+    pixelSize: 4
+  }
+] as const satisfies readonly SpriteDescriptor[];

--- a/src/render/sprite-data/player-ship.ts
+++ b/src/render/sprite-data/player-ship.ts
@@ -1,0 +1,19 @@
+import type { SpriteDescriptor } from "../sprites";
+
+const PLAYER_SHIP_FRAMES = [
+  [
+    ".........c.........", "........ccc........", ".......ccccc.......",
+    "......cccbccc......", ".....ccbbbbbcc.....", "...ccbbbbbbbbbcc...",
+    "..ccbbbbbbbbbbbcc.."
+  ]
+] as const;
+
+export const PLAYER_SHIP_DESCRIPTOR = {
+  id: "player-ship",
+  frames: PLAYER_SHIP_FRAMES,
+  palette: {
+    c: "#d7f4ff",
+    b: "#59d8ff"
+  },
+  pixelSize: 4
+} satisfies SpriteDescriptor;

--- a/src/render/sprite-data/projectiles.ts
+++ b/src/render/sprite-data/projectiles.ts
@@ -1,0 +1,10 @@
+import type { SpriteDescriptor } from "../sprites";
+
+export const PLAYER_PROJECTILE_DESCRIPTOR = {
+  id: "player-projectile",
+  frames: [["p.", "pp", "pp", "pp", "pp", ".p"]],
+  palette: {
+    p: "#f7fbff"
+  },
+  pixelSize: 3
+} satisfies SpriteDescriptor;

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { SPRITE_DESCRIPTOR_REGISTRY } from "./sprite-data";
 import {
+  EMPTY_PIXEL,
   INVADER_ROW_DESCRIPTORS,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
@@ -67,6 +69,15 @@ function expectPreparedSpriteToMatchDescriptor(
   expect(sprite.width).toBe(firstRow.length * pixelSize);
   expect(sprite.height).toBe(firstFrame.length * pixelSize);
   expect(sprite.sheet.getFrameCount()).toBe(sprite.frameCount);
+}
+
+function countFilledPixels(frame: readonly string[]): number {
+  return frame.reduce(
+    (filledPixelCount, row) =>
+      filledPixelCount +
+      [...row].filter((pixelKey) => pixelKey !== EMPTY_PIXEL).length,
+    0
+  );
 }
 
 describe("createSpriteSheet", () => {
@@ -186,6 +197,51 @@ describe("createSpriteSheet", () => {
     const context = new FakeSpriteContext();
 
     expect(() => spriteSheet.drawFrame(context, 99, 0, 0)).toThrow(RangeError);
+  });
+
+  it("creates a sprite sheet from a descriptor looked up by id in the registry", () => {
+    const descriptor = SPRITE_DESCRIPTOR_REGISTRY["player-projectile"]!;
+    const spriteSheet = createSpriteSheet(descriptor);
+    const context = new FakeSpriteContext();
+
+    spriteSheet.drawFrame(context, 0, 3, 5);
+
+    expect(spriteSheet.getFrameCount()).toBe(descriptor.frames.length);
+    expect(context.fillRectCalls).toHaveLength(
+      countFilledPixels(descriptor.frames[0] ?? [])
+    );
+  });
+});
+
+describe("SPRITE_DESCRIPTOR_REGISTRY", () => {
+  it("keeps every registered descriptor geometrically consistent and palette-safe", () => {
+    expect(Object.values(SPRITE_DESCRIPTOR_REGISTRY)).toHaveLength(
+      SPRITE_DESCRIPTORS.length
+    );
+
+    for (const descriptor of Object.values(SPRITE_DESCRIPTOR_REGISTRY)) {
+      const expectedHeight = descriptor.frames[0]?.length ?? 0;
+      const expectedWidth = descriptor.frames[0]?.[0]?.length ?? 0;
+      const allowedPixelKeys = new Set([
+        EMPTY_PIXEL,
+        ...Object.keys(descriptor.palette)
+      ]);
+
+      expect(expectedHeight).toBeGreaterThan(0);
+      expect(expectedWidth).toBeGreaterThan(0);
+
+      for (const frame of descriptor.frames) {
+        expect(frame).toHaveLength(expectedHeight);
+
+        for (const row of frame) {
+          expect(row).toHaveLength(expectedWidth);
+
+          for (const pixelKey of row) {
+            expect(allowedPixelKeys.has(pixelKey)).toBe(true);
+          }
+        }
+      }
+    }
   });
 });
 

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -1,3 +1,9 @@
+import {
+  INVADER_ROW_DESCRIPTORS,
+  PLAYER_SHIP_DESCRIPTOR,
+  SPRITE_DESCRIPTOR_REGISTRY
+} from "./sprite-data";
+
 export type SpriteFrame = readonly string[];
 
 export type SpriteDescriptor = {
@@ -31,134 +37,12 @@ export type PreparedSprite = {
 
 export const EMPTY_PIXEL = ".";
 
-const PLAYER_SHIP_FRAMES: readonly SpriteFrame[] = [
-  [
-    ".........c.........",
-    "........ccc........",
-    ".......ccccc.......",
-    "......cccbccc......",
-    ".....ccbbbbbcc.....",
-    "...ccbbbbbbbbbcc...",
-    "..ccbbbbbbbbbbbcc.."
-  ]
-];
-
-const INVADER_SQUID_FRAMES: readonly SpriteFrame[] = [
-  [
-    "..xx....xx..",
-    "...xxxxxx...",
-    "..xxxxxxxx..",
-    ".xx.xxxx.xx.",
-    ".xxxxxxxxxx.",
-    "...xx..xx...",
-    "..xx....xx..",
-    ".xx......xx."
-  ],
-  [
-    "..xx....xx..",
-    "...xxxxxx...",
-    "..xxxxxxxx..",
-    ".xx.xxxx.xx.",
-    ".xxxxxxxxxx.",
-    "..xx.xx.xx..",
-    ".xx......xx.",
-    "xx........xx"
-  ]
-];
-
-const INVADER_CRAB_FRAMES: readonly SpriteFrame[] = [
-  [
-    "...xx..xx...",
-    "..xxxxxxxx..",
-    ".xxxxxxxxxx.",
-    "xx..xxxx..xx",
-    "xxxxxxxxxxxx",
-    "..xx.xx.xx..",
-    ".xx..xx..xx.",
-    "xx........xx"
-  ],
-  [
-    "...xx..xx...",
-    "..xxxxxxxx..",
-    ".xxxxxxxxxx.",
-    "xx..xxxx..xx",
-    "xxxxxxxxxxxx",
-    "...xx..xx...",
-    "..xx.xx.xx..",
-    ".xx......xx."
-  ]
-];
-
-const INVADER_BOMBER_FRAMES: readonly SpriteFrame[] = [
-  [
-    "...xxxxxx...",
-    "..xxxxxxxx..",
-    ".xxxxxxxxxx.",
-    "xxxx.xx.xxxx",
-    "xxxxxxxxxxxx",
-    "..xx.xx.xx..",
-    ".xx......xx.",
-    "xx........xx"
-  ],
-  [
-    "...xxxxxx...",
-    "..xxxxxxxx..",
-    ".xxxxxxxxxx.",
-    "xxxx.xx.xxxx",
-    "xxxxxxxxxxxx",
-    ".xx..xx..xx.",
-    "xx..xx..xx..",
-    "..xx....xx.."
-  ]
-];
-
-function createInvaderDescriptor(
-  id: string,
-  color: string,
-  frames: readonly SpriteFrame[]
-): SpriteDescriptor {
-  return {
-    id,
-    frames,
-    palette: {
-      x: color
-    },
-    pixelSize: 4
-  };
-}
-
-export const PLAYER_SHIP_DESCRIPTOR = {
-  id: "player-ship",
-  frames: PLAYER_SHIP_FRAMES,
-  palette: {
-    c: "#d7f4ff",
-    b: "#59d8ff"
-  },
-  pixelSize: 4
-} satisfies SpriteDescriptor;
-
-export const INVADER_ROW_DESCRIPTORS = [
-  createInvaderDescriptor("invader-row-0", "#8bf3ff", INVADER_SQUID_FRAMES),
-  createInvaderDescriptor("invader-row-1", "#7ad7ff", INVADER_CRAB_FRAMES),
-  createInvaderDescriptor("invader-row-2", "#5fbbff", INVADER_CRAB_FRAMES),
-  createInvaderDescriptor("invader-row-3", "#62f4c3", INVADER_BOMBER_FRAMES),
-  createInvaderDescriptor("invader-row-4", "#ffe37a", INVADER_BOMBER_FRAMES)
-] as const satisfies readonly SpriteDescriptor[];
-
-export const PLAYER_PROJECTILE_DESCRIPTOR = {
-  id: "player-projectile",
-  frames: [["p.", "pp", "pp", "pp", "pp", ".p"]],
-  palette: {
-    p: "#f7fbff"
-  },
-  pixelSize: 3
-} satisfies SpriteDescriptor;
-
-export const SPRITE_DESCRIPTORS = [
+export {
+  INVADER_ROW_DESCRIPTORS,
+  PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
-  ...INVADER_ROW_DESCRIPTORS,
-  PLAYER_PROJECTILE_DESCRIPTOR
-] as const satisfies readonly SpriteDescriptor[];
+  SPRITE_DESCRIPTORS
+} from "./sprite-data";
 
 const HUD_PLAYER_SHIP_DESCRIPTOR = {
   ...PLAYER_SHIP_DESCRIPTOR,
@@ -166,18 +50,21 @@ const HUD_PLAYER_SHIP_DESCRIPTOR = {
   pixelSize: 2
 } satisfies SpriteDescriptor;
 
-const INVADER_ROW_SPRITES = {
-  "invader-row-0": prepareSprite(INVADER_ROW_DESCRIPTORS[0]),
-  "invader-row-1": prepareSprite(INVADER_ROW_DESCRIPTORS[1]),
-  "invader-row-2": prepareSprite(INVADER_ROW_DESCRIPTORS[2]),
-  "invader-row-3": prepareSprite(INVADER_ROW_DESCRIPTORS[3]),
-  "invader-row-4": prepareSprite(INVADER_ROW_DESCRIPTORS[4])
-} satisfies Record<(typeof INVADER_ROW_DESCRIPTORS)[number]["id"], PreparedSprite>;
+const INVADER_ROW_SPRITES = Object.fromEntries(
+  INVADER_ROW_DESCRIPTORS.map((descriptor) => [
+    descriptor.id,
+    prepareSprite(descriptor)
+  ] as const)
+) as Readonly<
+  Record<(typeof INVADER_ROW_DESCRIPTORS)[number]["id"], PreparedSprite>
+>;
 
 const SPRITE_REGISTRY = {
-  "player-ship": prepareSprite(PLAYER_SHIP_DESCRIPTOR),
+  "player-ship": prepareSprite(SPRITE_DESCRIPTOR_REGISTRY["player-ship"]!),
   "hud-player-ship": prepareSprite(HUD_PLAYER_SHIP_DESCRIPTOR),
-  "player-projectile": prepareSprite(PLAYER_PROJECTILE_DESCRIPTOR),
+  "player-projectile": prepareSprite(
+    SPRITE_DESCRIPTOR_REGISTRY["player-projectile"]!
+  ),
   ...INVADER_ROW_SPRITES
 } satisfies Record<string, PreparedSprite>;
 


### PR DESCRIPTION
## Extract sprite pixel data into JSON-shaped descriptor modules

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #280

### Changes
Move every hand-authored pixel grid (player ship frames, invader squid/crab/octopus frames, player projectile frame, plus their palettes and pixelSize values) out of src/render/sprites.ts into separate JSON-shaped TypeScript data modules under a new src/render/sprite-data/ directory. Each descriptor file should export a const that satisfies the existing SpriteDescriptor shape ({ id, frames, palette, pixelSize }) and contains ONLY serializable data — no functions, no imports beyond a `type`-only import for SpriteDescriptor. Create src/render/sprite-data/index.ts that re-exports the descriptors plus a keyed registry (e.g. SPRITE_DESCRIPTOR_REGISTRY: Readonly<Record<string, SpriteDescriptor>>) so sprites.ts and other consumers can look descriptors up by id. Refactor src/render/sprites.ts so it keeps the SpriteFrame / SpriteDescriptor / SpriteCanvasContext / SpriteSheet types and createSpriteSheet() implementation, but sources PLAYER_SHIP_DESCRIPTOR, INVADER_ROW_DESCRIPTORS, PLAYER_PROJECTILE_DESCRIPTOR, and SPRITE_DESCRIPTORS from the new data modules and re-exports them with the same names so src/render/canvas.ts and src/render/sprites.test.ts continue to import from './sprites' unchanged. Extend src/render/sprites.test.ts with cases that (a) confirm every descriptor in the registry has consistent geometry (all frames same row count, equal row widths, only palette keys or EMPTY_PIXEL appear in pixel strings) and (b) confirm createSpriteSheet works when fed a descriptor pulled directly from the registry by id. Do NOT change rendering behavior, public API surface, or descriptor ids — canvas.ts must still render identically.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*