### PR TITLE
feature: Plumb distinct audio status (unavailable vs muted) into render flags

### DIFF
--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -362,7 +362,7 @@ describe("createSfxController", () => {
     expect(controller.getStatus()).toBe("ready");
   });
 
-  it("mutes itself when AudioContext construction fails and play becomes a no-op", async () => {
+  it("reports unavailable when AudioContext construction fails and play becomes a no-op", async () => {
     harness.throwOnAudioContextConstruction = true;
 
     const controller = createSfxController();
@@ -371,9 +371,20 @@ describe("createSfxController", () => {
     controller.play("shoot");
 
     expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
-    expect(controller.getStatus()).toBe("muted");
+    expect(controller.getStatus()).toBe("unavailable");
     expect(harness.oscillators).toHaveLength(0);
     expect(harness.gains).toHaveLength(0);
+  });
+
+  it("keeps reporting unavailable when the user mutes after an arm failure", async () => {
+    harness.throwOnAudioContextConstruction = true;
+
+    const controller = createSfxController();
+
+    await controller.arm();
+    controller.setMuted(true);
+
+    expect(controller.getStatus()).toBe("unavailable");
   });
 
   it("reports muted while the user mute preference is enabled, even after arming", async () => {
@@ -400,13 +411,16 @@ describe("createSfxController", () => {
   it("restores playback after the user mute preference is cleared", async () => {
     const controller = createSfxController();
 
-    controller.setMuted(true);
     await controller.arm();
+
+    controller.setMuted(true);
+    expect(controller.getStatus()).toBe("muted");
+
     controller.setMuted(false);
+    expect(controller.getStatus()).toBe("ready");
 
     const playback = capturePlayback(harness, controller, "shoot");
 
-    expect(controller.getStatus()).toBe("ready");
     expectScheduledShortBeeps(playback, harness.destination);
   });
 

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,8 +1,9 @@
 export type SfxName = "shoot" | "hit" | "playerDeath" | "waveClear";
+export type SfxStatus = "idle" | "ready" | "muted" | "unavailable";
 
 export type SfxController = {
   arm: () => Promise<void>;
-  getStatus: () => "idle" | "ready" | "muted";
+  getStatus: () => SfxStatus;
   play: (name: SfxName) => void;
   setMuted: (muted: boolean) => void;
 };
@@ -18,16 +19,12 @@ const SFX_COOLDOWN_SECONDS = 0.03;
 
 export function createSfxController(): SfxController {
   let context: AudioContext | null = null;
-  let status: "idle" | "ready" | "muted" = "idle";
+  let status: Exclude<SfxStatus, "muted"> = "idle";
   let muted = false;
   const lastPlayedAtByName = new Map<SfxName, number>();
 
   return {
     arm: async () => {
-      if (status === "muted") {
-        return;
-      }
-
       try {
         if (context === null) {
           context = new AudioContext();
@@ -38,12 +35,12 @@ export function createSfxController(): SfxController {
         }
         status = "ready";
       } catch {
-        status = "muted";
+        status = "unavailable";
       }
     },
-    getStatus: () => (muted ? "muted" : status),
+    getStatus: () => getStatusValue(status, muted),
     play: (name) => {
-      if (muted || status !== "ready" || context === null) {
+      if (context === null || getStatusValue(status, muted) !== "ready") {
         return;
       }
 
@@ -70,6 +67,21 @@ export function createSfxController(): SfxController {
       muted = value;
     }
   };
+}
+
+function getStatusValue(
+  status: Exclude<SfxStatus, "muted">,
+  muted: boolean
+): SfxStatus {
+  if (status === "unavailable") {
+    return "unavailable";
+  }
+
+  if (muted) {
+    return "muted";
+  }
+
+  return status;
 }
 
 function playTone(

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createMuteStore } from "./audio/mute";
-import type { SfxName } from "./audio/sfx";
+import type { SfxName, SfxStatus } from "./audio/sfx";
 import { EMPTY_INPUT, createPlayingState, type GameState, type Input } from "./game/state";
 import { bootstrap } from "./main";
 import { createHighScoreStore } from "./persistence";
@@ -11,6 +11,7 @@ type HarnessOptions = {
   deriveSfxEvents?: (previousState: GameState, nextState: GameState) => SfxName[];
   initialHighScore?: number;
   initialMuted?: boolean;
+  initialSfxStatus?: SfxStatus;
   initialState?: GameState;
   step?: (state: GameState, dtMs: number, input: Input) => GameState;
 };
@@ -52,14 +53,39 @@ function createHarness(options: HarnessOptions = {}) {
       : { [HIGH_SCORE_STORAGE_KEY]: String(options.initialHighScore) })
   });
   const keyboard = { queued: createInput(), queue(input: Partial<Input> = {}): void { this.queued = createInput(input); }, dispose(): void {}, snapshot(): Input { const input = this.queued; this.queued = createInput(); return input; } };
+  let sfxMuted = options.initialSfxStatus === "muted";
+  let sfxReady = options.initialSfxStatus === "ready";
+  const sfxUnavailable = options.initialSfxStatus === "unavailable";
   const sfx = {
     armCalls: 0,
     playCalls: [] as SfxName[],
     setMutedCalls: [] as boolean[],
-    arm: async (): Promise<void> => { sfx.armCalls += 1; },
-    getStatus: () => "idle" as const,
+    arm: async (): Promise<void> => {
+      sfx.armCalls += 1;
+
+      if (!sfxUnavailable) {
+        sfxReady = true;
+      }
+    },
+    getStatus: (): SfxStatus => {
+      if (sfxUnavailable) {
+        return "unavailable";
+      }
+
+      if (sfxMuted) {
+        return "muted";
+      }
+
+      return sfxReady ? "ready" : "idle";
+    },
     play: (name: SfxName): void => void sfx.playCalls.push(name),
-    setMuted: (muted: boolean): void => void sfx.setMutedCalls.push(muted)
+    setMuted: (muted: boolean): void => {
+      sfx.setMutedCalls.push(muted);
+
+      if (!sfxUnavailable) {
+        sfxMuted = muted;
+      }
+    }
   };
   const stepCalls: Array<{ dtMs: number; input: Input; state: GameState }> = [];
   let hidden = false;
@@ -121,7 +147,11 @@ describe("bootstrap", () => {
   it("arms audio once and persists mute changes", () => {
     const harness = createHarness({ initialMuted: true });
     expect(harness.sfx.setMutedCalls).toEqual([true]);
-    expect(harness.latestRender().flags).toEqual({ bootstrapping: true, highScore: 0, muted: true });
+    expect(harness.latestRender().flags).toEqual({
+      bootstrapping: true,
+      highScore: 0,
+      audioStatus: "muted"
+    });
     harness.keyboard.queue({ firePressed: true });
     harness.render();
     harness.keyboard.queue({ firePressed: true });
@@ -131,7 +161,12 @@ describe("bootstrap", () => {
     expect(harness.sfx.armCalls).toBe(1);
     expect(harness.sfx.setMutedCalls).toEqual([true, false]);
     expect(harness.storage.getItem(MUTE_STORAGE_KEY)).toBe("false");
-    expect(harness.latestRender().flags.muted).toBe(false);
+    expect(harness.latestRender().flags.audioStatus).toBe("ready");
+  });
+  it("surfaces unavailable audio on the first render frame", () => {
+    const harness = createHarness({ initialSfxStatus: "unavailable" });
+
+    expect(harness.latestRender().flags.audioStatus).toBe("unavailable");
   });
   it("records a new high score when gameplay reaches game over", () => {
     const harness = createHarness({

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,7 @@ export function bootstrap(
 
   const createRenderFlags = (): RuntimeRenderFlags => ({
     bootstrapping,
-    muted: runtime.isMuted(),
+    audioStatus: sfx.getStatus(),
     highScore: runtime.getDisplayHighScore()
   });
 

--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -214,7 +214,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(canvas.width).toBe(2560);
@@ -242,7 +242,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
@@ -267,7 +267,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 360,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(
@@ -315,7 +315,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(
@@ -327,6 +327,36 @@ describe("createCanvasRenderer", () => {
           call.y < HUD_TOP + HUD_HEIGHT
       )
     ).toBe(true);
+  });
+
+  it("renders distinct audio badge labels and omits the badge when audio is ready", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const renderAudioStatus = (audioStatus: "muted" | "ready" | "unavailable") => {
+      const context = new FakeCanvasContext();
+      const canvas = createFakeCanvas(context);
+      const renderer = createCanvasRenderer(canvas);
+      const state = {
+        ...createPlayingState(),
+        invaders: [],
+        projectiles: []
+      };
+
+      renderer.render(state, {
+        bootstrapping: false,
+        highScore: 0,
+        audioStatus
+      });
+
+      return context.fillTextCalls.map((call) => call.text);
+    };
+
+    expect(renderAudioStatus("muted")).toContain("Muted");
+    expect(renderAudioStatus("muted")).not.toContain("Sound unavailable");
+    expect(renderAudioStatus("unavailable")).toContain("Sound unavailable");
+    expect(renderAudioStatus("unavailable")).not.toContain("Muted");
+    expect(renderAudioStatus("ready")).not.toContain("Muted");
+    expect(renderAudioStatus("ready")).not.toContain("Sound unavailable");
   });
 
   it("renders the invulnerability halo and blinks the ship off on deterministic off frames", () => {
@@ -348,7 +378,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeDefined();
@@ -374,7 +404,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeUndefined();
@@ -396,7 +426,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(
@@ -419,7 +449,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -1,3 +1,4 @@
+import type { SfxStatus } from "../audio/sfx";
 import type { GameState, Invader, Projectile } from "../game/state";
 import { CONTROL_FOOTER, OVERLAY_PROMPTS } from "../input/bindings";
 import {
@@ -9,7 +10,7 @@ import { applyViewport, computeViewport, type Viewport } from "./viewport";
 export type RenderFlags = {
   bootstrapping: boolean;
   highScore: number;
-  muted: boolean;
+  audioStatus: SfxStatus;
 };
 
 export type CanvasRenderer = {
@@ -119,9 +120,7 @@ function drawScene(
   drawFloor(context, state);
   drawControlHints(context, state);
 
-  if (flags.muted) {
-    drawMutedBadge(context, state);
-  }
+  drawMutedBadge(context, state, flags.audioStatus);
 
   if (flags.bootstrapping) {
     drawOverlay(context, state, "Initializing canvas...", "Preparing the first frame");
@@ -364,9 +363,15 @@ function drawControlHints(
 
 function drawMutedBadge(
   context: CanvasRenderingContext2D,
-  state: GameState
+  state: GameState,
+  audioStatus: SfxStatus
 ): void {
-  const label = "Sound unavailable";
+  const label = getMutedBadgeLabel(audioStatus);
+
+  if (label === null) {
+    return;
+  }
+
   const width = 168;
   const x = state.arena.width - width - 28;
   const y = 96;
@@ -378,6 +383,18 @@ function drawMutedBadge(
   context.font = '600 14px "Arial Narrow", "Avenir Next Condensed", sans-serif';
   context.fillStyle = "#ffe0e0";
   context.fillText(label, x + 16, y + 22);
+}
+
+function getMutedBadgeLabel(audioStatus: SfxStatus): string | null {
+  switch (audioStatus) {
+    case "muted":
+      return "Muted";
+    case "unavailable":
+      return "Sound unavailable";
+    case "idle":
+    case "ready":
+      return null;
+  }
 }
 
 function drawOverlay(


### PR DESCRIPTION
## Plumb distinct audio status (unavailable vs muted) into render flags

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #265

### Changes
Replace the boolean `muted` field on `RenderFlags` with a four-state audio status sourced from the SFX controller, and update the mute badge to render distinct labels for user-muted vs unavailable audio.

Concretely:

1. In `src/audio/sfx.ts`, widen the controller's status so failure is no longer conflated with user mute. Update the `SfxController` type and `getStatus()` to return `"idle" | "ready" | "muted" | "unavailable"`. When `arm()` catches an error constructing or resuming the `AudioContext`, set the internal state to `"unavailable"` (not `"muted"`). Make `"unavailable"` sticky — subsequent `arm()` calls must not silently flip it back to `"ready"` unless a fresh context actually succeeds. `setMuted(true)` when the controller is `"unavailable"` must keep reporting `"unavailable"` (the hardware condition dominates user intent). When the controller is ready, `getStatus()` returns `"muted"` if the user muted, otherwise `"ready"`. `play()` must early-return on both `"muted"` and `"unavailable"`.

2. Extend `src/audio/sfx.test.ts` to cover the new status contract: (a) `arm()` failure reports `"unavailable"` and leaves `play()` a no-op, (b) `"unavailable"` wins over `setMuted(true)`, (c) a successful `arm()` followed by `setMuted(true)` reports `"muted"` and `setMuted(false)` returns to `"ready"`. Preserve existing behavioural tests.

3. In `src/render/canvas.ts`, change `RenderFlags` so the audio indicator is the controller's status (rename the field to `audioStatus` with the same union type exported from `sfx.ts` — import the type, do not duplicate the union). Update `drawMutedBadge` (and any call sites inside the renderer) to:
   - render nothing when status is `"idle"` or `"ready"`,
   - render a `"Muted"` badge when status is `"muted"`,
   - render a `"Sound unavailable"` badge when status is `"unavailable"`.
   Keep the badge's placement and styling otherwise intact.

4. Update `src/render/canvas.test.ts` so any existing flag fixtures use the new `audioStatus` field, and add focused assertions that the badge text differs between `"muted"` and `"unavailable"` (and is absent for `"ready"`).

5. In `src/main.ts`, update `createRenderFlags()` to read from `sfxController.getStatus()` (exposing the controller or its status accessor to the render-flag builder — do not add a second source of truth). Remove the boolean `muted` plumbing. Ensure the bootstrap still compiles and runs: armed audio that the user toggles mute on shows `"muted"`; an AudioContext construction failure surfaces `"unavailable"` on the first frame.

Scope clarification: because main.ts bootstrap tests assert the render flags passed into the canvas renderer, updating the status-driven render flag plumbing may require updating src/main.test.ts. Keep those harness changes minimal and only adjust expectations/fixtures needed for the new unavailable-vs-muted status.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*