### PR TITLE
test: Test createGameRuntime lazy audio arming in runtime.test.ts

### DIFF
--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -157,6 +157,51 @@ function createInput(input: Partial<Input> = {}): Input {
   };
 }
 
+type AudioArmingHarness = {
+  getReadInputCalls: () => number;
+  runtime: GameRuntime;
+  sfxController: FakeSfxController;
+};
+
+const FIRST_AUDIO_ARM_INPUT_CASES = [
+  ["moveX !== 0", createInput({ moveX: -1 })],
+  ["firePressed", createInput({ firePressed: true })],
+  ["pausePressed", createInput({ pausePressed: true })],
+  ["fireHeld", createInput({ fireHeld: true })],
+  ["pauseHeld", createInput({ pauseHeld: true })],
+  ["mutePressed", createInput({ mutePressed: true })]
+] as const satisfies ReadonlyArray<readonly [string, Input]>;
+
+function createAudioArmingHarness(
+  renderInputs: readonly Input[] = []
+): AudioArmingHarness {
+  const sfxController = new FakeSfxController();
+  const muteStore = new FakeMuteStore();
+  const scriptedInputs = [createInput(), ...renderInputs];
+  let readInputCalls = 0;
+
+  const runtime = createGameRuntime({
+    deriveSfxEvents: () => [],
+    initialState: createInitialGameState(),
+    muteStore,
+    readHighScore: () => 0,
+    readInput: () => {
+      const snapshot = scriptedInputs[readInputCalls] ?? createInput();
+      readInputCalls += 1;
+      return snapshot;
+    },
+    sfxController,
+    step: (state) => state,
+    writeHighScore: () => {}
+  });
+
+  return {
+    getReadInputCalls: () => readInputCalls,
+    runtime,
+    sfxController
+  };
+}
+
 function withPlayerProjectileCount(state: GameState, count: number): GameState {
   return {
     ...state,
@@ -217,18 +262,58 @@ function createInvaderTestProjectile(
   };
 }
 
-describe("createGameRuntime", () => {
-  it("arms audio exactly once on the first observed user input", () => {
-    const harness = createHarness();
+describe("createGameRuntime audio arming", () => {
+  it("keeps audio unarmed when renders observe only EMPTY_INPUT", () => {
+    const harness = createAudioArmingHarness([
+      createInput(),
+      createInput(),
+      createInput()
+    ]);
 
-    harness.runtime.onUserInput();
-    harness.runtime.onUserInput();
-    harness.queueInput({ moveX: -1 });
     harness.runtime.onRender();
+    harness.runtime.onRender();
+    harness.runtime.onRender();
+
+    expect(harness.sfxController.armCalls).toBe(0);
+  });
+
+  it.each(FIRST_AUDIO_ARM_INPUT_CASES)(
+    "arms audio on the first render that observes %s",
+    (_label, input) => {
+      const harness = createAudioArmingHarness([input]);
+
+      harness.runtime.onRender();
+
+      expect(harness.sfxController.armCalls).toBe(1);
+    }
+  );
+
+  it("does not re-arm after the first non-empty render input", () => {
+    const harness = createAudioArmingHarness(
+      FIRST_AUDIO_ARM_INPUT_CASES.map(([, input]) => input)
+    );
+
+    for (let index = 0; index < FIRST_AUDIO_ARM_INPUT_CASES.length; index += 1) {
+      harness.runtime.onRender();
+    }
 
     expect(harness.sfxController.armCalls).toBe(1);
   });
 
+  it("arms audio exactly once on onUserInput before any render", () => {
+    const harness = createAudioArmingHarness();
+
+    expect(harness.getReadInputCalls()).toBe(1);
+
+    harness.runtime.onUserInput();
+    harness.runtime.onUserInput();
+
+    expect(harness.sfxController.armCalls).toBe(1);
+    expect(harness.getReadInputCalls()).toBe(1);
+  });
+});
+
+describe("createGameRuntime", () => {
   it("toggles mute on a mute edge and propagates the result to the sfx controller", () => {
     const harness = createHarness();
 


### PR DESCRIPTION
## Test createGameRuntime lazy audio arming in runtime.test.ts

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #519

### Changes
Add tests to src/runtime.test.ts that verify the lazy audio-arming behavior of createGameRuntime in src/runtime.ts. Use the existing FakeSfxController (which counts arm() invocations) and a FakeMuteStore. Build a runtime with createGameRuntime, providing a deterministic readInput callback that returns scripted Input snapshots and a step function (the real step from src/game/step.ts is fine, or a stub that returns the same state — pick whichever keeps the test focused). Add at least four test cases covering: (a) calling onRender repeatedly while readInput returns EMPTY_INPUT keeps fakeSfx.armCalls === 0; (b) the first onRender after readInput returns an Input with any non-empty signal (try one case each, parameterized or separate it.each entries, for moveX !== 0, firePressed, pausePressed, fireHeld, pauseHeld, mutePressed) produces exactly armCalls === 1; (c) after that first arming, additional onRender ticks with further non-empty input keep armCalls === 1 (no re-arming); (d) calling onUserInput() arms the controller exactly once even when no input snapshot has been read. Use createInitialGameState or createPlayingState from src/game/state.ts as needed. Keep the FakeSfxController and FakeMuteStore class definitions already at the top of the file — extend rather than duplicate. Group the new cases in a describe block such as 'createGameRuntime audio arming'.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*