### PR TITLE
feature: Add firing frame to player ship sprite and verify it renders

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -10,14 +10,8 @@ const HUD_HEIGHT = 68;
 const HUD_SHIP_COLORS = new Set(Object.values(PLAYER_SHIP_DESCRIPTOR.palette));
 const PLAYER_INVULNERABILITY_HALO_COLOR = "rgba(123, 229, 255, 0.22)";
 const PLAYER_INVULNERABILITY_HALO_MARGIN = 12;
-const PLAYER_SHIP_PIXEL_COUNT = PLAYER_SHIP_DESCRIPTOR.frames.reduce(
-  (frameCount, frame) =>
-    frameCount +
-    frame.reduce(
-      (rowCount, row) => rowCount + [...row].filter((pixel) => pixel !== ".").length,
-      0
-    ),
-  0
+const PLAYER_SHIP_PIXEL_COUNT = countFilledPixels(
+  PLAYER_SHIP_DESCRIPTOR.frames[0] ?? []
 );
 
 type FillRectCall = {
@@ -160,6 +154,13 @@ function countClusters(values: number[]): number {
   }
 
   return clusterCount;
+}
+
+function countFilledPixels(frame: readonly string[]): number {
+  return frame.reduce(
+    (rowCount, row) => rowCount + [...row].filter((pixel) => pixel !== ".").length,
+    0
+  );
 }
 
 function getPlayerShipFillRects(
@@ -379,6 +380,39 @@ describe("createCanvasRenderer", () => {
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeUndefined();
     expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
+  });
+
+  it("renders a distinct player sprite frame while the shoot animation is active", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const idleContext = new FakeCanvasContext();
+    const firingContext = new FakeCanvasContext();
+    const idleRenderer = createCanvasRenderer(createFakeCanvas(idleContext));
+    const firingRenderer = createCanvasRenderer(createFakeCanvas(firingContext));
+    const baseState = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+    const firingState = {
+      ...baseState,
+      playerShootFrame: 60
+    };
+
+    idleRenderer.render(baseState, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+    firingRenderer.render(firingState, {
+      bootstrapping: false,
+      highScore: 0,
+      muted: false
+    });
+
+    expect(getPlayerShipFillRects(idleContext, baseState)).not.toEqual(
+      getPlayerShipFillRects(firingContext, firingState)
+    );
   });
 
   it("renders the shared control footer", () => {

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { SPRITE_DESCRIPTOR_REGISTRY } from "./sprite-data";
 import {
   EMPTY_PIXEL,
   INVADER_ROW_DESCRIPTORS,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
+  SPRITE_DESCRIPTOR_REGISTRY,
   SPRITE_DESCRIPTORS,
   createSpriteSheet,
   getSprite,
@@ -85,7 +85,10 @@ describe("createSpriteSheet", () => {
     expect(SPRITE_DESCRIPTORS).toHaveLength(7);
     expect(INVADER_ROW_DESCRIPTORS).toHaveLength(5);
 
-    expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(2);
+    expect(PLAYER_SHIP_DESCRIPTOR.frames[1]).not.toEqual(
+      PLAYER_SHIP_DESCRIPTOR.frames[0]
+    );
     expect(createSpriteSheet(PLAYER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(1);
 
     for (const descriptor of INVADER_ROW_DESCRIPTORS) {

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -1,7 +1,7 @@
 import {
   INVADER_ROW_DESCRIPTORS,
-  PLAYER_SHIP_DESCRIPTOR,
-  SPRITE_DESCRIPTOR_REGISTRY
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  PLAYER_SHIP_DESCRIPTOR as BASE_PLAYER_SHIP_DESCRIPTOR
 } from "./sprite-data";
 
 export type SpriteFrame = readonly string[];
@@ -37,12 +37,40 @@ export type PreparedSprite = {
 
 export const EMPTY_PIXEL = ".";
 
-export {
-  INVADER_ROW_DESCRIPTORS,
-  PLAYER_PROJECTILE_DESCRIPTOR,
+const PLAYER_IDLE_FRAME = BASE_PLAYER_SHIP_DESCRIPTOR.frames[0];
+
+if (PLAYER_IDLE_FRAME === undefined) {
+  throw new Error('Sprite "player-ship" must include an idle frame.');
+}
+
+const PLAYER_SHIP_FIRE_FRAME = [
+  ".........b.........",
+  "........cbc........",
+  ".......ccccc.......",
+  "......cccbccc......",
+  ".....ccbbbbbcc.....",
+  "...ccbbbbbbbbbcc...",
+  "..ccbbbbbbbbbbbcc.."
+] as const satisfies SpriteFrame;
+
+export { INVADER_ROW_DESCRIPTORS, PLAYER_PROJECTILE_DESCRIPTOR };
+
+export const PLAYER_SHIP_DESCRIPTOR = {
+  ...BASE_PLAYER_SHIP_DESCRIPTOR,
+  frames: [PLAYER_IDLE_FRAME, PLAYER_SHIP_FIRE_FRAME]
+} satisfies SpriteDescriptor;
+
+export const SPRITE_DESCRIPTORS = [
   PLAYER_SHIP_DESCRIPTOR,
-  SPRITE_DESCRIPTORS
-} from "./sprite-data";
+  ...INVADER_ROW_DESCRIPTORS,
+  PLAYER_PROJECTILE_DESCRIPTOR
+] as const satisfies readonly SpriteDescriptor[];
+
+type SpriteDescriptorId = (typeof SPRITE_DESCRIPTORS)[number]["id"];
+
+export const SPRITE_DESCRIPTOR_REGISTRY = Object.fromEntries(
+  SPRITE_DESCRIPTORS.map((descriptor) => [descriptor.id, descriptor] as const)
+) as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>;
 
 const HUD_PLAYER_SHIP_DESCRIPTOR = {
   ...PLAYER_SHIP_DESCRIPTOR,
@@ -60,11 +88,9 @@ const INVADER_ROW_SPRITES = Object.fromEntries(
 >;
 
 const SPRITE_REGISTRY = {
-  "player-ship": prepareSprite(SPRITE_DESCRIPTOR_REGISTRY["player-ship"]!),
+  "player-ship": prepareSprite(PLAYER_SHIP_DESCRIPTOR),
   "hud-player-ship": prepareSprite(HUD_PLAYER_SHIP_DESCRIPTOR),
-  "player-projectile": prepareSprite(
-    SPRITE_DESCRIPTOR_REGISTRY["player-projectile"]!
-  ),
+  "player-projectile": prepareSprite(PLAYER_PROJECTILE_DESCRIPTOR),
   ...INVADER_ROW_SPRITES
 } satisfies Record<string, PreparedSprite>;
 


### PR DESCRIPTION
## Add firing frame to player ship sprite and verify it renders

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #270

### Changes
Give PLAYER_SHIP_DESCRIPTOR a second frame representing the firing pose so drawPlayer()'s `state.playerShootFrame > 0 ? 1 : 0` branch in src/render/canvas.ts actually selects a distinct frame instead of being clamped back to 0 by getFrameIndex(). The second frame must use the same width/height grid as the existing frame and the same palette keys; differentiate it visually (e.g. a muzzle/cannon pixel at the ship's nose) so the pixel output meaningfully differs from the idle frame. Update src/render/sprites.test.ts so the assertion about PLAYER_SHIP_DESCRIPTOR's frame count matches the new count of 2 (and add an assertion that frame 1 differs from frame 0). Add a renderer test in src/render/canvas.test.ts that constructs a playing GameState, renders it once with playerShootFrame === 0 and once with playerShootFrame > 0 (and no other state changes), captures the fillRect calls from the fake context in the player's rendered region, and asserts the two captured sequences are not deep-equal — proving the firing animation path produces different pixels. Do not change behavior outside the sprite frame data, the canvas player-draw path is already correct.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*