### PR TITLE
feature: Plumb distinct audio status (unavailable vs muted) into render flags

### DIFF
--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -59,6 +59,7 @@ type MockPlayback = {
 type MockWebAudioHarness = {
   initialState: AudioContextState;
   throwOnAudioContextConstruction: boolean;
+  throwOnResume: boolean;
   readonly destination: MockDestination;
   readonly contexts: MockAudioContext[];
   readonly oscillators: MockOscillatorNode[];
@@ -143,6 +144,7 @@ function installMockWebAudio(
   const harness: MockWebAudioHarness = {
     initialState,
     throwOnAudioContextConstruction: false,
+    throwOnResume: false,
     destination,
     contexts,
     oscillators,
@@ -163,6 +165,10 @@ function installMockWebAudio(
         destination,
         currentTime: 0,
         resume: vi.fn(async () => {
+          if (harness.throwOnResume) {
+            throw new Error("AudioContext resume failed");
+          }
+
           context.state = "running";
         }),
         createOscillator: vi.fn(() => {
@@ -362,8 +368,23 @@ describe("createSfxController", () => {
     expect(controller.getStatus()).toBe("ready");
   });
 
-  it("mutes itself when AudioContext construction fails and play becomes a no-op", async () => {
+  it("reports unavailable when AudioContext construction fails and play becomes a no-op", async () => {
     harness.throwOnAudioContextConstruction = true;
+
+    const controller = createSfxController();
+
+    await controller.arm();
+    controller.play("shoot");
+    controller.setMuted(true);
+
+    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
+    expect(controller.getStatus()).toBe("unavailable");
+    expect(harness.oscillators).toHaveLength(0);
+    expect(harness.gains).toHaveLength(0);
+  });
+
+  it("reports unavailable when AudioContext.resume fails and only recovers through a fresh context", async () => {
+    harness.throwOnResume = true;
 
     const controller = createSfxController();
 
@@ -371,9 +392,15 @@ describe("createSfxController", () => {
     controller.play("shoot");
 
     expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
-    expect(controller.getStatus()).toBe("muted");
+    expect(controller.getStatus()).toBe("unavailable");
     expect(harness.oscillators).toHaveLength(0);
     expect(harness.gains).toHaveLength(0);
+
+    harness.throwOnResume = false;
+    await controller.arm();
+
+    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(2);
+    expect(controller.getStatus()).toBe("ready");
   });
 
   it("reports muted while the user mute preference is enabled, even after arming", async () => {
@@ -400,13 +427,17 @@ describe("createSfxController", () => {
   it("restores playback after the user mute preference is cleared", async () => {
     const controller = createSfxController();
 
-    controller.setMuted(true);
     await controller.arm();
+    controller.setMuted(true);
+
+    expect(controller.getStatus()).toBe("muted");
+
     controller.setMuted(false);
+
+    expect(controller.getStatus()).toBe("ready");
 
     const playback = capturePlayback(harness, controller, "shoot");
 
-    expect(controller.getStatus()).toBe("ready");
     expectScheduledShortBeeps(playback, harness.destination);
   });
 

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,8 +1,9 @@
 export type SfxName = "shoot" | "hit" | "playerDeath" | "waveClear";
+export type AudioStatus = "idle" | "ready" | "muted" | "unavailable";
 
 export type SfxController = {
   arm: () => Promise<void>;
-  getStatus: () => "idle" | "ready" | "muted";
+  getStatus: () => AudioStatus;
   play: (name: SfxName) => void;
   setMuted: (muted: boolean) => void;
 };
@@ -18,16 +19,24 @@ const SFX_COOLDOWN_SECONDS = 0.03;
 
 export function createSfxController(): SfxController {
   let context: AudioContext | null = null;
-  let status: "idle" | "ready" | "muted" = "idle";
+  let status: Exclude<AudioStatus, "muted"> = "idle";
   let muted = false;
   const lastPlayedAtByName = new Map<SfxName, number>();
 
+  const getStatus = (): AudioStatus => {
+    if (status === "unavailable") {
+      return "unavailable";
+    }
+
+    if (muted) {
+      return "muted";
+    }
+
+    return status;
+  };
+
   return {
     arm: async () => {
-      if (status === "muted") {
-        return;
-      }
-
       try {
         if (context === null) {
           context = new AudioContext();
@@ -38,12 +47,20 @@ export function createSfxController(): SfxController {
         }
         status = "ready";
       } catch {
-        status = "muted";
+        context = null;
+        status = "unavailable";
       }
     },
-    getStatus: () => (muted ? "muted" : status),
+    getStatus,
     play: (name) => {
-      if (muted || status !== "ready" || context === null) {
+      const currentStatus = getStatus();
+
+      if (
+        currentStatus === "muted" ||
+        currentStatus === "unavailable" ||
+        status !== "ready" ||
+        context === null
+      ) {
         return;
       }
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createMuteStore } from "./audio/mute";
-import type { SfxName } from "./audio/sfx";
+import type { AudioStatus, SfxName } from "./audio/sfx";
 import { EMPTY_INPUT, createPlayingState, type GameState, type Input } from "./game/state";
 import { bootstrap } from "./main";
 import { createHighScoreStore } from "./persistence";
@@ -12,6 +12,7 @@ type HarnessOptions = {
   initialHighScore?: number;
   initialMuted?: boolean;
   initialState?: GameState;
+  sfxStatus?: AudioStatus;
   step?: (state: GameState, dtMs: number, input: Input) => GameState;
 };
 type ListenerRecord = {
@@ -52,14 +53,29 @@ function createHarness(options: HarnessOptions = {}) {
       : { [HIGH_SCORE_STORAGE_KEY]: String(options.initialHighScore) })
   });
   const keyboard = { queued: createInput(), queue(input: Partial<Input> = {}): void { this.queued = createInput(input); }, dispose(): void {}, snapshot(): Input { const input = this.queued; this.queued = createInput(); return input; } };
+  let audioArmed = false;
+  let audioMuted = false;
   const sfx = {
     armCalls: 0,
     playCalls: [] as SfxName[],
     setMutedCalls: [] as boolean[],
-    arm: async (): Promise<void> => { sfx.armCalls += 1; },
-    getStatus: () => "idle" as const,
+    arm: async (): Promise<void> => { sfx.armCalls += 1; audioArmed = true; },
+    getStatus: (): AudioStatus => {
+      if (options.sfxStatus !== undefined) {
+        return options.sfxStatus;
+      }
+
+      if (audioMuted) {
+        return "muted";
+      }
+
+      return audioArmed ? "ready" : "idle";
+    },
     play: (name: SfxName): void => void sfx.playCalls.push(name),
-    setMuted: (muted: boolean): void => void sfx.setMutedCalls.push(muted)
+    setMuted: (muted: boolean): void => {
+      sfx.setMutedCalls.push(muted);
+      audioMuted = muted;
+    }
   };
   const stepCalls: Array<{ dtMs: number; input: Input; state: GameState }> = [];
   let hidden = false;
@@ -121,7 +137,11 @@ describe("bootstrap", () => {
   it("arms audio once and persists mute changes", () => {
     const harness = createHarness({ initialMuted: true });
     expect(harness.sfx.setMutedCalls).toEqual([true]);
-    expect(harness.latestRender().flags).toEqual({ bootstrapping: true, highScore: 0, muted: true });
+    expect(harness.latestRender().flags).toEqual({
+      bootstrapping: true,
+      highScore: 0,
+      audioStatus: "muted"
+    });
     harness.keyboard.queue({ firePressed: true });
     harness.render();
     harness.keyboard.queue({ firePressed: true });
@@ -131,7 +151,13 @@ describe("bootstrap", () => {
     expect(harness.sfx.armCalls).toBe(1);
     expect(harness.sfx.setMutedCalls).toEqual([true, false]);
     expect(harness.storage.getItem(MUTE_STORAGE_KEY)).toBe("false");
-    expect(harness.latestRender().flags.muted).toBe(false);
+    expect(harness.latestRender().flags.audioStatus).toBe("ready");
+  });
+
+  it("passes the controller audio status through to render flags", () => {
+    const harness = createHarness({ sfxStatus: "unavailable" });
+
+    expect(harness.latestRender().flags.audioStatus).toBe("unavailable");
   });
   it("records a new high score when gameplay reaches game over", () => {
     const harness = createHarness({

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,7 @@ export function bootstrap(
 
   const createRenderFlags = (): RuntimeRenderFlags => ({
     bootstrapping,
-    muted: runtime.isMuted(),
+    audioStatus: sfx.getStatus(),
     highScore: runtime.getDisplayHighScore()
   });
 

--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -214,7 +214,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(canvas.width).toBe(2560);
@@ -242,7 +242,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
@@ -267,7 +267,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 360,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(
@@ -315,7 +315,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(
@@ -327,6 +327,37 @@ describe("createCanvasRenderer", () => {
           call.y < HUD_TOP + HUD_HEIGHT
       )
     ).toBe(true);
+  });
+
+  it("renders distinct badge text for muted and unavailable audio", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      projectiles: []
+    };
+
+    const renderTexts = (audioStatus: "ready" | "muted" | "unavailable") => {
+      const context = new FakeCanvasContext();
+      const canvas = createFakeCanvas(context);
+      const renderer = createCanvasRenderer(canvas);
+
+      renderer.render(state, {
+        bootstrapping: false,
+        highScore: 0,
+        audioStatus
+      });
+
+      return context.fillTextCalls.map((call) => call.text);
+    };
+
+    expect(renderTexts("ready")).not.toContain("Muted");
+    expect(renderTexts("ready")).not.toContain("Sound unavailable");
+    expect(renderTexts("muted")).toContain("Muted");
+    expect(renderTexts("muted")).not.toContain("Sound unavailable");
+    expect(renderTexts("unavailable")).toContain("Sound unavailable");
+    expect(renderTexts("unavailable")).not.toContain("Muted");
   });
 
   it("renders the invulnerability halo and blinks the ship off on deterministic off frames", () => {
@@ -348,7 +379,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeDefined();
@@ -374,7 +405,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeUndefined();
@@ -396,7 +427,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(
@@ -419,7 +450,7 @@ describe("createCanvasRenderer", () => {
     renderer.render(state, {
       bootstrapping: false,
       highScore: 0,
-      muted: false
+      audioStatus: "ready"
     });
 
     expect(

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -1,3 +1,4 @@
+import type { AudioStatus } from "../audio/sfx";
 import type { GameState, Invader, Projectile } from "../game/state";
 import { CONTROL_FOOTER, OVERLAY_PROMPTS } from "../input/bindings";
 import {
@@ -9,7 +10,7 @@ import { applyViewport, computeViewport, type Viewport } from "./viewport";
 export type RenderFlags = {
   bootstrapping: boolean;
   highScore: number;
-  muted: boolean;
+  audioStatus: AudioStatus;
 };
 
 export type CanvasRenderer = {
@@ -119,9 +120,7 @@ function drawScene(
   drawFloor(context, state);
   drawControlHints(context, state);
 
-  if (flags.muted) {
-    drawMutedBadge(context, state);
-  }
+  drawMutedBadge(context, state, flags.audioStatus);
 
   if (flags.bootstrapping) {
     drawOverlay(context, state, "Initializing canvas...", "Preparing the first frame");
@@ -364,9 +363,14 @@ function drawControlHints(
 
 function drawMutedBadge(
   context: CanvasRenderingContext2D,
-  state: GameState
+  state: GameState,
+  status: AudioStatus
 ): void {
-  const label = "Sound unavailable";
+  if (status === "idle" || status === "ready") {
+    return;
+  }
+
+  const label = status === "muted" ? "Muted" : "Sound unavailable";
   const width = 168;
   const x = state.arena.width - width - 28;
   const y = 96;


### PR DESCRIPTION
## Plumb distinct audio status (unavailable vs muted) into render flags

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #265

### Changes
Replace the boolean `muted` field on `RenderFlags` with a four-state audio status sourced from the SFX controller, and update the mute badge to render distinct labels for user-muted vs unavailable audio.

Concretely:

1. In `src/audio/sfx.ts`, widen the controller's status so failure is no longer conflated with user mute. Update the `SfxController` type and `getStatus()` to return `"idle" | "ready" | "muted" | "unavailable"`. When `arm()` catches an error constructing or resuming the `AudioContext`, set the internal state to `"unavailable"` (not `"muted"`). Make `"unavailable"` sticky — subsequent `arm()` calls must not silently flip it back to `"ready"` unless a fresh context actually succeeds. `setMuted(true)` when the controller is `"unavailable"` must keep reporting `"unavailable"` (the hardware condition dominates user intent). When the controller is ready, `getStatus()` returns `"muted"` if the user muted, otherwise `"ready"`. `play()` must early-return on both `"muted"` and `"unavailable"`.

2. Extend `src/audio/sfx.test.ts` to cover the new status contract: (a) `arm()` failure reports `"unavailable"` and leaves `play()` a no-op, (b) `"unavailable"` wins over `setMuted(true)`, (c) a successful `arm()` followed by `setMuted(true)` reports `"muted"` and `setMuted(false)` returns to `"ready"`. Preserve existing behavioural tests.

3. In `src/render/canvas.ts`, change `RenderFlags` so the audio indicator is the controller's status (rename the field to `audioStatus` with the same union type exported from `sfx.ts` — import the type, do not duplicate the union). Update `drawMutedBadge` (and any call sites inside the renderer) to:
   - render nothing when status is `"idle"` or `"ready"`,
   - render a `"Muted"` badge when status is `"muted"`,
   - render a `"Sound unavailable"` badge when status is `"unavailable"`.
   Keep the badge's placement and styling otherwise intact.

4. Update `src/render/canvas.test.ts` so any existing flag fixtures use the new `audioStatus` field, and add focused assertions that the badge text differs between `"muted"` and `"unavailable"` (and is absent for `"ready"`).

5. In `src/main.ts`, update `createRenderFlags()` to read from `sfxController.getStatus()` (exposing the controller or its status accessor to the render-flag builder — do not add a second source of truth). Remove the boolean `muted` plumbing. Ensure the bootstrap still compiles and runs: armed audio that the user toggles mute on shows `"muted"`; an AudioContext construction failure surfaces `"unavailable"` on the first frame.

Scope clarification: because main.ts bootstrap tests assert the render flags passed into the canvas renderer, updating the status-driven render flag plumbing may require updating src/main.test.ts. Keep those harness changes minimal and only adjust expectations/fixtures needed for the new unavailable-vs-muted status.

Review clarification: the unavailable status must be sticky after AudioContext creation or resume fails. If arm()/resume rejects, do not leave a stale context that can later report or behave as armed; clear or quarantine it so getStatus() remains 'unavailable' until a deliberate new initialization path succeeds. Add/keep an SFX unit test for resume failure, not only constructor failure.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*