### PR TITLE
test: Add shield collision test cases to step.test.ts

### DIFF
--- a/src/game/step.test.ts
+++ b/src/game/step.test.ts
@@ -89,16 +89,21 @@ function createShieldProjectile(
   row: number,
   col: number,
   id: number,
-  velocityY: number
+  velocityY: number,
+  owner: "player" | "invader" = "player"
 ) {
   const cell = getShieldCell(state, 0, row, col);
+  const width =
+    owner === "player" ? PROJECTILE_WIDTH : INVADER_PROJECTILE_WIDTH;
+  const height =
+    owner === "player" ? PROJECTILE_HEIGHT : INVADER_PROJECTILE_HEIGHT;
   return {
     id,
-    owner: "player" as const,
-    x: cell.x + (cell.width - PROJECTILE_WIDTH) / 2,
-    y: velocityY < 0 ? cell.y + cell.height + 4 : cell.y - PROJECTILE_HEIGHT - 4,
-    width: PROJECTILE_WIDTH,
-    height: PROJECTILE_HEIGHT,
+    owner,
+    x: cell.x + (cell.width - width) / 2,
+    y: velocityY < 0 ? cell.y + cell.height + 4 : cell.y - height - 4,
+    width,
+    height,
     velocityY,
     active: true
   };
@@ -283,6 +288,114 @@ describe("step", () => {
     expect(next.state.projectiles).toHaveLength(0);
     expect(getShieldCell(next.state, 0, targetRow, targetCol).alive).toBe(false);
     expect(countAliveShieldCells(next.state)).toBe(countAliveShieldCells(base) - 1);
+  });
+
+  describe("shield collisions", () => {
+    it("removes a player projectile that strikes a live shield cell", () => {
+      const targetRow = SHIELD_CELL_ROWS - 1;
+      const targetCol = 2;
+      const base = createPlayingState();
+      const state = {
+        ...base,
+        projectiles: [createShieldProjectile(base, targetRow, targetCol, 1, PROJECTILE_SPEED)],
+        nextProjectileId: 2
+      };
+
+      const next = step(state, SHIELD_HIT_DT_MS, EMPTY_INPUT);
+
+      expect(getShieldCell(next, 0, targetRow, targetCol).alive).toBe(false);
+      expect(next.projectiles).toHaveLength(0);
+    });
+
+    it("removes an invader projectile that strikes a live shield cell", () => {
+      const targetRow = 0;
+      const targetCol = 2;
+      const base = createPlayingState();
+      const state = {
+        ...base,
+        projectiles: [
+          createShieldProjectile(
+            base,
+            targetRow,
+            targetCol,
+            1,
+            INVADER_PROJECTILE_SPEED,
+            "invader"
+          )
+        ],
+        nextProjectileId: 2
+      };
+
+      const next = step(state, SHIELD_HIT_DT_MS, EMPTY_INPUT);
+
+      expect(getShieldCell(next, 0, targetRow, targetCol).alive).toBe(false);
+      expect(next.projectiles).toHaveLength(0);
+    });
+
+    it("lets a second projectile pass through a shield cell that was already destroyed", () => {
+      const targetRow = SHIELD_CELL_ROWS - 1;
+      const targetCol = 2;
+      const base = createPlayingState();
+      const afterFirstHit = step(
+        {
+          ...base,
+          projectiles: [createShieldProjectile(base, targetRow, targetCol, 1, PROJECTILE_SPEED)],
+          nextProjectileId: 2
+        },
+        SHIELD_HIT_DT_MS,
+        EMPTY_INPUT
+      );
+      const secondProjectile = createShieldProjectile(
+        afterFirstHit,
+        targetRow,
+        targetCol,
+        2,
+        PROJECTILE_SPEED
+      );
+
+      const next = step(
+        {
+          ...afterFirstHit,
+          projectiles: [secondProjectile],
+          nextProjectileId: 3
+        },
+        SHIELD_HIT_DT_MS,
+        EMPTY_INPUT
+      );
+
+      expect(getShieldCell(next, 0, targetRow, targetCol).alive).toBe(false);
+      expect(countAliveShieldCells(next)).toBe(countAliveShieldCells(afterFirstHit));
+      expect(next.projectiles[0]?.id).toBe(secondProjectile.id);
+    });
+
+    it("does not consume a player projectile that passes through a dead shield cell", () => {
+      const targetRow = SHIELD_CELL_ROWS - 1;
+      const targetCol = 2;
+      const base = createPlayingState();
+      const cell = getShieldCell(base, 0, targetRow, targetCol);
+      const stateWithDeadCell = setShieldCellAlive(base, cell.id, false);
+      const projectile = createShieldProjectile(
+        stateWithDeadCell,
+        targetRow,
+        targetCol,
+        1,
+        PROJECTILE_SPEED
+      );
+
+      const next = step(
+        {
+          ...stateWithDeadCell,
+          projectiles: [projectile],
+          nextProjectileId: 2
+        },
+        SHIELD_HIT_DT_MS,
+        EMPTY_INPUT
+      );
+
+      expect(getShieldCell(next, 0, targetRow, targetCol).alive).toBe(false);
+      expect(countAliveShieldCells(next)).toBe(countAliveShieldCells(stateWithDeadCell));
+      expect(next.projectiles[0]?.id).toBe(projectile.id);
+    });
   });
 
   it("lets a projectile continue through a dead shield-cell gap", () => {


### PR DESCRIPTION
## Add shield collision test cases to step.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #504

### Changes
Extend the existing Vitest suite in src/game/step.test.ts with four new focused cases covering shield collisions against the pure step() function. Read src/game/state.ts and src/game/step.ts first to understand the current Shield representation (SHIELD_COUNT, SHIELD_CELL_COLS, SHIELD_CELL_ROWS, shield cell geometry on GameState) and how shield hits are processed (the existing 'shieldHit' StepEvent and SHIELD_HIT_DT_MS helper already present in the test file). Then add tests for: (1) a player projectile positioned to strike a live shield cell: after one or more sub-steps sufficient to cause collision, the struck cell is deactivated and the player projectile is removed from state.projectiles; (2) an invader projectile positioned to strike a live shield cell: after stepping, that cell is deactivated and the invader projectile is removed; (3) a shield absorbs one hit but a second projectile fired at the same column passes through the now-dead cell — i.e., after the first projectile deactivates a cell, a second projectile aligned to that same dead cell is not stopped by it (it either continues past or hits the next live cell behind/below, per current step() semantics); (4) a player projectile passing through coordinates of an already-dead shield cell does not change that cell's state (it remains inactive) and the projectile is not consumed by the dead cell. Use createPlayingState / createGameState helpers already present, construct projectiles using the existing state helpers or by directly appending to state.projectiles the same way other tests in this file do, and reuse the existing step(state, dt, input) wrapper and SHIELD_HIT_DT_MS constant. Keep assertions narrow and use `expect` matchers consistent with the rest of the file. Do not modify src/game/step.ts or src/game/state.ts — these tests must pass against the current implementation; if a case cannot pass against current behavior, skip that case and note the other three still apply.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*