### PR TITLE
feature: Create shared WebAudio engine that owns AudioContext, unlock, mute, and scheduling

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -1,0 +1,331 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock
+} from "vitest";
+
+import {
+  createAudioEngine,
+  type AudioContextLike,
+  type AudioDestinationLike,
+  type AudioGainNodeLike,
+  type AudioOscillatorNodeLike
+} from "./engine";
+
+type MockDestination = {
+  readonly kind: "destination";
+};
+
+type MockAudioParam = {
+  value: number;
+  setValueAtTime: Mock<(value: number, time: number) => MockAudioParam>;
+  exponentialRampToValueAtTime: Mock<
+    (value: number, time: number) => MockAudioParam
+  >;
+};
+
+type MockGainNode = {
+  gain: MockAudioParam;
+  connect: Mock<(target: AudioDestinationLike) => unknown>;
+} & AudioGainNodeLike;
+
+type MockOscillatorNode = {
+  type: OscillatorType;
+  frequency: MockAudioParam;
+  connect: Mock<(target: AudioGainNodeLike) => unknown>;
+  start: Mock<(time: number) => void>;
+  stop: Mock<(time: number) => void>;
+} & AudioOscillatorNodeLike;
+
+type MockAudioContext = {
+  state: AudioContextState;
+  readonly destination: MockDestination;
+  currentTime: number;
+  readonly resume: Mock<() => Promise<void>>;
+  readonly createOscillator: Mock<() => MockOscillatorNode>;
+  readonly createGain: Mock<() => MockGainNode>;
+} & AudioContextLike;
+
+type MockWebAudioHarness = {
+  failOnCreate: boolean;
+  failOnResume: boolean;
+  initialState: AudioContextState;
+  readonly destination: MockDestination;
+  readonly contexts: MockAudioContext[];
+  readonly oscillators: MockOscillatorNode[];
+  readonly gains: MockGainNode[];
+  readonly createContext: Mock<() => MockAudioContext>;
+};
+
+let harness: MockWebAudioHarness;
+
+function createMockAudioParam(initialValue: number): MockAudioParam {
+  const audioParam: MockAudioParam = {
+    value: initialValue,
+    setValueAtTime: vi.fn<(value: number, time: number) => MockAudioParam>(),
+    exponentialRampToValueAtTime:
+      vi.fn<(value: number, time: number) => MockAudioParam>()
+  };
+
+  audioParam.setValueAtTime.mockImplementation((value) => {
+    audioParam.value = value;
+    return audioParam;
+  });
+  audioParam.exponentialRampToValueAtTime.mockImplementation((value) => {
+    audioParam.value = value;
+    return audioParam;
+  });
+
+  return audioParam;
+}
+
+function createMockWebAudioHarness(
+  initialState: AudioContextState = "suspended"
+): MockWebAudioHarness {
+  const destination: MockDestination = { kind: "destination" };
+  const contexts: MockAudioContext[] = [];
+  const oscillators: MockOscillatorNode[] = [];
+  const gains: MockGainNode[] = [];
+
+  const harness: MockWebAudioHarness = {
+    failOnCreate: false,
+    failOnResume: false,
+    initialState,
+    destination,
+    contexts,
+    oscillators,
+    gains,
+    createContext: vi.fn<() => MockAudioContext>()
+  };
+
+  harness.createContext.mockImplementation(() => {
+    if (harness.failOnCreate) {
+      throw new Error("AudioContext unavailable");
+    }
+
+    const context: MockAudioContext = {
+      state: harness.initialState,
+      destination,
+      currentTime: 0,
+      resume: vi.fn(async () => {
+        if (harness.failOnResume) {
+          throw new Error("Resume failed");
+        }
+
+        context.state = "running";
+      }),
+      createOscillator: vi.fn(() => {
+        const oscillator: MockOscillatorNode = {
+          type: "sine",
+          frequency: createMockAudioParam(0),
+          connect: vi.fn((target: AudioGainNodeLike) => target),
+          start: vi.fn<(time: number) => void>(),
+          stop: vi.fn<(time: number) => void>()
+        };
+
+        oscillators.push(oscillator);
+
+        return oscillator;
+      }),
+      createGain: vi.fn(() => {
+        const gain: MockGainNode = {
+          gain: createMockAudioParam(0),
+          connect: vi.fn((target: AudioDestinationLike) => target)
+        };
+
+        gains.push(gain);
+
+        return gain;
+      })
+    };
+
+    contexts.push(context);
+
+    return context;
+  });
+
+  return harness;
+}
+
+function getLastContext(mockHarness: MockWebAudioHarness): MockAudioContext {
+  const context = mockHarness.contexts.at(-1);
+
+  if (context === undefined) {
+    throw new Error("Expected an AudioContext instance.");
+  }
+
+  return context;
+}
+
+describe("createAudioEngine", () => {
+  beforeEach(() => {
+    harness = createMockWebAudioHarness();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("arms a suspended context once and reuses it across repeated arm calls", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+
+    await engine.arm();
+    await engine.arm();
+
+    expect(harness.createContext).toHaveBeenCalledTimes(1);
+
+    const context = getLastContext(harness);
+
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(context.state).toBe("running");
+    expect(engine.getStatus()).toBe("ready");
+  });
+
+  it.each([
+    {
+      label: "context construction fails",
+      prepare: (mockHarness: MockWebAudioHarness) => {
+        mockHarness.failOnCreate = true;
+      }
+    },
+    {
+      label: "context resume fails",
+      prepare: (mockHarness: MockWebAudioHarness) => {
+        mockHarness.failOnResume = true;
+      }
+    }
+  ])("reports muted when $label", async ({ prepare }) => {
+    prepare(harness);
+    const engine = createAudioEngine({ createContext: harness.createContext });
+
+    await engine.arm();
+
+    expect(engine.getStatus()).toBe("muted");
+  });
+
+  it("does not schedule anything while idle or muted", async () => {
+    const idleEngine = createAudioEngine({ createContext: harness.createContext });
+
+    idleEngine.scheduleTone({
+      frequency: 440,
+      duration: 0.1,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(harness.contexts).toHaveLength(0);
+    expect(harness.oscillators).toHaveLength(0);
+    expect(harness.gains).toHaveLength(0);
+
+    const mutedEngine = createAudioEngine({ createContext: harness.createContext });
+    await mutedEngine.arm();
+    mutedEngine.setMuted(true);
+    mutedEngine.scheduleTone({
+      frequency: 660,
+      duration: 0.08,
+      gain: 0.04,
+      type: "triangle"
+    });
+
+    expect(mutedEngine.getStatus()).toBe("muted");
+    expect(harness.oscillators).toHaveLength(0);
+    expect(harness.gains).toHaveLength(0);
+  });
+
+  it("schedules oscillator playback through a gain envelope", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+    await engine.arm();
+
+    const context = getLastContext(harness);
+
+    context.currentTime = 12;
+    engine.scheduleTone({
+      frequency: 880,
+      duration: 0.25,
+      gain: 0.08,
+      type: "sawtooth",
+      startOffset: 0.1
+    });
+
+    const oscillator = harness.oscillators[0];
+    const gain = harness.gains[0];
+
+    if (oscillator === undefined || gain === undefined) {
+      throw new Error("Expected a scheduled oscillator and gain node.");
+    }
+
+    expect(engine.now()).toBe(12);
+    expect(oscillator.type).toBe("sawtooth");
+    expect(oscillator.connect).toHaveBeenCalledWith(gain);
+    expect(gain.connect).toHaveBeenCalledWith(harness.destination);
+    expect(oscillator.frequency.setValueAtTime).toHaveBeenCalledWith(880, 12.1);
+    expect(gain.gain.setValueAtTime).toHaveBeenCalledWith(0.0001, 12.1);
+
+    const attackCall = gain.gain.exponentialRampToValueAtTime.mock.calls[0];
+    const releaseCall = gain.gain.exponentialRampToValueAtTime.mock.calls[1];
+    const startCall = oscillator.start.mock.calls[0];
+    const stopCall = oscillator.stop.mock.calls[0];
+
+    if (
+      attackCall === undefined ||
+      releaseCall === undefined ||
+      startCall === undefined ||
+      stopCall === undefined
+    ) {
+      throw new Error("Expected scheduled gain ramps and playback times.");
+    }
+
+    expect(attackCall[0]).toBe(0.08);
+    expect(attackCall[1]).toBeCloseTo(12.12);
+    expect(releaseCall[0]).toBe(0.0001);
+    expect(releaseCall[1]).toBeCloseTo(12.35);
+    expect(startCall[0]).toBeCloseTo(12.1);
+    expect(stopCall[0]).toBeCloseTo(12.37);
+  });
+
+  it("suppresses rapid repeats when a cooldown tag is reused", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+    await engine.arm();
+
+    const context = getLastContext(harness);
+
+    context.currentTime = 1;
+    engine.scheduleTone({
+      tag: "laser",
+      cooldownSeconds: 0.05,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+
+    const scheduledOscillatorCount = harness.oscillators.length;
+
+    engine.scheduleTone({
+      tag: "laser",
+      cooldownSeconds: 0.05,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(harness.oscillators).toHaveLength(scheduledOscillatorCount);
+
+    context.currentTime += 0.051;
+    engine.scheduleTone({
+      tag: "laser",
+      cooldownSeconds: 0.05,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(harness.oscillators).toHaveLength(scheduledOscillatorCount + 1);
+  });
+});

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -1,0 +1,151 @@
+export type AudioEngineStatus = "idle" | "ready" | "muted";
+
+export type AudioDestinationLike = object;
+
+export type AudioParamLike = {
+  setValueAtTime: (value: number, time: number) => unknown;
+  exponentialRampToValueAtTime: (value: number, time: number) => unknown;
+};
+
+export type AudioGainNodeLike = {
+  gain: AudioParamLike;
+  connect: (target: AudioDestinationLike) => unknown;
+};
+
+export type AudioOscillatorNodeLike = {
+  type: OscillatorType;
+  frequency: AudioParamLike;
+  connect: (target: AudioGainNodeLike) => unknown;
+  start: (time: number) => void;
+  stop: (time: number) => void;
+};
+
+export type AudioContextLike = {
+  state: AudioContextState;
+  readonly destination: AudioDestinationLike;
+  currentTime: number;
+  resume: () => Promise<void>;
+  createOscillator: () => AudioOscillatorNodeLike;
+  createGain: () => AudioGainNodeLike;
+};
+
+export type ScheduleToneOptions = {
+  frequency: number;
+  duration: number;
+  gain: number;
+  type: OscillatorType;
+  cooldownSeconds?: number;
+  startOffset?: number;
+  tag?: string;
+};
+
+export type AudioEngine = {
+  arm: () => Promise<void>;
+  getStatus: () => AudioEngineStatus;
+  now: () => number;
+  scheduleTone: (options: ScheduleToneOptions) => void;
+  setMuted: (muted: boolean) => void;
+};
+
+export type CreateAudioEngineOptions = {
+  createContext?: () => AudioContextLike;
+};
+
+const ATTACK_SECONDS = 0.02;
+const MIN_GAIN = 0.0001;
+const STOP_PADDING_SECONDS = 0.02;
+
+export function createAudioEngine(
+  options: CreateAudioEngineOptions = {}
+): AudioEngine {
+  const createContext = options.createContext ?? createDefaultAudioContext;
+  const lastScheduledAtByTag = new Map<string, number>();
+  let context: AudioContextLike | null = null;
+  let status: AudioEngineStatus = "idle";
+  let muted = false;
+
+  const getOrCreateContext = (): AudioContextLike => {
+    if (context === null) {
+      context = createContext();
+      lastScheduledAtByTag.clear();
+    }
+
+    return context;
+  };
+
+  return {
+    arm: async () => {
+      if (status === "muted") {
+        return;
+      }
+
+      try {
+        const audioContext = getOrCreateContext();
+
+        if (audioContext.state === "suspended") {
+          await audioContext.resume();
+        }
+
+        status = "ready";
+      } catch {
+        status = "muted";
+      }
+    },
+    getStatus: () => (muted ? "muted" : status),
+    now: () => context?.currentTime ?? 0,
+    scheduleTone: ({
+      frequency,
+      duration,
+      gain,
+      type,
+      cooldownSeconds,
+      startOffset = 0,
+      tag
+    }) => {
+      if (muted || status !== "ready" || context === null) {
+        return;
+      }
+
+      const currentTime = context.currentTime;
+
+      if (tag !== undefined && cooldownSeconds !== undefined) {
+        const lastScheduledAt = lastScheduledAtByTag.get(tag);
+
+        if (
+          lastScheduledAt !== undefined &&
+          currentTime - lastScheduledAt < cooldownSeconds
+        ) {
+          return;
+        }
+
+        lastScheduledAtByTag.set(tag, currentTime);
+      }
+
+      const startTime = currentTime + startOffset;
+      const endTime = startTime + duration;
+      const oscillator = context.createOscillator();
+      const toneGain = context.createGain();
+
+      oscillator.type = type;
+      oscillator.frequency.setValueAtTime(frequency, startTime);
+      toneGain.gain.setValueAtTime(MIN_GAIN, startTime);
+      toneGain.gain.exponentialRampToValueAtTime(
+        gain,
+        startTime + ATTACK_SECONDS
+      );
+      toneGain.gain.exponentialRampToValueAtTime(MIN_GAIN, endTime);
+
+      oscillator.connect(toneGain);
+      toneGain.connect(context.destination);
+      oscillator.start(startTime);
+      oscillator.stop(endTime + STOP_PADDING_SECONDS);
+    },
+    setMuted: (value) => {
+      muted = value;
+    }
+  };
+}
+
+function createDefaultAudioContext(): AudioContextLike {
+  return new AudioContext() as unknown as AudioContextLike;
+}


### PR DESCRIPTION
## Create shared WebAudio engine that owns AudioContext, unlock, mute, and scheduling

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #428

### Changes
Create a new module src/audio/engine.ts exporting createAudioEngine() that returns an AudioEngine with the lifecycle primitives currently inlined inside createSfxController. The engine must: (1) lazily construct a single AudioContext on first arm() and memoize it, (2) expose arm(): Promise<void> that resumes a suspended context and transitions status 'idle' → 'ready' (or 'muted' on failure), (3) expose getStatus(): 'idle' | 'ready' | 'muted' reflecting both context readiness and mute state, (4) expose setMuted(muted: boolean) that flips the muted flag without tearing down the context, (5) expose a schedule primitive such as scheduleTone({ frequency, duration, gain, type, startOffset? }) that, when status==='ready', wires createOscillator → createGain → destination with the same envelope shape createSfxController currently builds, gated by a shared cooldown map keyed by caller-supplied tag, (6) expose getContext() or now(): number so callers can read AudioContext.currentTime for scheduling music bars. Do not import sfx.ts; engine must stand alone. Write src/audio/engine.test.ts using a mocked AudioContext (pattern from src/audio/sfx.test.ts) covering: arm resumes suspended contexts once, repeated arm calls reuse the context, failure paths produce 'muted' status, scheduleTone is a no-op when muted or idle, scheduleTone wires oscillator→gain→destination and applies gain ramps, cooldown suppresses rapid repeats within the window when a tag is reused.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*