### PR TITLE
test: Add boundary-case tests for getFormationSpeed

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FORMATION_SPEED_BASE,
+  FORMATION_SPEED_MAX,
+  getFormationSpeed
+} from "./state";
+
+describe("getFormationSpeed", () => {
+  it("returns the wave start speed when invaderCount exceeds totalInvaders", () => {
+    const waveStartSpeed = FORMATION_SPEED_BASE * 2;
+
+    expect(getFormationSpeed(99, waveStartSpeed, 10)).toBe(waveStartSpeed);
+  });
+
+  it("treats negative invaderCount as a fully cleared formation", () => {
+    const waveStartSpeed = FORMATION_SPEED_BASE * 2;
+
+    expect(getFormationSpeed(-1, waveStartSpeed, 10)).toBe(
+      FORMATION_SPEED_MAX
+    );
+  });
+
+  it("caps waveStartSpeed at FORMATION_SPEED_MAX before interpolation", () => {
+    expect(getFormationSpeed(5, FORMATION_SPEED_MAX * 2, 10)).toBe(
+      FORMATION_SPEED_MAX
+    );
+  });
+
+  it("returns a finite number when totalInvaders is zero", () => {
+    expect(Number.isFinite(getFormationSpeed(0, FORMATION_SPEED_BASE, 0))).toBe(
+      true
+    );
+  });
+
+  it("interpolates halfway between the capped wave start speed and FORMATION_SPEED_MAX", () => {
+    const waveStartSpeed = FORMATION_SPEED_BASE * 2;
+
+    expect(getFormationSpeed(5, waveStartSpeed, 10)).toBe(
+      waveStartSpeed + (FORMATION_SPEED_MAX - waveStartSpeed) / 2
+    );
+  });
+});


### PR DESCRIPTION
## Add boundary-case tests for getFormationSpeed

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #516

### Changes
Create a new co-located test file `src/game/state.test.ts` that exercises boundary cases of `getFormationSpeed(invaderCount, waveStartSpeed, totalInvaders)` from `src/game/state.ts`. Cover: (1) invaderCount > totalInvaders clamps killedRatio to 1 and returns FORMATION_SPEED_MAX, (2) negative invaderCount clamps killedRatio to 0 and returns the capped waveStartSpeed (FORMATION_SPEED_BASE floor behavior per the existing implementation), (3) waveStartSpeed above FORMATION_SPEED_MAX is capped to FORMATION_SPEED_MAX before interpolation, (4) totalInvaders = 0 returns a finite number (no NaN or Infinity) — use `Number.isFinite`. Also include a sanity case at the midpoint (half-killed) to confirm interpolation between cappedWaveStartSpeed and FORMATION_SPEED_MAX. Import `getFormationSpeed`, `FORMATION_SPEED_BASE`, and `FORMATION_SPEED_MAX` from `./state`. Before writing assertions, READ `src/game/state.ts` to confirm the actual clamping/capping behavior — assertions must match current behavior, not assumed behavior. Do not modify `src/game/state.ts`; if you discover the function produces NaN at totalInvaders=0, assert the current behavior and stop (do not add implementation changes — flag it in a comment for follow-up).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*