### PR TITLE
feature: Rotate invader firing across occupied columns

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -97,6 +97,7 @@ export type GameState = {
   playerShootFrame: number;
   nextProjectileId: number;
   invaderFireCooldownMs: number;
+  invaderFireCursor: number;
   transitionTimerMs: number;
   elapsedMs: number;
 };
@@ -109,6 +110,7 @@ export type GameStateSeed = {
   frame?: number;
   nextProjectileId?: number;
   invaderFireCooldownMs?: number;
+  invaderFireCursor?: number;
   transitionTimerMs?: number;
   elapsedMs?: number;
 };
@@ -184,6 +186,7 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
   const nextProjectileId = seed.nextProjectileId ?? 1;
   const invaderFireCooldownMs =
     seed.invaderFireCooldownMs ?? INVADER_FIRE_INTERVAL_MS;
+  const invaderFireCursor = seed.invaderFireCursor ?? 0;
 
   return {
     phase: seed.phase ?? "start",
@@ -204,6 +207,7 @@ export function createGameState(seed: GameStateSeed = {}): GameState {
     playerShootFrame: 0,
     nextProjectileId,
     invaderFireCooldownMs,
+    invaderFireCursor,
     transitionTimerMs: seed.transitionTimerMs ?? 0,
     elapsedMs: seed.elapsedMs ?? 0
   };

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -128,6 +128,58 @@ function getMarchAnimationIntervalMs(state: GameState): number {
   );
 }
 
