### PR TITLE
test: Add integration tests for src/main.ts runtime wiring

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { createMuteStore } from "./audio/mute";
+import type { SfxName } from "./audio/sfx";
+import { EMPTY_INPUT, createPlayingState, type GameState, type Input } from "./game/state";
+import { bootstrap } from "./main";
+import { createHighScoreStore } from "./persistence";
+import type { CanvasRenderer } from "./render/canvas";
+const HIGH_SCORE_STORAGE_KEY = "space-invaders-hd.highScore";
+const MUTE_STORAGE_KEY = "audio:muted";
+type HarnessOptions = {
+  deriveSfxEvents?: (previousState: GameState, nextState: GameState) => SfxName[];
+  initialHighScore?: number;
+  initialMuted?: boolean;
+  initialState?: GameState;
+  step?: (state: GameState, dtMs: number, input: Input) => GameState;
+};
+class FakeStorage implements Storage {
+  private readonly entries = new Map<string, string>();
+  constructor(seed: Record<string, string>) { for (const [key, value] of Object.entries(seed)) this.entries.set(key, value); }
+  get length(): number { return this.entries.size; }
+  clear(): void { this.entries.clear(); }
+  getItem(key: string): string | null { return this.entries.get(key) ?? null; }
+  key(index: number): string | null { return [...this.entries.keys()][index] ?? null; }
+  removeItem(key: string): void { this.entries.delete(key); }
+  setItem(key: string, value: string): void { this.entries.set(key, value); }
+}
+function createInput(input: Partial<Input> = {}): Input { return { ...EMPTY_INPUT, ...input }; }
+function createHarness(options: HarnessOptions = {}) {
+  const storage = new FakeStorage({
+    ...(options.initialMuted === undefined ? {} : { [MUTE_STORAGE_KEY]: String(options.initialMuted) }),
+    ...(options.initialHighScore === undefined
+      ? {}
+      : { [HIGH_SCORE_STORAGE_KEY]: String(options.initialHighScore) })
+  });
+  const keyboard = { queued: createInput(), queue(input: Partial<Input> = {}): void { this.queued = createInput(input); }, dispose(): void {}, snapshot(): Input { const input = this.queued; this.queued = createInput(); return input; } };
+  const sfx = {
+    armCalls: 0,
+    playCalls: [] as SfxName[],
+    setMutedCalls: [] as boolean[],
+    arm: async (): Promise<void> => { sfx.armCalls += 1; },
+    getStatus: () => "idle" as const,
+    play: (name: SfxName): void => void sfx.playCalls.push(name),
+    setMuted: (muted: boolean): void => void sfx.setMutedCalls.push(muted)
+  };
+  const stepCalls: Array<{ dtMs: number; input: Input; state: GameState }> = [];
+  let hidden = false;
+  let latestRender: { state: GameState; flags: Parameters<CanvasRenderer["render"]>[1] } | undefined;
+  let loop: {
+    isHidden?: () => boolean;
+    onRender: () => void;
+    onStep: (input: { dtMs: number; firstStepOfFrame: boolean }) => void;
+    stepMs: number;
+  } | undefined;
+  let onHide: (() => void) | undefined;
+  const step =
+    options.step ??
+    ((state: GameState, dtMs: number, input: Input) => { void dtMs; void input; return state; });
+  bootstrap({
+    beforeUnloadTarget: { addEventListener: () => {} },
+    createLoop: (config) => { loop = config; return { start: () => {}, stop: () => {} }; },
+    createVisibilityPauseController: ({ onHide: hide }) => { onHide = hide; return { dispose: () => {} }; },
+    deriveSfxEvents: options.deriveSfxEvents ?? (() => []),
+    highScoreStore: createHighScoreStore(storage),
+    initialState: options.initialState,
+    isHidden: () => hidden,
+    keyboard,
+    muteStore: createMuteStore(storage),
+    renderer: { render: (state, flags) => void (latestRender = { state, flags: { ...flags } }) },
+    sfx,
+    step: (state, dtMs, input) => {
+      stepCalls.push({ dtMs, input, state });
+      return step(state, dtMs, input);
+    },
+    visibilityTarget: { addEventListener: () => {}, removeEventListener: () => {} }
+  });
+  const readLoop = () => { if (loop === undefined) throw new Error("Expected loop."); return loop; };
+  const readRender = () => { if (latestRender === undefined) throw new Error("Expected render."); return latestRender; };
+  return {
+    keyboard,
+    sfx,
+    stepCalls,
+    storage,
+    latestRender: readRender,
+    setHidden: (nextHidden: boolean): void => { hidden = nextHidden; },
+    triggerHide: (): void => { if (onHide === undefined) throw new Error("Expected hide handler."); onHide(); },
+    render: (): void => {
+      const config = readLoop();
+      if (config.isHidden?.() !== true) config.onRender();
+    },
+    frame: (steps = 1): void => {
+      const config = readLoop();
+      if (config.isHidden?.() === true) return;
+      for (let index = 0; index < steps; index += 1) {
+        config.onStep({ dtMs: config.stepMs, firstStepOfFrame: index === 0 });
+      }
+      config.onRender();
+    }
+  };
+}
+
+describe("bootstrap", () => {
+  it("arms audio once and persists mute changes", () => {
+    const harness = createHarness({ initialMuted: true });
+    expect(harness.sfx.setMutedCalls).toEqual([true]);
+    expect(harness.latestRender().flags).toEqual({ bootstrapping: true, highScore: 0, muted: true });
+    harness.keyboard.queue({ firePressed: true });
+    harness.render();
+    harness.keyboard.queue({ firePressed: true });
+    harness.render();
+    harness.keyboard.queue({ mutePressed: true });
+    harness.render();
+    expect(harness.sfx.armCalls).toBe(1);
+    expect(harness.sfx.setMutedCalls).toEqual([true, false]);
+    expect(harness.storage.getItem(MUTE_STORAGE_KEY)).toBe("false");
+    expect(harness.latestRender().flags.muted).toBe(false);
+  });
+  it("records a new high score when gameplay reaches game over", () => {
+    const harness = createHarness({
+      initialHighScore: 200,
+      initialState: createPlayingState({ score: 180 }),
+      step: (state) => ({ ...state, phase: "gameOver", hud: { ...state.hud, score: 320 } })
+    });
+    harness.frame();
+    expect(harness.storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("320");
+    expect(harness.latestRender().state.phase).toBe("gameOver");
+    expect(harness.latestRender().flags.highScore).toBe(320);
+  });
+  it("auto-pauses on hide and skips simulation work while hidden", () => {
+    const playing = createPlayingState();
+    const harness = createHarness({
+      initialState: playing,
+      step: (state, _dtMs, input) => (input.pausePressed ? { ...state, phase: "paused" } : state)
+    });
+    harness.setHidden(true);
+    harness.triggerHide();
+    harness.frame();
+    harness.setHidden(false);
+    harness.render();
+    expect(harness.stepCalls).toEqual([{ dtMs: 0, input: createInput({ pausePressed: true }), state: playing }]);
+    expect(harness.latestRender().state.phase).toBe("paused");
+  });
+  it("surfaces step transitions to the renderer and sfx sinks", () => {
+    const playing = createPlayingState();
+    const lifeLost = { ...playing, phase: "lifeLost" as const, hud: { ...playing.hud, score: 120, lives: 2 } };
+    const waveClear = { ...playing, phase: "waveClear" as const, invaders: [], hud: { ...playing.hud, score: 260, lives: 2 } };
+    let index = 0;
+    const harness = createHarness({
+      deriveSfxEvents: (_previousState, nextState) =>
+        nextState.phase === "lifeLost"
+          ? ["playerDeath"]
+          : nextState.phase === "waveClear"
+            ? ["waveClear"]
+            : [],
+      initialState: playing,
+      step: () => (index++ === 0 ? lifeLost : waveClear)
+    });
+    harness.frame();
+    expect(harness.sfx.playCalls).toEqual(["playerDeath"]);
+    expect(harness.latestRender().state.hud).toEqual(lifeLost.hud);
+    harness.frame();
+    expect(harness.sfx.playCalls).toEqual(["playerDeath", "waveClear"]);
+    expect(harness.latestRender().state.phase).toBe("waveClear");
+    expect(harness.latestRender().flags.highScore).toBe(260);
+  });
+  it("throws when the game canvas is missing", () => {
+    expect(() => bootstrap({ findCanvas: () => null })).toThrowError("Game canvas not found.");
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,125 +16,162 @@ import { createVisibilityPauseController } from "./visibility";
 
 const FIXED_TIMESTEP_MS = 1000 / 60;
 type RuntimeRenderFlags = Parameters<CanvasRenderer["render"]>[1];
+type KeyboardController = ReturnType<typeof createKeyboardController>;
 
-const canvas = document.querySelector<HTMLCanvasElement>("#game");
+export function bootstrap(
+  options: {
+    beforeUnloadTarget?: Pick<Window, "addEventListener">;
+    createLoop?: typeof createFixedStepLoop;
+    createVisibilityPauseController?: typeof createVisibilityPauseController;
+    deriveSfxEvents?: typeof deriveSfxEvents;
+    findCanvas?: () => HTMLCanvasElement | null;
+    highScoreStore?: ReturnType<typeof createHighScoreStore>;
+    initialState?: GameState;
+    isHidden?: () => boolean;
+    keyboard?: KeyboardController;
+    keyboardTarget?: Window;
+    muteStore?: ReturnType<typeof createMuteStore>;
+    renderer?: CanvasRenderer;
+    sfx?: ReturnType<typeof createSfxController>;
+    step?: (state: GameState, dtMs: number, input: Input) => GameState;
+    storage?: Storage;
+    visibilityTarget?: Pick<Document, "addEventListener" | "removeEventListener">;
+  } = {}
+) {
+  const resolveHidden = options.isHidden ?? (() => getDefaultDocument().hidden);
+  const renderer =
+    options.renderer ?? createRenderer(getRequiredCanvas(options.findCanvas));
+  const keyboard =
+    options.keyboard ??
+    createKeyboardController(options.keyboardTarget ?? getDefaultWindow());
+  const sfx = options.sfx ?? createSfxController();
+  const muteStore = options.muteStore ?? createMuteStore(options.storage);
+  const highScoreStore =
+    options.highScoreStore ?? createHighScoreStore(options.storage);
+  const createLoop = options.createLoop ?? createFixedStepLoop;
+  const createVisibilityController =
+    options.createVisibilityPauseController ?? createVisibilityPauseController;
+  const advanceGameState = options.step ?? step;
+  const deriveAudioEvents = options.deriveSfxEvents ?? deriveSfxEvents;
+  const visibilityTarget = options.visibilityTarget ?? getDefaultDocument();
+  const beforeUnloadTarget =
+    options.beforeUnloadTarget ?? getDefaultWindow();
 
-if (canvas === null) {
-  throw new Error("Game canvas not found.");
-}
+  let state = options.initialState ?? createInitialGameState();
+  let bootstrapping = true;
+  let audioAttempted = false;
+  let frameInput: Input = keyboard.snapshot();
 
-const renderer = createRenderer(canvas);
-const keyboard = createKeyboardController(window);
-const sfx = createSfxController();
-const muteStore = createMuteStore();
-const highScoreStore = createHighScoreStore();
-
-let state = createInitialGameState();
-let bootstrapping = true;
-let audioAttempted = false;
-let frameInput: Input = keyboard.snapshot();
-
-sfx.setMuted(muteStore.isMuted());
-renderer.render(state, createRenderFlags(muteStore.isMuted()));
-bootstrapping = false;
-maybeArmAudio(state.phase, frameInput);
-
-const visibilityPauseController = createVisibilityPauseController({
-  target: document,
-  isHidden: () => document.hidden,
-  onHide: () => {
-    if (state.phase !== "playing") {
-      return;
-    }
-
-    advanceState(0, {
-      ...EMPTY_INPUT,
-      pausePressed: true
-    });
-  }
-});
-
-const loop = createFixedStepLoop({
-  stepMs: FIXED_TIMESTEP_MS,
-  onStep: ({ dtMs, firstStepOfFrame }) => {
-    const stepInput = firstStepOfFrame
-      ? frameInput
-      : {
-          ...frameInput,
-          firePressed: false,
-          pausePressed: false,
-          mutePressed: false
-        };
-    advanceState(dtMs, stepInput);
-  },
-  onRender: () => {
-    frameInput = keyboard.snapshot();
-
-    if (frameInput.mutePressed) {
-      muteStore.toggle();
-      sfx.setMuted(muteStore.isMuted());
-    }
-
-    maybeArmAudio(state.phase, frameInput);
-    renderer.render(state, createRenderFlags(muteStore.isMuted()));
-  }
-});
-
-window.addEventListener("beforeunload", () => {
-  loop.stop();
-  keyboard.dispose();
-  visibilityPauseController.dispose();
-});
-
-loop.start();
-
-function maybeArmAudio(phase: GameState["phase"], input: Input): void {
-  if (audioAttempted) {
-    return;
-  }
-
-  const leavesOverlay =
-    ((phase === "start" || phase === "waveClear" || phase === "gameOver") &&
-      input.firePressed) ||
-    (phase === "paused" && input.pausePressed);
-
-  if (!leavesOverlay) {
-    return;
-  }
-
-  audioAttempted = true;
-  void sfx.arm();
-}
-
-function advanceState(dtMs: number, input: Input): void {
-  const previousState = state;
-  state = step(state, dtMs, input);
-  maybeRecordHighScore(state.hud.score);
-  playDerivedEvents(previousState, state);
-}
-
-function playDerivedEvents(previousState: GameState, nextState: GameState): void {
-  for (const event of deriveSfxEvents(previousState, nextState)) {
-    sfx.play(event);
-  }
-}
-
-function maybeRecordHighScore(score: number): void {
-  if (score <= highScoreStore.getHighScore()) {
-    return;
-  }
-
-  highScoreStore.recordScore(score);
-}
-
-function createRenderFlags(muted: boolean): RuntimeRenderFlags {
-  return {
+  const createRenderFlags = (): RuntimeRenderFlags => ({
     bootstrapping,
-    muted,
+    muted: muteStore.isMuted(),
     highScore: pickDisplayHighScore(
       highScoreStore.getHighScore(),
       state.hud.score
     )
+  });
+
+  const maybeArmAudio = (phase: GameState["phase"], input: Input): void => {
+    if (audioAttempted) {
+      return;
+    }
+
+    const leavesOverlay =
+      ((phase === "start" || phase === "waveClear" || phase === "gameOver") &&
+        input.firePressed) ||
+      (phase === "paused" && input.pausePressed);
+
+    if (!leavesOverlay) {
+      return;
+    }
+
+    audioAttempted = true;
+    void sfx.arm();
+  };
+
+  const maybeRecordHighScore = (score: number): void => {
+    if (score <= highScoreStore.getHighScore()) {
+      return;
+    }
+
+    highScoreStore.recordScore(score);
+  };
+
+  const playDerivedEvents = (
+    previousState: GameState,
+    nextState: GameState
+  ): void => {
+    for (const event of deriveAudioEvents(previousState, nextState)) {
+      sfx.play(event);
+    }
+  };
+
+  const advanceState = (dtMs: number, input: Input): void => {
+    const previousState = state;
+    state = advanceGameState(state, dtMs, input);
+    maybeRecordHighScore(state.hud.score);
+    playDerivedEvents(previousState, state);
+  };
+
+  sfx.setMuted(muteStore.isMuted());
+  renderer.render(state, createRenderFlags());
+  bootstrapping = false;
+  maybeArmAudio(state.phase, frameInput);
+
+  const visibilityPauseController = createVisibilityController({
+    target: visibilityTarget,
+    isHidden: resolveHidden,
+    onHide: () => {
+      if (state.phase !== "playing") {
+        return;
+      }
+
+      advanceState(0, {
+        ...EMPTY_INPUT,
+        pausePressed: true
+      });
+    }
+  });
+
+  const loop = createLoop({
+    stepMs: FIXED_TIMESTEP_MS,
+    onStep: ({ dtMs, firstStepOfFrame }) => {
+      const stepInput = firstStepOfFrame
+        ? frameInput
+        : {
+            ...frameInput,
+            firePressed: false,
+            pausePressed: false,
+            mutePressed: false
+          };
+      advanceState(dtMs, stepInput);
+    },
+    onRender: () => {
+      frameInput = keyboard.snapshot();
+
+      if (frameInput.mutePressed) {
+        muteStore.toggle();
+        sfx.setMuted(muteStore.isMuted());
+      }
+
+      maybeArmAudio(state.phase, frameInput);
+      renderer.render(state, createRenderFlags());
+    },
+    isHidden: resolveHidden
+  });
+
+  const dispose = (): void => {
+    loop.stop();
+    keyboard.dispose();
+    visibilityPauseController.dispose();
+  };
+
+  beforeUnloadTarget.addEventListener("beforeunload", dispose);
+  loop.start();
+
+  return {
+    dispose,
+    loop
   };
 }
 
@@ -152,7 +189,7 @@ function renderFallback(title: string, detail: string): void {
   `;
 }
 
-function createRenderer(canvasElement: HTMLCanvasElement) {
+function createRenderer(canvasElement: HTMLCanvasElement): CanvasRenderer {
   try {
     return createCanvasRenderer(canvasElement);
   } catch (error) {
@@ -162,4 +199,39 @@ function createRenderer(canvasElement: HTMLCanvasElement) {
     );
     throw error;
   }
+}
+
+function getDefaultDocument(): Document {
+  if (typeof document === "undefined") {
+    throw new Error("Document is required to bootstrap the game.");
+  }
+
+  return document;
+}
+
+function getDefaultWindow(): Window {
+  if (typeof window === "undefined") {
+    throw new Error("Window is required to bootstrap the game.");
+  }
+
+  return window;
+}
+
+function getRequiredCanvas(
+  findCanvas: (() => HTMLCanvasElement | null) | undefined
+): HTMLCanvasElement {
+  const canvas =
+    findCanvas === undefined
+      ? getDefaultDocument().querySelector<HTMLCanvasElement>("#game")
+      : findCanvas();
+
+  if (canvas === null) {
+    throw new Error("Game canvas not found.");
+  }
+
+  return canvas;
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  bootstrap();
 }


### PR DESCRIPTION
## Add integration tests for src/main.ts runtime wiring

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #383

### Changes
Create `src/main.test.ts` that exercises the top-level wiring in `src/main.ts` by driving fake collaborators — keyboard input, audio (sfx + mute store), persistence (high-score storage), visibility controller, renderer, and the fixed-step loop — and asserting the observable effects that currently have no direct coverage: (1) audio is armed on first user interaction and muted state is respected and persisted, (2) game-over score reaching a new high gets written through the high-score store, (3) visibility change triggers auto-pause and does not step the simulation while hidden, (4) step() results (score/lives/gameOver/wave-clear transitions) are surfaced to the renderer and to the audio/high-score sinks as expected. To make this testable, inspect `src/main.ts` and, if it does not already expose an injectable bootstrap, export a pure `bootstrap({ window, storage, audio, renderer, loop, ... })` function (or equivalent factory) that main.ts's top-level side effects call with real collaborators — keep the change minimal and do NOT refactor the loop logic itself (that is owned by the separate `Refactor main.ts to bootstrap createGameRuntime` task). The new test file should use in-memory fakes consistent with the patterns in `src/audio/mute.test.ts`, `src/persistence.test.ts`, `src/visibility.test.ts`, `src/input/keyboard.test.ts`, and `src/loop/fixedStep.test.ts`. Aim for 4–8 focused cases covering the seams listed above.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*