### PR TITLE
bug_fix: Replace cast in SPRITE_DESCRIPTOR_REGISTRY with a typed builder

### DIFF
--- a/src/render/sprite-data/index.ts
+++ b/src/render/sprite-data/index.ts
@@ -1,11 +1,23 @@
 import type { SpriteDescriptor } from "../sprites";
 import { INVADER_ROW_DESCRIPTORS } from "./invaders";
-import { PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
-import { PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
+import { PLAYER_SHIP_DESCRIPTOR as SOURCE_PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
+import { PLAYER_PROJECTILE_DESCRIPTOR as SOURCE_PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
 
-export { INVADER_ROW_DESCRIPTORS } from "./invaders";
-export { PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
-export { PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
+export { INVADER_ROW_DESCRIPTORS };
+
+export const PLAYER_SHIP_DESCRIPTOR = {
+  id: "player-ship",
+  frames: SOURCE_PLAYER_SHIP_DESCRIPTOR.frames,
+  palette: SOURCE_PLAYER_SHIP_DESCRIPTOR.palette,
+  pixelSize: SOURCE_PLAYER_SHIP_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
+
+export const PLAYER_PROJECTILE_DESCRIPTOR = {
+  id: "player-projectile",
+  frames: SOURCE_PLAYER_PROJECTILE_DESCRIPTOR.frames,
+  palette: SOURCE_PLAYER_PROJECTILE_DESCRIPTOR.palette,
+  pixelSize: SOURCE_PLAYER_PROJECTILE_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
 
 export const SPRITE_DESCRIPTORS = [
   PLAYER_SHIP_DESCRIPTOR,
@@ -13,8 +25,31 @@ export const SPRITE_DESCRIPTORS = [
   PLAYER_PROJECTILE_DESCRIPTOR
 ] as const satisfies readonly SpriteDescriptor[];
 
-type SpriteDescriptorId = (typeof SPRITE_DESCRIPTORS)[number]["id"];
+type SpriteDescriptorRegistry<
+  TDescriptors extends readonly SpriteDescriptor[]
+> = {
+  readonly [TDescriptor in TDescriptors[number] as TDescriptor["id"]]: TDescriptor;
+};
 
-export const SPRITE_DESCRIPTOR_REGISTRY = Object.fromEntries(
-  SPRITE_DESCRIPTORS.map((descriptor) => [descriptor.id, descriptor] as const)
-) as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>;
+function buildSpriteDescriptorRegistry<
+  const TDescriptors extends readonly SpriteDescriptor[]
+>(
+  descriptors: TDescriptors,
+  registry: SpriteDescriptorRegistry<TDescriptors>
+): SpriteDescriptorRegistry<TDescriptors> {
+  void descriptors;
+  return registry;
+}
+
+export const SPRITE_DESCRIPTOR_REGISTRY = buildSpriteDescriptorRegistry(
+  SPRITE_DESCRIPTORS,
+  {
+    "player-ship": PLAYER_SHIP_DESCRIPTOR,
+    "invader-row-0": INVADER_ROW_DESCRIPTORS[0],
+    "invader-row-1": INVADER_ROW_DESCRIPTORS[1],
+    "invader-row-2": INVADER_ROW_DESCRIPTORS[2],
+    "invader-row-3": INVADER_ROW_DESCRIPTORS[3],
+    "invader-row-4": INVADER_ROW_DESCRIPTORS[4],
+    "player-projectile": PLAYER_PROJECTILE_DESCRIPTOR
+  }
+);


### PR DESCRIPTION
## Replace cast in SPRITE_DESCRIPTOR_REGISTRY with a typed builder

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #449

### Changes
In `src/render/sprite-data/index.ts`, remove the broad exported `as Readonly<Record<SpriteDescriptorId, SpriteDescriptor>>` cast on `SPRITE_DESCRIPTOR_REGISTRY` and replace it with a type-checked registry construction whose keys are derived from `SPRITE_DESCRIPTORS` literal ids. Do not use dynamic accumulator assignment or helper return assertions. The two singleton descriptors imported from `player-ship.ts` and `projectiles.ts` are widened by `satisfies SpriteDescriptor`; re-establish literal ids in this file by creating shallow descriptor values with explicit `id: "player-ship"` / `id: "player-projectile"` and `as const satisfies SpriteDescriptor`, reusing the imported frames/palette/pixelSize values. Then use a generic helper that accepts `SPRITE_DESCRIPTORS` plus an explicit registry object and type-checks exact key coverage/value-id matching. Keep all existing named exports and runtime sprite data equivalent to current consumers; only the type construction in this file should change.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*