### PR TITLE
bug_fix: Remove beforeunload listener in bootstrap dispose

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -14,6 +14,11 @@ type HarnessOptions = {
   initialState?: GameState;
   step?: (state: GameState, dtMs: number, input: Input) => GameState;
 };
+type ListenerRecord = {
+  listener: EventListenerOrEventListenerObject | null;
+  type: string;
+};
+
 class FakeStorage implements Storage {
   private readonly entries = new Map<string, string>();
   constructor(seed: Record<string, string>) { for (const [key, value] of Object.entries(seed)) this.entries.set(key, value); }
@@ -24,6 +29,20 @@ class FakeStorage implements Storage {
   removeItem(key: string): void { this.entries.delete(key); }
   setItem(key: string, value: string): void { this.entries.set(key, value); }
 }
+
+class FakeBeforeUnloadTarget {
+  readonly addedListeners: ListenerRecord[] = [];
+  readonly removedListeners: ListenerRecord[] = [];
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    this.addedListeners.push({ type, listener });
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    this.removedListeners.push({ type, listener });
+  }
+}
+
 function createInput(input: Partial<Input> = {}): Input { return { ...EMPTY_INPUT, ...input }; }
 function createHarness(options: HarnessOptions = {}) {
   const storage = new FakeStorage({
@@ -56,7 +75,7 @@ function createHarness(options: HarnessOptions = {}) {
     options.step ??
     ((state: GameState, dtMs: number, input: Input) => { void dtMs; void input; return state; });
   bootstrap({
-    beforeUnloadTarget: { addEventListener: () => {} },
+    beforeUnloadTarget: { addEventListener: () => {}, removeEventListener: () => {} },
     createLoop: (config) => { loop = config; return { start: () => {}, stop: () => {} }; },
     createVisibilityPauseController: ({ onHide: hide }) => { onHide = hide; return { dispose: () => {} }; },
     deriveSfxEvents: options.deriveSfxEvents ?? (() => []),
@@ -164,5 +183,39 @@ describe("bootstrap", () => {
   });
   it("throws when the game canvas is missing", () => {
     expect(() => bootstrap({ findCanvas: () => null })).toThrowError("Game canvas not found.");
+  });
+
+  it("removes the beforeunload listener when disposed", () => {
+    const beforeUnloadTarget = new FakeBeforeUnloadTarget();
+    const { dispose } = bootstrap({
+      beforeUnloadTarget: beforeUnloadTarget as Pick<
+        Window,
+        "addEventListener" | "removeEventListener"
+      >,
+      createLoop: () => ({ start: () => {}, stop: () => {} }),
+      createVisibilityPauseController: () => ({ dispose: () => {} }),
+      findCanvas: () => document.createElement("canvas"),
+      isHidden: () => false,
+      keyboard: { dispose: () => {}, snapshot: () => EMPTY_INPUT },
+      renderer: { render: () => {} },
+      sfx: {
+        arm: async () => {},
+        getStatus: () => "idle",
+        play: () => {},
+        setMuted: () => {}
+      },
+      visibilityTarget: { addEventListener: () => {}, removeEventListener: () => {} }
+    });
+
+    dispose();
+    dispose();
+
+    expect(beforeUnloadTarget.addedListeners).toHaveLength(1);
+    expect(beforeUnloadTarget.removedListeners).toHaveLength(1);
+    expect(beforeUnloadTarget.addedListeners[0]?.type).toBe("beforeunload");
+    expect(beforeUnloadTarget.removedListeners[0]?.type).toBe("beforeunload");
+    expect(beforeUnloadTarget.removedListeners[0]?.listener).toBe(
+      beforeUnloadTarget.addedListeners[0]?.listener
+    );
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ type KeyboardController = ReturnType<typeof createKeyboardController>;
 
 export function bootstrap(
   options: {
-    beforeUnloadTarget?: Pick<Window, "addEventListener">;
+    beforeUnloadTarget?: Pick<Window, "addEventListener" | "removeEventListener">;
     createLoop?: typeof createFixedStepLoop;
     createVisibilityPauseController?: typeof createVisibilityPauseController;
     deriveSfxEvents?: typeof deriveSfxEvents;
@@ -160,13 +160,26 @@ export function bootstrap(
     isHidden: resolveHidden
   });
 
-  const dispose = (): void => {
+  let disposed = false;
+  let dispose = (): void => {};
+
+  const onBeforeUnload = (): void => {
+    dispose();
+  };
+
+  dispose = (): void => {
+    if (disposed) {
+      return;
+    }
+
+    disposed = true;
+    beforeUnloadTarget.removeEventListener("beforeunload", onBeforeUnload);
     loop.stop();
     keyboard.dispose();
     visibilityPauseController.dispose();
   };
 
-  beforeUnloadTarget.addEventListener("beforeunload", dispose);
+  beforeUnloadTarget.addEventListener("beforeunload", onBeforeUnload);
   loop.start();
 
   return {


### PR DESCRIPTION
## Remove beforeunload listener in bootstrap dispose

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #482

### Changes
In src/main.ts, the bootstrap() function registers `beforeUnloadTarget.addEventListener("beforeunload", dispose)` but the returned dispose() only stops the loop and disposes keyboard + visibility controllers — the beforeunload listener is never removed, leaking listeners across repeated bootstrap() calls (notably in tests). Fix: capture the handler in a variable (e.g. `const onBeforeUnload = () => dispose();` or bind the dispose reference before registration) and call `beforeUnloadTarget.removeEventListener("beforeunload", onBeforeUnload)` inside dispose(). Make dispose idempotent so the removal does not trigger re-entry. Then extend src/main.test.ts: add a test using a fake beforeunload target (an EventTarget subclass or a record-based stub similar to FakeVisibilityTarget in src/visibility.test.ts) that records addEventListener/removeEventListener calls, bootstrap with that target injected, manually call the returned dispose(), and assert the target recorded a matching removeEventListener("beforeunload", …) call for the same handler that was added. If the bootstrap options do not already accept an injectable beforeUnloadTarget, add one (mirroring how document/window targets are injected for visibility/keyboard) so the test can observe add/remove without touching the real window.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*