### PR TITLE
feature: Add shield-cell and invader-projectile sprite descriptors

### DIFF
--- a/src/render/sprite-data/index.test.ts
+++ b/src/render/sprite-data/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INVADER_PROJECTILE_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
+  SPRITE_DESCRIPTOR_REGISTRY
+} from "./index";
+import { getSprite } from "../sprites";
+
+describe("SPRITE_DESCRIPTOR_REGISTRY", () => {
+  it("registers shield-cell and invader-projectile descriptors", () => {
+    expect(SPRITE_DESCRIPTOR_REGISTRY).toHaveProperty("shield-cell");
+    expect(SPRITE_DESCRIPTOR_REGISTRY).toHaveProperty("invader-projectile");
+    expect(SPRITE_DESCRIPTOR_REGISTRY["shield-cell"]).toBe(
+      SHIELD_CELL_DESCRIPTOR
+    );
+    expect(SPRITE_DESCRIPTOR_REGISTRY["invader-projectile"]).toBe(
+      INVADER_PROJECTILE_DESCRIPTOR
+    );
+  });
+});
+
+describe("getSprite", () => {
+  it("prepares shield-cell and invader-projectile sprites from the public lookup path", () => {
+    const shieldCellSprite = getSprite("shield-cell");
+    const invaderProjectileSprite = getSprite("invader-projectile");
+
+    expect(shieldCellSprite.frameCount).toBeGreaterThanOrEqual(1);
+    expect(invaderProjectileSprite.frameCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("projectile descriptors", () => {
+  it("uses distinct palette colors for player and invader projectiles", () => {
+    expect(Object.values(INVADER_PROJECTILE_DESCRIPTOR.palette)).not.toEqual(
+      Object.values(PLAYER_PROJECTILE_DESCRIPTOR.palette)
+    );
+  });
+});

--- a/src/render/sprite-data/index.ts
+++ b/src/render/sprite-data/index.ts
@@ -1,7 +1,11 @@
 import type { SpriteDescriptor } from "../sprites";
 import { INVADER_ROW_DESCRIPTORS } from "./invaders";
 import { PLAYER_SHIP_DESCRIPTOR as SOURCE_PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
-import { PLAYER_PROJECTILE_DESCRIPTOR as SOURCE_PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
+import {
+  INVADER_PROJECTILE_DESCRIPTOR as SOURCE_INVADER_PROJECTILE_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR as SOURCE_PLAYER_PROJECTILE_DESCRIPTOR
+} from "./projectiles";
+import { SHIELD_CELL_DESCRIPTOR as SOURCE_SHIELD_CELL_DESCRIPTOR } from "./shield-cell";
 
 export { INVADER_ROW_DESCRIPTORS };
 
@@ -19,10 +23,26 @@ export const PLAYER_PROJECTILE_DESCRIPTOR = {
   pixelSize: SOURCE_PLAYER_PROJECTILE_DESCRIPTOR.pixelSize
 } as const satisfies SpriteDescriptor;
 
+export const INVADER_PROJECTILE_DESCRIPTOR = {
+  id: "invader-projectile",
+  frames: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.frames,
+  palette: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.palette,
+  pixelSize: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
+
+export const SHIELD_CELL_DESCRIPTOR = {
+  id: "shield-cell",
+  frames: SOURCE_SHIELD_CELL_DESCRIPTOR.frames,
+  palette: SOURCE_SHIELD_CELL_DESCRIPTOR.palette,
+  pixelSize: SOURCE_SHIELD_CELL_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
+
 export const SPRITE_DESCRIPTORS = [
   PLAYER_SHIP_DESCRIPTOR,
   ...INVADER_ROW_DESCRIPTORS,
-  PLAYER_PROJECTILE_DESCRIPTOR
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  INVADER_PROJECTILE_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR
 ] as const satisfies readonly SpriteDescriptor[];
 
 type SpriteDescriptorRegistry<
@@ -50,6 +70,8 @@ export const SPRITE_DESCRIPTOR_REGISTRY = buildSpriteDescriptorRegistry(
     "invader-row-2": INVADER_ROW_DESCRIPTORS[2],
     "invader-row-3": INVADER_ROW_DESCRIPTORS[3],
     "invader-row-4": INVADER_ROW_DESCRIPTORS[4],
-    "player-projectile": PLAYER_PROJECTILE_DESCRIPTOR
+    "player-projectile": PLAYER_PROJECTILE_DESCRIPTOR,
+    "invader-projectile": INVADER_PROJECTILE_DESCRIPTOR,
+    "shield-cell": SHIELD_CELL_DESCRIPTOR
   }
 );

--- a/src/render/sprite-data/projectiles.ts
+++ b/src/render/sprite-data/projectiles.ts
@@ -1,5 +1,9 @@
 import type { SpriteDescriptor } from "../sprites";
 
+const INVADER_PROJECTILE_FRAMES = [
+  ["..ii", ".ii.", "ii..", ".ii.", "..ii", ".ii.", "ii..", ".ii.", "..ii"]
+] as const;
+
 export const PLAYER_PROJECTILE_DESCRIPTOR = {
   id: "player-projectile",
   frames: [["p.", "pp", "pp", "pp", "pp", ".p"]],
@@ -7,4 +11,13 @@ export const PLAYER_PROJECTILE_DESCRIPTOR = {
     p: "#f7fbff"
   },
   pixelSize: 3
+} satisfies SpriteDescriptor;
+
+export const INVADER_PROJECTILE_DESCRIPTOR = {
+  id: "invader-projectile",
+  frames: INVADER_PROJECTILE_FRAMES,
+  palette: {
+    i: "#ff8f6b"
+  },
+  pixelSize: 2
 } satisfies SpriteDescriptor;

--- a/src/render/sprite-data/shield-cell.ts
+++ b/src/render/sprite-data/shield-cell.ts
@@ -1,0 +1,12 @@
+import type { SpriteDescriptor } from "../sprites";
+
+const SHIELD_CELL_FRAMES = [["ssss", "ssss", "ssss"]] as const;
+
+export const SHIELD_CELL_DESCRIPTOR = {
+  id: "shield-cell",
+  frames: SHIELD_CELL_FRAMES,
+  palette: {
+    s: "#7dff8a"
+  },
+  pixelSize: 4
+} satisfies SpriteDescriptor;

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import { SPRITE_DESCRIPTOR_REGISTRY } from "./sprite-data";
 import {
   EMPTY_PIXEL,
+  INVADER_PROJECTILE_DESCRIPTOR,
   INVADER_ROW_DESCRIPTORS,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTORS,
   createSpriteSheet,
   getSprite,
@@ -81,12 +83,14 @@ function countFilledPixels(frame: readonly string[]): number {
 }
 
 describe("createSpriteSheet", () => {
-  it("includes descriptors for the player, each invader row, and the projectile", () => {
-    expect(SPRITE_DESCRIPTORS).toHaveLength(7);
+  it("includes descriptors for the player, each invader row, the projectiles, and the shield cell", () => {
+    expect(SPRITE_DESCRIPTORS).toHaveLength(9);
     expect(INVADER_ROW_DESCRIPTORS).toHaveLength(5);
 
     expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(1);
     expect(createSpriteSheet(PLAYER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(INVADER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(SHIELD_CELL_DESCRIPTOR).getFrameCount()).toBe(1);
 
     for (const descriptor of INVADER_ROW_DESCRIPTORS) {
       expect(createSpriteSheet(descriptor).getFrameCount()).toBe(2);
@@ -257,6 +261,11 @@ describe("getSprite", () => {
       "player-projectile",
       PLAYER_PROJECTILE_DESCRIPTOR
     );
+    expectPreparedSpriteToMatchDescriptor(
+      "invader-projectile",
+      INVADER_PROJECTILE_DESCRIPTOR
+    );
+    expectPreparedSpriteToMatchDescriptor("shield-cell", SHIELD_CELL_DESCRIPTOR);
 
     for (const descriptor of INVADER_ROW_DESCRIPTORS) {
       expectPreparedSpriteToMatchDescriptor(descriptor.id, descriptor);

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -38,9 +38,11 @@ export type PreparedSprite = {
 export const EMPTY_PIXEL = ".";
 
 export {
+  INVADER_PROJECTILE_DESCRIPTOR,
   INVADER_ROW_DESCRIPTORS,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTORS
 } from "./sprite-data";
 
@@ -65,6 +67,10 @@ const SPRITE_REGISTRY = {
   "player-projectile": prepareSprite(
     SPRITE_DESCRIPTOR_REGISTRY["player-projectile"]!
   ),
+  "invader-projectile": prepareSprite(
+    SPRITE_DESCRIPTOR_REGISTRY["invader-projectile"]!
+  ),
+  "shield-cell": prepareSprite(SPRITE_DESCRIPTOR_REGISTRY["shield-cell"]!),
   ...INVADER_ROW_SPRITES
 } satisfies Record<string, PreparedSprite>;
 


### PR DESCRIPTION
## Add shield-cell and invader-projectile sprite descriptors

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #475

### Changes
Add first-class sprite descriptors so the canvas renderer can draw shields and enemy shots procedurally (no external images). (1) Create src/render/sprite-data/shield-cell.ts exporting SHIELD_CELL_DESCRIPTOR (id: 'shield-cell') — a small blocky pixel-art frame with a single palette key; keep dimensions consistent with SHIELD_CELL_COLS / shield cell sizing in src/game/state.ts. (2) Extend src/render/sprite-data/projectiles.ts with INVADER_PROJECTILE_DESCRIPTOR (id: 'invader-projectile') — a distinct bitmap/palette from PLAYER_PROJECTILE_DESCRIPTOR so the two shot types are visually unambiguous (e.g. zig-zag bolt in a different color). (3) Update src/render/sprite-data/index.ts to re-export both new descriptors and include them in SPRITE_DESCRIPTORS so they flow through SPRITE_DESCRIPTOR_REGISTRY and getSprite(). (4) Create src/render/sprite-data/index.test.ts with Vitest cases that (a) assert SPRITE_DESCRIPTOR_REGISTRY contains 'shield-cell' and 'invader-projectile', (b) assert getSprite resolves both to a PreparedSprite with frames.length >= 1, (c) assert the two projectile descriptors have distinct palette colors.

Scope clarification: this task must register the new descriptors through the real sprite registry and public sprite lookup path. Update src/render/sprites.ts and src/render/sprites.test.ts as needed so shield-cell and invader-projectile are first-class sprite keys. Do not fake membership with Proxy/Object.defineProperty or other runtime indirection in sprite-data/index.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*