### PR TITLE
bug_fix: Replace cast in SPRITE_DESCRIPTOR_REGISTRY with a typed builder

### DIFF
--- a/src/render/sprite-data/index.ts
+++ b/src/render/sprite-data/index.ts
@@ -13,8 +13,26 @@ export const SPRITE_DESCRIPTORS = [
   PLAYER_PROJECTILE_DESCRIPTOR
 ] as const satisfies readonly SpriteDescriptor[];
 
-type SpriteDescriptorId = (typeof SPRITE_DESCRIPTORS)[number]["id"];
+type SpriteDescriptorRegistry<D extends readonly { readonly id: string }[]> = {
+  readonly [K in D[number]["id"]]: Extract<D[number], { readonly id: K }>;
+};
 
-export const SPRITE_DESCRIPTOR_REGISTRY = Object.fromEntries(
-  SPRITE_DESCRIPTORS.map((descriptor) => [descriptor.id, descriptor] as const)
-) as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>;
+function buildRegistry<const D extends readonly { readonly id: string }[]>(
+  descriptors: D
+): SpriteDescriptorRegistry<D>;
+function buildRegistry(
+  descriptors: readonly { readonly id: string }[]
+): Readonly<Record<string, { readonly id: string }>> {
+  const [descriptor, ...rest] = descriptors;
+
+  if (descriptor === undefined) {
+    return {};
+  }
+
+  return {
+    [descriptor.id]: descriptor,
+    ...buildRegistry(rest)
+  };
+}
+
+export const SPRITE_DESCRIPTOR_REGISTRY = buildRegistry(SPRITE_DESCRIPTORS);


### PR DESCRIPTION
## Replace cast in SPRITE_DESCRIPTOR_REGISTRY with a typed builder

**Category:** `bug_fix` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #449

### Changes
In src/render/sprite-data/index.ts, remove the `as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>` cast on SPRITE_DESCRIPTOR_REGISTRY. Introduce a generic helper (e.g. `function buildRegistry<D extends { readonly id: string }>(descriptors: readonly D[]): { readonly [K in D['id']]: Extract<D, { id: K }> }`) that reduces SPRITE_DESCRIPTORS into a strongly-typed record whose key set is structurally derived from the descriptor tuple's literal `id` values. Use it to produce SPRITE_DESCRIPTOR_REGISTRY without any `as` assertion, without `any`, and without widening to plain `SpriteDescriptor` (values should retain their narrowed descriptor shape where practical). Keep all existing named exports and the existing value/shape observable to consumers (src/render/sprites.ts and src/render/sprites.test.ts still import SPRITE_DESCRIPTOR_REGISTRY). The helper may live inline in index.ts — do not add a new file unless necessary.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*