### PR TITLE
feature: Introduce typed game events module and route audio + high-score through it

### DIFF
--- a/src/audio/events.ts
+++ b/src/audio/events.ts
@@ -1,3 +1,4 @@
+import { deriveGameEvents, type GameEvent } from "../game/events";
 import type { GameState } from "../game/state";
 
 import type { SfxName } from "./sfx";
@@ -6,35 +7,36 @@ export function deriveSfxEvents(
   previousState: GameState,
   nextState: GameState
 ): SfxName[] {
-  const events: SfxName[] = [];
-
-  if (countPlayerProjectiles(nextState) > countPlayerProjectiles(previousState)) {
-    events.push("shoot");
-  }
-
-  if (nextState.invaders.length < previousState.invaders.length) {
-    events.push("hit");
-  }
-
-  if (previousState.phase !== "lifeLost" && nextState.phase === "lifeLost") {
-    events.push("playerDeath");
-  }
-
-  if (previousState.phase !== "waveClear" && nextState.phase === "waveClear") {
-    events.push("waveClear");
-  }
-
-  return events;
+  return mapGameEventsToSfxEvents(deriveGameEvents(previousState, nextState));
 }
 
-function countPlayerProjectiles(state: GameState): number {
-  let count = 0;
+export function mapGameEventsToSfxEvents(
+  events: readonly GameEvent[]
+): SfxName[] {
+  const sfxEvents: SfxName[] = [];
+  let emittedHit = false;
 
-  for (const projectile of state.projectiles) {
-    if (projectile.owner === "player") {
-      count += 1;
+  for (const event of events) {
+    switch (event.type) {
+      case "playerShot":
+        sfxEvents.push("shoot");
+        break;
+      case "invaderHit":
+        if (!emittedHit) {
+          sfxEvents.push("hit");
+          emittedHit = true;
+        }
+        break;
+      case "lifeLost":
+        sfxEvents.push("playerDeath");
+        break;
+      case "waveClear":
+        sfxEvents.push("waveClear");
+        break;
+      case "scoreChanged":
+        break;
     }
   }
 
-  return count;
+  return sfxEvents;
 }

--- a/src/game/events.test.ts
+++ b/src/game/events.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMPTY_INPUT,
+  createInvaderProjectile,
+  createPlayingState,
+  type GameState
+} from "./state";
+import { deriveGameEvents } from "./events";
+import { step } from "./step";
+
+function withProjectiles(
+  state: GameState,
+  projectiles: GameState["projectiles"]
+): GameState {
+  return {
+    ...state,
+    projectiles
+  };
+}
+
+describe("deriveGameEvents", () => {
+  it("emits playerShot for a real firing transition", () => {
+    const previousState = createPlayingState();
+    const nextState = step(previousState, 16, {
+      ...EMPTY_INPUT,
+      firePressed: true
+    }).state;
+
+    expect(deriveGameEvents(previousState, nextState)).toEqual([
+      { type: "playerShot" }
+    ]);
+  });
+
+  it("does not emit playerShot when only an invader projectile spawns", () => {
+    const previousState = createPlayingState({ nextProjectileId: 1 });
+    const invader = previousState.invaders[0];
+
+    if (invader === undefined) {
+      throw new Error("Expected an invader.");
+    }
+
+    const nextState = withProjectiles(
+      {
+        ...previousState,
+        nextProjectileId: previousState.nextProjectileId + 1
+      },
+      [
+        createInvaderProjectile(
+          {
+            ...previousState,
+            nextProjectileId: previousState.nextProjectileId
+          },
+          invader
+        )
+      ]
+    );
+
+    expect(deriveGameEvents(previousState, nextState)).toEqual([]);
+  });
+
+  it("preserves event ordering when firing clears the last invader", () => {
+    const base = createPlayingState();
+    const invader = base.invaders[0];
+
+    if (invader === undefined) {
+      throw new Error("Expected an invader.");
+    }
+
+    const previousState = {
+      ...base,
+      invaders: [invader],
+      projectiles: [
+        {
+          id: 1,
+          owner: "player" as const,
+          x: invader.x,
+          y: invader.y,
+          width: invader.width,
+          height: invader.height,
+          velocityY: 0,
+          active: true
+        }
+      ],
+      nextProjectileId: 2
+    };
+    const nextState = step(previousState, 0, {
+      ...EMPTY_INPUT,
+      firePressed: true
+    }).state;
+
+    expect(deriveGameEvents(previousState, nextState)).toEqual([
+      { type: "playerShot" },
+      {
+        type: "invaderHit",
+        invaderId: invader.id,
+        points: invader.points
+      },
+      {
+        type: "scoreChanged",
+        previousScore: previousState.hud.score,
+        nextScore: previousState.hud.score + invader.points,
+        delta: invader.points
+      },
+      { type: "waveClear" }
+    ]);
+  });
+});

--- a/src/game/events.ts
+++ b/src/game/events.ts
@@ -1,0 +1,82 @@
+import type { GameState } from "./state";
+
+export type GameEvent =
+  | {
+      type: "playerShot";
+    }
+  | {
+      type: "invaderHit";
+      invaderId: number;
+      points: number;
+    }
+  | {
+      type: "scoreChanged";
+      previousScore: number;
+      nextScore: number;
+      delta: number;
+    }
+  | {
+      type: "lifeLost";
+    }
+  | {
+      type: "waveClear";
+    };
+
+export function deriveGameEvents(
+  previousState: GameState,
+  nextState: GameState
+): GameEvent[] {
+  const events: GameEvent[] = [];
+
+  // Prefer the explicit firing animation, but preserve the existing
+  // state-only fallback for synthetic transitions that add a player projectile.
+  if (
+    nextState.playerShootFrame > previousState.playerShootFrame ||
+    countPlayerProjectiles(nextState) > countPlayerProjectiles(previousState)
+  ) {
+    events.push({ type: "playerShot" });
+  }
+
+  const nextInvaderIds = new Set(nextState.invaders.map((invader) => invader.id));
+
+  for (const invader of previousState.invaders) {
+    if (!nextInvaderIds.has(invader.id)) {
+      events.push({
+        type: "invaderHit",
+        invaderId: invader.id,
+        points: invader.points
+      });
+    }
+  }
+
+  if (nextState.hud.score > previousState.hud.score) {
+    events.push({
+      type: "scoreChanged",
+      previousScore: previousState.hud.score,
+      nextScore: nextState.hud.score,
+      delta: nextState.hud.score - previousState.hud.score
+    });
+  }
+
+  if (previousState.phase !== "lifeLost" && nextState.phase === "lifeLost") {
+    events.push({ type: "lifeLost" });
+  }
+
+  if (previousState.phase !== "waveClear" && nextState.phase === "waveClear") {
+    events.push({ type: "waveClear" });
+  }
+
+  return events;
+}
+
+function countPlayerProjectiles(state: GameState): number {
+  let count = 0;
+
+  for (const projectile of state.projectiles) {
+    if (projectile.owner === "player") {
+      count += 1;
+    }
+  }
+
+  return count;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
-import { deriveSfxEvents } from "./audio/events";
+import { deriveSfxEvents, mapGameEventsToSfxEvents } from "./audio/events";
 import { createMuteStore } from "./audio/mute";
 import { createSfxController } from "./audio/sfx";
+import { deriveGameEvents, type GameEvent } from "./game/events";
 import {
   EMPTY_INPUT,
   createInitialGameState,
@@ -53,7 +54,6 @@ export function bootstrap(
   const createVisibilityController =
     options.createVisibilityPauseController ?? createVisibilityPauseController;
   const advanceGameState = options.step ?? step;
-  const deriveAudioEvents = options.deriveSfxEvents ?? deriveSfxEvents;
   const visibilityTarget = options.visibilityTarget ?? getDefaultDocument();
   const beforeUnloadTarget =
     options.beforeUnloadTarget ?? getDefaultWindow();
@@ -72,17 +72,28 @@ export function bootstrap(
     return frameInput;
   };
 
+  const deriveTransitionAudioEvents = (
+    previousState: GameState,
+    nextState: GameState
+  ) => {
+    const gameEvents = deriveGameEvents(previousState, nextState);
+
+    recordHighScoreFromEvents(highScoreStore, gameEvents);
+
+    return options.deriveSfxEvents === undefined
+      ? mapGameEventsToSfxEvents(gameEvents)
+      : options.deriveSfxEvents(previousState, nextState);
+  };
+
   const runtime = createGameRuntime({
-    deriveSfxEvents: deriveAudioEvents,
+    deriveSfxEvents: deriveTransitionAudioEvents,
     initialState: options.initialState ?? createInitialGameState(),
     muteStore,
     readHighScore: () => highScoreStore.getHighScore(),
     readInput,
     sfxController: sfx,
     step: (state, dtMs, input) => advanceGameState(state, dtMs, cloneInput(input)),
-    writeHighScore: (score) => {
-      highScoreStore.recordScore(score);
-    }
+    writeHighScore: () => undefined
   });
 
   const renderRuntime = (): void => {
@@ -235,6 +246,17 @@ function createPauseInput(): Input {
     ...EMPTY_INPUT,
     pausePressed: true
   };
+}
+
+function recordHighScoreFromEvents(
+  highScoreStore: Pick<ReturnType<typeof createHighScoreStore>, "recordScore">,
+  events: readonly GameEvent[]
+): void {
+  for (const event of events) {
+    if (event.type === "scoreChanged") {
+      highScoreStore.recordScore(event.nextScore);
+    }
+  }
 }
 
 if (typeof window !== "undefined" && typeof document !== "undefined") {


### PR DESCRIPTION
## Introduce typed game events module and route audio + high-score through it

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #272

### Changes
Create a new `src/game/events.ts` module exporting a discriminated-union `GameEvent` type and a pure `deriveGameEvents(previousState, nextState): GameEvent[]` function that captures state-transition events needed by audio and high-score logic. Preserve observable behavior. In particular, the existing `shoot` SFX corresponds to a player firing action only; do not derive or map a shoot event from invader projectile spawns or from arbitrary new projectile IDs. Include variants such as player shot, invader hit, life lost, wave cleared, score changed, and any other payloads consumers need. Add `src/game/events.test.ts` with focused coverage for emit, do-not-emit, and ordering when multiple events fire on one tick, including a regression that invader projectile spawns do not produce the player shoot SFX/event. Refactor `src/audio/events.ts` so `deriveSfxEvents(previousState, nextState)` is a thin mapper over the new game events while keeping its public signature stable. Update `src/audio/events.test.ts` as needed while preserving behavior. In `src/main.ts`, replace inline previous-vs-next high-score transition logic with logic driven by the shared events so audio and persistence share one transition stream. Do not change user-visible behavior.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*