+function getInvaderProjectileSourceColumn(
+  state: GameState,
+  projectile: GameState["projectiles"][number]
+): number {
+  const sourceInvader = state.invaders.find(
+    (invader) =>
+      Math.abs(
+        invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2 - projectile.x
+      ) < 1e-9
+  );
+
+  if (sourceInvader === undefined) {
+    throw new Error(`Missing invader source for projectile ${projectile.id}`);
+  }
+
+  return sourceInvader.col;
+}
+
+function advanceToNextInvaderShot(state: GameState): {
+  state: GameState;
+  sourceColumn: number;
+} {
+  const almost = step(state, INVADER_FIRE_INTERVAL_MS - 1, EMPTY_INPUT);
+  const next = step(almost, 1, EMPTY_INPUT);
+  const projectile = next.projectiles.find(
+    (candidate) =>
+      candidate.owner === "invader" && candidate.id === almost.nextProjectileId
+  );
+
+  if (projectile === undefined) {
+    throw new Error("Expected an invader projectile to spawn");
+  }
+
+  return {
+    state: next,
+    sourceColumn: getInvaderProjectileSourceColumn(next, projectile)
+  };
+}
+
+function collectInvaderShotColumns(state: GameState, shotCount: number): number[] {
+  const sourceColumns: number[] = [];
+  let nextState = state;
+
+  for (let shotIndex = 0; shotIndex < shotCount; shotIndex += 1) {
+    const shot = advanceToNextInvaderShot(nextState);
+    sourceColumns.push(shot.sourceColumn);
+    nextState = shot.state;
+  }
+
+  return sourceColumns;
+}
+
 describe("step", () => {
   it("keeps the start screen active without confirm input", () => {
     const state = createGameState({ phase: "start" });
@@ -335,6 +387,30 @@ describe("step", () => {
 
     expect(almost.projectiles.some((projectile) => projectile.owner === "invader")).toBe(false);
     expect(step(almost, 1, EMPTY_INPUT).projectiles.some((projectile) => projectile.owner === "invader")).toBe(true);
+  });
+
+  it("rotates invader firing across multiple occupied columns from a fresh wave", () => {
+    const sourceColumns = collectInvaderShotColumns(createPlayingState(), 5);
+
+    expect(new Set(sourceColumns).size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("skips a cleared leftmost column and keeps rotating over the remaining columns", () => {
+    const base = createPlayingState();
+    const state = {
+      ...base,
+      invaders: base.invaders.filter((invader) => invader.col > 0)
+    };
+
+    expect(collectInvaderShotColumns(state, 4)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("replays the same invader firing columns from the same starting state", () => {
+    const state = createPlayingState();
+
+    expect(JSON.stringify(collectInvaderShotColumns(state, 6))).toBe(
+      JSON.stringify(collectInvaderShotColumns(state, 6))
+    );
   });
 
   it("does not let an invader killed by the player in the same frame fire", () => {

--- a/src/game/step.ts
+++ b/src/game/step.ts
@@ -1,6 +1,7 @@
 import {
   EMPTY_INPUT,
   FORMATION_SPEED_BASE,
+  INVADER_COLS,
   INVADER_FIRE_INTERVAL_MS,
   LIFE_LOST_DURATION_MS,
   MARCH_FRAME_INTERVAL_MS,
@@ -156,6 +157,7 @@ function advanceLifeLost(
       frame: state.frame + 1,
       nextProjectileId: state.nextProjectileId,
       invaderFireCooldownMs,
+      invaderFireCursor: state.invaderFireCursor,
       elapsedMs: resolvedElapsedMs
     });
 
@@ -307,6 +309,7 @@ function advancePlaying(
         lives: Math.max(0, state.hud.lives - 1)
       },
       invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
+      invaderFireCursor: invaderProjectileBundle.invaderFireCursor,
       transitionTimerMs: LIFE_LOST_DURATION_MS,
       frame: nextFrame,
       nextProjectileId: invaderProjectileBundle.nextProjectileId,
@@ -335,6 +338,7 @@ function advancePlaying(
         score
       },
       invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
+      invaderFireCursor: invaderProjectileBundle.invaderFireCursor,
       transitionTimerMs: 0,
       frame: nextFrame,
       nextProjectileId: invaderProjectileBundle.nextProjectileId,
@@ -361,6 +365,7 @@ function advancePlaying(
     },
     frame: nextFrame,
     invaderFireCooldownMs: invaderProjectileBundle.invaderFireCooldownMs,
+    invaderFireCursor: invaderProjectileBundle.invaderFireCursor,
     transitionTimerMs: 0,
     nextProjectileId: invaderProjectileBundle.nextProjectileId,
     elapsedMs: nextElapsedMs
@@ -417,22 +422,25 @@ function maybeSpawnInvaderProjectile(
 ): {
   nextProjectileId: number;
   invaderFireCooldownMs: number;
+  invaderFireCursor: number;
   projectile: Projectile | undefined;
 } {
   if (invaderFireCooldownMs > 0) {
     return {
       nextProjectileId,
       invaderFireCooldownMs,
+      invaderFireCursor: state.invaderFireCursor,
       projectile: undefined
     };
   }
 
-  const firingInvader = selectFiringInvader(invaders);
+  const firingSelection = selectFiringInvader(invaders, state.invaderFireCursor);
 
-  if (firingInvader === undefined) {
+  if (firingSelection === undefined) {
     return {
       nextProjectileId,
       invaderFireCooldownMs,
+      invaderFireCursor: state.invaderFireCursor,
       projectile: undefined
     };
   }
@@ -440,12 +448,13 @@ function maybeSpawnInvaderProjectile(
   return {
     nextProjectileId: nextProjectileId + 1,
     invaderFireCooldownMs: INVADER_FIRE_INTERVAL_MS,
+    invaderFireCursor: firingSelection.nextCursor,
     projectile: createInvaderProjectile(
       {
         ...state,
         nextProjectileId
       },
-      firingInvader
+      firingSelection.invader
     )
   };
 }
@@ -743,20 +752,56 @@ function hasInvaderBreached(invaders: Invader[], player: GameState["player"]): b
   return false;
 }
 
-function selectFiringInvader(invaders: Invader[]): Invader | undefined {
+function selectFiringInvader(
+  invaders: Invader[],
+  invaderFireCursor: number
+):
+  | {
+      invader: Invader;
+      nextCursor: number;
+    }
+  | undefined {
+  const occupiedColumns = [...new Set(invaders.map((invader) => invader.col))].sort(
+    (left, right) => left - right
+  );
+
+  if (occupiedColumns.length === 0) {
+    return undefined;
+  }
+
+  const normalizedCursor = normalizeInvaderFireCursor(invaderFireCursor);
+  const firstOccupiedColumn = occupiedColumns[0];
+
+  if (firstOccupiedColumn === undefined) {
+    return undefined;
+  }
+
+  const firingColumn =
+    occupiedColumns.find((col) => col >= normalizedCursor) ?? firstOccupiedColumn;
   let firingInvader: Invader | undefined;
 
   for (const invader of invaders) {
-    if (
-      firingInvader === undefined ||
-      invader.col < firingInvader.col ||
-      (invader.col === firingInvader.col && invader.row > firingInvader.row)
-    ) {
+    if (invader.col !== firingColumn) {
+      continue;
+    }
+
+    if (firingInvader === undefined || invader.row > firingInvader.row) {
       firingInvader = invader;
     }
   }
 
-  return firingInvader;
+  if (firingInvader === undefined) {
+    return undefined;
+  }
+
+  return {
+    invader: firingInvader,
+    nextCursor: (firingColumn + 1) % INVADER_COLS
+  };
+}
+
+function normalizeInvaderFireCursor(invaderFireCursor: number): number {
+  return ((invaderFireCursor % INVADER_COLS) + INVADER_COLS) % INVADER_COLS;
 }
 
 function intersects(a: Rect, b: Rect): boolean {


### PR DESCRIPTION
## Rotate invader firing across occupied columns

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #274

### Changes
In src/game/step.ts, change `maybeSpawnProjectiles()` so successive invader shots are distributed across the currently-occupied columns instead of always firing from the leftmost one. Build the list of occupied columns (sorted left-to-right) and pick the bottom-most invader from a selected column using a deterministic, reproducible chooser — either a round-robin index that advances each shot and skips columns that are no longer occupied, or a seeded LCG/xorshift over the selector state. Persist the minimal selector state (e.g., `invaderFireCursor: number` and/or `invaderFireRngSeed: number`) on `GameState` in src/game/state.ts; initialize it in `createGameState`/`createPlayingState` and propagate it through wave transitions deterministically (resetting on new waves is fine, but the same starting state must always produce the same sequence of firing columns). Do NOT change the firing interval, projectile speed, or projectile spawn geometry — only which invader is chosen as the shooter. Add at least three new cases to src/game/step.test.ts that: (1) advance enough ticks to let several invader shots spawn from a fresh playing state and assert that the resulting projectiles span at least 3 distinct source columns; (2) clear the leftmost column entirely and assert subsequent shots still rotate over the remaining occupied columns without getting stuck; (3) run the same starting state through the same input sequence twice and assert byte-equal column ordering of spawned invader projectiles (reproducibility). Keep all existing tests passing — if any existing test asserted exact x-coordinates of invader shots that depended on the leftmost-column behavior, update it to reflect the new selector but keep the assertion meaningful (e.g., assert source column membership, not a hard-coded x).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*