### PR TITLE
bug_fix: Replace cast in SPRITE_DESCRIPTOR_REGISTRY with a typed builder

### DIFF
--- a/src/render/sprite-data/index.ts
+++ b/src/render/sprite-data/index.ts
@@ -7,14 +7,39 @@ export { INVADER_ROW_DESCRIPTORS } from "./invaders";
 export { PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
 export { PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
 
+function hasDescriptorId<const Id extends string, D extends SpriteDescriptor>(
+  descriptor: D,
+  id: Id
+): descriptor is D & { readonly id: Id } {
+  return descriptor.id === id;
+}
+
+function expectDescriptorId<const Id extends string, D extends SpriteDescriptor>(
+  descriptor: D,
+  id: Id
+): D & { readonly id: Id } {
+  if (!hasDescriptorId(descriptor, id)) {
+    throw new Error(`Expected sprite descriptor "${id}".`);
+  }
+
+  return descriptor;
+}
+
+function buildRegistry<const D extends { readonly id: string }>(
+  descriptors: readonly D[]
+): { readonly [K in D["id"]]: Extract<D, { readonly id: K }> };
+function buildRegistry(
+  descriptors: readonly { readonly id: string }[]
+): Readonly<Record<string, { readonly id: string }>> {
+  return Object.fromEntries(
+    descriptors.map((descriptor) => [descriptor.id, descriptor] as const)
+  );
+}
+
 export const SPRITE_DESCRIPTORS = [
-  PLAYER_SHIP_DESCRIPTOR,
+  expectDescriptorId(PLAYER_SHIP_DESCRIPTOR, "player-ship"),
   ...INVADER_ROW_DESCRIPTORS,
-  PLAYER_PROJECTILE_DESCRIPTOR
+  expectDescriptorId(PLAYER_PROJECTILE_DESCRIPTOR, "player-projectile")
 ] as const satisfies readonly SpriteDescriptor[];
 
-type SpriteDescriptorId = (typeof SPRITE_DESCRIPTORS)[number]["id"];
-
-export const SPRITE_DESCRIPTOR_REGISTRY = Object.fromEntries(
-  SPRITE_DESCRIPTORS.map((descriptor) => [descriptor.id, descriptor] as const)
-) as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>;
+export const SPRITE_DESCRIPTOR_REGISTRY = buildRegistry(SPRITE_DESCRIPTORS);


### PR DESCRIPTION
## Replace cast in SPRITE_DESCRIPTOR_REGISTRY with a typed builder

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #449

### Changes
In src/render/sprite-data/index.ts, remove the `as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>` cast on SPRITE_DESCRIPTOR_REGISTRY. Introduce a generic helper (e.g. `function buildRegistry<D extends { readonly id: string }>(descriptors: readonly D[]): { readonly [K in D['id']]: Extract<D, { id: K }> }`) that reduces SPRITE_DESCRIPTORS into a strongly-typed record whose key set is structurally derived from the descriptor tuple's literal `id` values. Use it to produce SPRITE_DESCRIPTOR_REGISTRY without any `as` assertion, without `any`, and without widening to plain `SpriteDescriptor` (values should retain their narrowed descriptor shape where practical). Keep all existing named exports and the existing value/shape observable to consumers (src/render/sprites.ts and src/render/sprites.test.ts still import SPRITE_DESCRIPTOR_REGISTRY). The helper may live inline in index.ts — do not add a new file unless necessary.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*