### PR TITLE
feature: Expose StepResult.events from createGameRuntime

### DIFF
--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -4,6 +4,14 @@ import { deriveSfxEvents } from "./audio/events";
 import type { SfxName } from "./audio/sfx";
 import {
   EMPTY_INPUT,
+  INVADER_PROJECTILE_HEIGHT,
+  INVADER_PROJECTILE_SPEED,
+  INVADER_PROJECTILE_WIDTH,
+  PROJECTILE_HEIGHT,
+  PROJECTILE_SPEED,
+  PROJECTILE_WIDTH,
+  SHIELD_CELL_COLS,
+  SHIELD_CELL_ROWS,
   createInitialGameState,
   createPlayerProjectile,
   createPlayingState,
@@ -12,7 +20,10 @@ import {
   type GameState,
   type Input
 } from "./game/state";
+import { step as stepWithEvents, type StepEvent, type StepResult } from "./game/step";
 import { createGameRuntime, type GameRuntime } from "./runtime";
+
+const SHIELD_HIT_DT_MS = 21;
 
 class FakeSfxController {
   public armCalls = 0;
@@ -76,6 +87,7 @@ type RuntimeHarness = {
   queueInput: (input?: Partial<Input>) => void;
   runtime: GameRuntime;
   sfxController: FakeSfxController;
+  stepEventCalls: StepEvent[][];
   stepCalls: Array<{ dtMs: number; input: Input }>;
   writeHighScoreCalls: number[];
   muteStore: FakeMuteStore;
@@ -89,13 +101,15 @@ type RuntimeHarnessOptions = {
   initialHighScore?: number;
   initialMuted?: boolean;
   initialState?: GameState;
-  step?: (state: GameState, dtMs: number, input: Input) => GameState;
+  onStepEvents?: (events: readonly StepEvent[]) => void;
+  step?: (state: GameState, dtMs: number, input: Input) => GameState | StepResult;
 };
 
 function createHarness(options: RuntimeHarnessOptions = {}): RuntimeHarness {
   const sfxController = new FakeSfxController();
   const muteStore = new FakeMuteStore(options.initialMuted);
   const highScoreWriter = new FakeHighScoreWriter(options.initialHighScore);
+  const stepEventCalls: StepEvent[][] = [];
   const stepCalls: Array<{ dtMs: number; input: Input }> = [];
   let queuedInput = createInput();
 
@@ -103,6 +117,11 @@ function createHarness(options: RuntimeHarnessOptions = {}): RuntimeHarness {
     deriveSfxEvents: options.deriveEvents ?? (() => []),
     initialState: options.initialState ?? createInitialGameState(),
     muteStore,
+    onStepEvents: (events) => {
+      const snapshot = [...events];
+      stepEventCalls.push(snapshot);
+      options.onStepEvents?.(snapshot);
+    },
     readHighScore: () => highScoreWriter.readHighScore(),
     readInput: () => {
       const snapshot = queuedInput;
@@ -124,6 +143,7 @@ function createHarness(options: RuntimeHarnessOptions = {}): RuntimeHarness {
     },
     runtime,
     sfxController,
+    stepEventCalls,
     stepCalls,
     writeHighScoreCalls: highScoreWriter.writeCalls,
     muteStore
@@ -148,6 +168,52 @@ function withPlayerProjectileCount(state: GameState, count: number): GameState {
       ),
       id: index + 1
     }))
+  };
+}
+
+function getShieldCell(state: GameState, shieldIndex: number, row: number, col: number) {
+  const cell = state.shields[shieldIndex]?.cells[row * SHIELD_CELL_COLS + col];
+  if (cell === undefined) {
+    throw new Error(`Missing shield cell ${shieldIndex}:${row},${col}`);
+  }
+
+  return cell;
+}
+
+function createShieldProjectile(
+  state: GameState,
+  row: number,
+  col: number,
+  id: number,
+  velocityY: number
+) {
+  const cell = getShieldCell(state, 0, row, col);
+
+  return {
+    id,
+    owner: "player" as const,
+    x: cell.x + (cell.width - PROJECTILE_WIDTH) / 2,
+    y: velocityY < 0 ? cell.y + cell.height + 4 : cell.y - PROJECTILE_HEIGHT - 4,
+    width: PROJECTILE_WIDTH,
+    height: PROJECTILE_HEIGHT,
+    velocityY,
+    active: true
+  };
+}
+
+function createInvaderTestProjectile(
+  state: GameState,
+  y = state.player.y - INVADER_PROJECTILE_HEIGHT
+) {
+  return {
+    id: 1,
+    owner: "invader" as const,
+    x: state.player.x + (state.player.width - INVADER_PROJECTILE_WIDTH) / 2,
+    y,
+    width: INVADER_PROJECTILE_WIDTH,
+    height: INVADER_PROJECTILE_HEIGHT,
+    velocityY: INVADER_PROJECTILE_SPEED,
+    active: true
   };
 }
 
@@ -299,5 +365,111 @@ describe("createGameRuntime", () => {
       false
     ]);
     expect(harness.sfxController.playCalls).toEqual(["shoot", "hit"]);
+  });
+
+  it("forwards step events in tick order and clears them between ticks", () => {
+    const playerShotState = createPlayingState();
+    const shieldHitState = createPlayingState();
+    const shieldHitRow = SHIELD_CELL_ROWS - 1;
+    const shieldHitCol = 2;
+    const shieldHitSource = {
+      ...shieldHitState,
+      projectiles: [
+        createShieldProjectile(
+          shieldHitState,
+          shieldHitRow,
+          shieldHitCol,
+          1,
+          PROJECTILE_SPEED
+        )
+      ],
+      nextProjectileId: 2
+    };
+    const waveClearBase = createPlayingState();
+    const waveClearInvader = waveClearBase.invaders[0];
+    if (waveClearInvader === undefined) {
+      throw new Error("Missing invader for wave-clear test.");
+    }
+    const waveClearSource = {
+      ...waveClearBase,
+      invaders: [waveClearInvader],
+      projectiles: [
+        {
+          id: 1,
+          owner: "player" as const,
+          x: waveClearInvader.x,
+          y: waveClearInvader.y,
+          width: waveClearInvader.width,
+          height: waveClearInvader.height,
+          velocityY: 0,
+          active: true
+        }
+      ],
+      nextProjectileId: 2,
+      invaderFireCooldownMs: 0
+    };
+    const lifeLostBase = createPlayingState();
+    const lifeLostSource = {
+      ...lifeLostBase,
+      projectiles: [createInvaderTestProjectile(lifeLostBase)],
+      invaderFireCooldownMs: 0
+    };
+    const scriptedStates = [
+      playerShotState,
+      shieldHitSource,
+      waveClearSource,
+      lifeLostSource,
+      createPlayingState()
+    ] satisfies GameState[];
+    let stepIndex = 0;
+    const harness = createHarness({
+      step: (_state, dtMs, input) => {
+        const sourceState = scriptedStates[stepIndex];
+        if (sourceState === undefined) {
+          throw new Error(`Unexpected step index ${stepIndex}.`);
+        }
+
+        stepIndex += 1;
+        return stepWithEvents(sourceState, dtMs, input);
+      }
+    });
+
+    harness.queueInput({ firePressed: true });
+    harness.runtime.onRender();
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+
+    harness.runtime.onRender();
+    harness.runtime.onStep({ dtMs: SHIELD_HIT_DT_MS, firstStepOfFrame: true });
+
+    harness.runtime.onRender();
+    harness.runtime.onStep({ dtMs: 0, firstStepOfFrame: true });
+
+    harness.runtime.onRender();
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+
+    harness.runtime.onRender();
+    harness.runtime.onStep({ dtMs: 16, firstStepOfFrame: true });
+
+    expect(harness.stepEventCalls).toEqual([
+      [{ type: "playerShot" }],
+      [
+        {
+          type: "shieldHit",
+          shieldIndex: 0,
+          row: shieldHitRow,
+          col: shieldHitCol
+        }
+      ],
+      [
+        {
+          type: "invaderHit",
+          invaderId: waveClearInvader.id,
+          points: waveClearInvader.points
+        },
+        { type: "waveClear" }
+      ],
+      [{ type: "lifeLost" }],
+      []
+    ]);
   });
 });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,7 @@
 import type { MuteStore } from "./audio/mute";
 import type { SfxController, SfxName } from "./audio/sfx";
 import type { GameState, Input } from "./game/state";
