### PR TITLE
type: Make fireHeld/pauseHeld/mutePressed required on Input

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -10,9 +10,9 @@ export type Input = {
   moveX: -1 | 0 | 1;
   firePressed: boolean;
   pausePressed: boolean;
-  fireHeld?: boolean;
-  pauseHeld?: boolean;
-  mutePressed?: boolean;
+  fireHeld: boolean;
+  pauseHeld: boolean;
+  mutePressed: boolean;
 };
 
 export type Arena = {

--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -732,7 +732,11 @@ describe("step", () => {
   it("keeps the paused state frozen without resume input", () => {
     const state = createGameState({ phase: "paused", score: 55, lives: 2 });
 
-    const next = step(state, 200, { moveX: 1, firePressed: true, pausePressed: false });
+    const next = step(state, 200, {
+      ...EMPTY_INPUT,
+      moveX: 1,
+      firePressed: true
+    });
 
     expect(next).toEqual(state);
   });
@@ -924,6 +928,7 @@ describe("step", () => {
     };
 
     const next = step(lifeLost, 100, {
+      ...EMPTY_INPUT,
       moveX: 1,
       firePressed: true,
       pausePressed: true

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -99,9 +99,9 @@ function hasObservedUserInput(input: Input): boolean {
     input.moveX !== 0 ||
     input.firePressed ||
     input.pausePressed ||
-    input.fireHeld === true ||
-    input.pauseHeld === true ||
-    input.mutePressed === true
+    input.fireHeld ||
+    input.pauseHeld ||
+    input.mutePressed
   );
 }
 


### PR DESCRIPTION
## Make fireHeld/pauseHeld/mutePressed required on Input

**Category:** `type` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #457

### Changes
Tighten the Input contract so optional flags that are always populated in practice become required. Changes: (1) In `src/game/state.ts`, change the `Input` type to drop the `?` from `fireHeld`, `pauseHeld`, and `mutePressed` — all three become `boolean`. (2) Update the `EMPTY_INPUT` constant in `src/game/state.ts` so it explicitly sets `fireHeld: false`, `pauseHeld: false`, and `mutePressed: false`. (3) In `src/runtime.ts`, simplify the defensive `input.fireHeld === true` / `input.pauseHeld === true` / `input.mutePressed === true` comparisons inside `hasObservedUserInput` (and any similar call sites) to plain truthy reads like `input.fireHeld`. (4) Verify `createKeyboardController` in `src/input/keyboard.ts` already sets all three fields on every snapshot — if any code path does not, populate it explicitly with `false`. Do NOT modify keyboard.ts if snapshots already emit all three. If typecheck exposes raw `Input` literals in `src/game/step.test.ts`, update only those literals by spreading `EMPTY_INPUT` before the test-specific overrides. Do NOT alter runtime behavior — this is a types-only / dead-comparison cleanup. Run typecheck, full test suite, and lint on the modified files to confirm nothing regresses.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*