### PR TITLE
bug_fix: Clear fireEdge/pauseEdge/muteEdge in keyboard onBlur

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -86,6 +86,32 @@ describe("createKeyboardController", () => {
     expect(snapshot.fireHeld).toBe(false);
   });
 
+  it("clears fire, pause, and mute edges on blur before snapshot", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "Space");
+    dispatchBlur(target);
+
+    const fireSnapshot = controller.snapshot();
+
+    expect(fireSnapshot.firePressed).toBe(false);
+    expect(fireSnapshot.fireHeld).toBe(false);
+
+    dispatchKeyDown(target, "KeyP");
+    dispatchBlur(target);
+
+    const pauseSnapshot = controller.snapshot();
+
+    expect(pauseSnapshot.pausePressed).toBe(false);
+    expect(pauseSnapshot.pauseHeld).toBe(false);
+
+    dispatchKeyDown(target, "KeyM");
+    dispatchBlur(target);
+
+    expect(controller.snapshot().mutePressed).toBe(false);
+  });
+
   it("preserves fire edge tracking after blur", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);

--- a/src/input/keyboard.ts
+++ b/src/input/keyboard.ts
@@ -86,6 +86,9 @@ export function createKeyboardController(target: Window = window): KeyboardContr
     held.fire = false;
     held.pause = false;
     held.mute = false;
+    held.fireEdge = false;
+    held.pauseEdge = false;
+    held.muteEdge = false;
   };
 
   target.addEventListener("keydown", onKeyDown);


### PR DESCRIPTION
## Clear fireEdge/pauseEdge/muteEdge in keyboard onBlur

**Category:** `bug_fix` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #483

### Changes
In src/input/keyboard.ts, the onBlur handler resets held.left/right/fire/pause/mute but leaves held.fireEdge/pauseEdge/muteEdge set. If a user presses Space/P/M and then the window blurs (e.g. Alt-Tab) before the next snapshot() runs, the stale edge flag is delivered on the next snapshot after refocus, producing phantom firePressed/pausePressed/mutePressed. Update the onBlur (or equivalent blur cleanup) path to also set fireEdge, pauseEdge, and muteEdge to false alongside the held booleans. Add a test case to src/input/keyboard.test.ts that dispatches a keydown (e.g. Space) to the controller target, then dispatches a blur event, then calls snapshot() and asserts that the resulting Input has no firePressed/fireHeld (and similarly cover pause and mute edges — one assertion per edge is fine, either in one test or three). The existing ArrowLeft blur test in keyboard.test.ts is a good template for event plumbing.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*