+import type { StepEvent, StepResult } from "./game/step";
 import type { FixedStepLoopStepInput } from "./loop/fixedStep";
 
 export type GameRuntime = {
@@ -19,10 +20,11 @@ export type GameRuntimeOptions = {
   ) => readonly SfxName[];
   initialState: GameState;
   muteStore: Pick<MuteStore, "isMuted" | "toggle">;
+  onStepEvents?: (events: readonly StepEvent[]) => void;
   readHighScore: () => number;
   readInput: () => Input;
   sfxController: Pick<SfxController, "arm" | "play" | "setMuted">;
-  step: (state: GameState, dtMs: number, input: Input) => GameState;
+  step: (state: GameState, dtMs: number, input: Input) => GameState | StepResult;
   writeHighScore: (score: number) => void;
 };
 
@@ -30,6 +32,7 @@ export function createGameRuntime({
   deriveSfxEvents,
   initialState,
   muteStore,
+  onStepEvents,
   readHighScore,
   readInput,
   sfxController,
@@ -71,9 +74,12 @@ export function createGameRuntime({
     onStep: ({ dtMs, firstStepOfFrame }) => {
       const previousState = state;
       const stepInput = firstStepOfFrame ? frameInput : clearEdgeInput(frameInput);
+      const stepResult = step(state, dtMs, stepInput);
+      const stepEvents = getStepEvents(stepResult);
 
-      state = step(state, dtMs, stepInput);
+      state = getStepState(stepResult);
       maybeRecordHighScore(previousState, state, writeHighScore);
+      onStepEvents?.(stepEvents);
 
       for (const event of deriveSfxEvents(previousState, state)) {
         sfxController.play(event);
@@ -115,4 +121,16 @@ function maybeRecordHighScore(
   }
 
   writeHighScore(nextState.hud.score);
+}
+
+function getStepEvents(result: GameState | StepResult): readonly StepEvent[] {
+  return isStepResult(result) ? result.events : [];
+}
+
+function getStepState(result: GameState | StepResult): GameState {
+  return isStepResult(result) ? result.state : result;
+}
+
+function isStepResult(result: GameState | StepResult): result is StepResult {
+  return "state" in result && "events" in result;
 }


### PR DESCRIPTION
## Expose StepResult.events from createGameRuntime

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #494

### Changes
Currently `createGameRuntime` calls `step(state, dt, input)` and discards the `events` array it already returns, forcing consumers like audio to re-derive effects via state diffing. Update `src/runtime.ts` so the runtime captures the `StepResult.events` each tick and exposes them to callers — either by passing them into the existing step/render callback, by accumulating them onto a per-frame field readable by the bootstrap, or by adding a new `onStepEvents(events)` hook on the runtime API. Pick whichever shape cleanly fits the existing runtime signature (do not redesign the whole API). Update `src/runtime.test.ts` to cover the new surface: at minimum assert that events produced by `step()` (e.g. `playerShot`, `invaderHit`, `shieldHit`, `lifeLost`, `waveClear`) flow through to the exposed hook/field in tick order and are cleared between ticks so callers do not see stale data. Do not modify `src/main.ts`, `src/audio/events.ts`, or `src/game/step.ts` in this task — a separate queued task owns rerouting audio/high-score through the event stream. Preserve all existing runtime behavior and callback contracts for state/render so other tests continue to pass.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*