### PR TITLE
feature: Add shield-cell and invader-projectile sprite descriptors

### DIFF
--- a/src/render/sprite-data/index.test.ts
+++ b/src/render/sprite-data/index.test.ts
@@ -1,0 +1,56 @@
+import {
+  INVADER_PROJECTILE_HEIGHT,
+  INVADER_PROJECTILE_WIDTH,
+  SHIELD_CELL_HEIGHT,
+  SHIELD_CELL_WIDTH
+} from "../../game/state";
+import { getSprite } from "../sprites";
+import {
+  INVADER_PROJECTILE_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
+  SPRITE_DESCRIPTOR_REGISTRY
+} from "./index";
+import { describe, expect, it } from "vitest";
+
+describe("SPRITE_DESCRIPTOR_REGISTRY", () => {
+  it("registers shield-cell and invader-projectile as enumerable descriptors", () => {
+    expect(Object.keys(SPRITE_DESCRIPTOR_REGISTRY)).toEqual(
+      expect.arrayContaining(["shield-cell", "invader-projectile"])
+    );
+    expect(SPRITE_DESCRIPTOR_REGISTRY["shield-cell"]).toBe(SHIELD_CELL_DESCRIPTOR);
+    expect(SPRITE_DESCRIPTOR_REGISTRY["invader-projectile"]).toBe(
+      INVADER_PROJECTILE_DESCRIPTOR
+    );
+  });
+});
+
+describe("getSprite", () => {
+  it("prepares shield-cell and invader-projectile through the public lookup path", () => {
+    const shieldCell = getSprite("shield-cell");
+    const invaderProjectile = getSprite("invader-projectile");
+
+    expect(shieldCell.frameCount).toBeGreaterThanOrEqual(1);
+    expect(shieldCell.sheet.getFrameCount()).toBeGreaterThanOrEqual(1);
+    expect(shieldCell.width).toBe(SHIELD_CELL_WIDTH);
+    expect(shieldCell.height).toBe(SHIELD_CELL_HEIGHT);
+
+    expect(invaderProjectile.frameCount).toBeGreaterThanOrEqual(1);
+    expect(invaderProjectile.sheet.getFrameCount()).toBeGreaterThanOrEqual(1);
+    expect(invaderProjectile.width).toBe(INVADER_PROJECTILE_WIDTH);
+    expect(invaderProjectile.height).toBe(INVADER_PROJECTILE_HEIGHT);
+  });
+});
+
+describe("projectile descriptors", () => {
+  it("use distinct palette colors for player and invader shots", () => {
+    const playerProjectileColors = Object.values(PLAYER_PROJECTILE_DESCRIPTOR.palette);
+    const invaderProjectileColors = Object.values(
+      INVADER_PROJECTILE_DESCRIPTOR.palette
+    );
+
+    for (const color of invaderProjectileColors) {
+      expect(playerProjectileColors).not.toContain(color);
+    }
+  });
+});

--- a/src/render/sprite-data/index.ts
+++ b/src/render/sprite-data/index.ts
@@ -1,7 +1,11 @@
 import type { SpriteDescriptor } from "../sprites";
 import { INVADER_ROW_DESCRIPTORS } from "./invaders";
 import { PLAYER_SHIP_DESCRIPTOR as SOURCE_PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
-import { PLAYER_PROJECTILE_DESCRIPTOR as SOURCE_PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
+import {
+  INVADER_PROJECTILE_DESCRIPTOR as SOURCE_INVADER_PROJECTILE_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR as SOURCE_PLAYER_PROJECTILE_DESCRIPTOR
+} from "./projectiles";
+import { SHIELD_CELL_DESCRIPTOR as SOURCE_SHIELD_CELL_DESCRIPTOR } from "./shield-cell";
 
 export { INVADER_ROW_DESCRIPTORS };
 
@@ -19,10 +23,26 @@ export const PLAYER_PROJECTILE_DESCRIPTOR = {
   pixelSize: SOURCE_PLAYER_PROJECTILE_DESCRIPTOR.pixelSize
 } as const satisfies SpriteDescriptor;
 
+export const INVADER_PROJECTILE_DESCRIPTOR = {
+  id: "invader-projectile",
+  frames: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.frames,
+  palette: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.palette,
+  pixelSize: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
+
+export const SHIELD_CELL_DESCRIPTOR = {
+  id: "shield-cell",
+  frames: SOURCE_SHIELD_CELL_DESCRIPTOR.frames,
+  palette: SOURCE_SHIELD_CELL_DESCRIPTOR.palette,
+  pixelSize: SOURCE_SHIELD_CELL_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
+
 export const SPRITE_DESCRIPTORS = [
   PLAYER_SHIP_DESCRIPTOR,
   ...INVADER_ROW_DESCRIPTORS,
-  PLAYER_PROJECTILE_DESCRIPTOR
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  INVADER_PROJECTILE_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR
 ] as const satisfies readonly SpriteDescriptor[];
 
 type SpriteDescriptorRegistry<
@@ -50,6 +70,8 @@ export const SPRITE_DESCRIPTOR_REGISTRY = buildSpriteDescriptorRegistry(
     "invader-row-2": INVADER_ROW_DESCRIPTORS[2],
     "invader-row-3": INVADER_ROW_DESCRIPTORS[3],
     "invader-row-4": INVADER_ROW_DESCRIPTORS[4],
-    "player-projectile": PLAYER_PROJECTILE_DESCRIPTOR
+    "player-projectile": PLAYER_PROJECTILE_DESCRIPTOR,
+    "invader-projectile": INVADER_PROJECTILE_DESCRIPTOR,
+    "shield-cell": SHIELD_CELL_DESCRIPTOR
   }
 );

--- a/src/render/sprite-data/projectiles.ts
+++ b/src/render/sprite-data/projectiles.ts
@@ -1,10 +1,34 @@
 import type { SpriteDescriptor } from "../sprites";
 
+const PLAYER_PROJECTILE_FRAMES = [["p.", "pp", "pp", "pp", "pp", ".p"]] as const;
+const INVADER_PROJECTILE_FRAMES = [
+  [
+    "..zz",
+    ".zz.",
+    "zz..",
+    ".zz.",
+    "..zz",
+    ".zz.",
+    "zz..",
+    ".zz.",
+    "..zz"
+  ]
+] as const;
+
 export const PLAYER_PROJECTILE_DESCRIPTOR = {
   id: "player-projectile",
-  frames: [["p.", "pp", "pp", "pp", "pp", ".p"]],
+  frames: PLAYER_PROJECTILE_FRAMES,
   palette: {
     p: "#f7fbff"
   },
   pixelSize: 3
+} satisfies SpriteDescriptor;
+
+export const INVADER_PROJECTILE_DESCRIPTOR = {
+  id: "invader-projectile",
+  frames: INVADER_PROJECTILE_FRAMES,
+  palette: {
+    z: "#ff9f43"
+  },
+  pixelSize: 2
 } satisfies SpriteDescriptor;

--- a/src/render/sprite-data/shield-cell.ts
+++ b/src/render/sprite-data/shield-cell.ts
@@ -1,0 +1,21 @@
+import type { SpriteDescriptor } from "../sprites";
+
+const SHIELD_CELL_FRAMES = [
+  [
+    ".ssssss.",
+    "ssssssss",
+    "ssssssss",
+    "ssssssss",
+    "ssssssss",
+    ".ssssss."
+  ]
+] as const;
+
+export const SHIELD_CELL_DESCRIPTOR = {
+  id: "shield-cell",
+  frames: SHIELD_CELL_FRAMES,
+  palette: {
+    s: "#6dff8f"
+  },
+  pixelSize: 2
+} satisfies SpriteDescriptor;

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import { SPRITE_DESCRIPTOR_REGISTRY } from "./sprite-data";
 import {
   EMPTY_PIXEL,
+  INVADER_PROJECTILE_DESCRIPTOR,
   INVADER_ROW_DESCRIPTORS,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTORS,
   createSpriteSheet,
   getSprite,
@@ -81,12 +83,16 @@ function countFilledPixels(frame: readonly string[]): number {
 }
 
 describe("createSpriteSheet", () => {
-  it("includes descriptors for the player, each invader row, and the projectile", () => {
-    expect(SPRITE_DESCRIPTORS).toHaveLength(7);
+  it("includes descriptors for the player, each invader row, the projectiles, and the shield cell", () => {
+    expect(SPRITE_DESCRIPTORS).toHaveLength(9);
     expect(INVADER_ROW_DESCRIPTORS).toHaveLength(5);
 
     expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(1);
     expect(createSpriteSheet(PLAYER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(INVADER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(
+      1
+    );
+    expect(createSpriteSheet(SHIELD_CELL_DESCRIPTOR).getFrameCount()).toBe(1);
 
     for (const descriptor of INVADER_ROW_DESCRIPTORS) {
       expect(createSpriteSheet(descriptor).getFrameCount()).toBe(2);
@@ -257,6 +263,11 @@ describe("getSprite", () => {
       "player-projectile",
       PLAYER_PROJECTILE_DESCRIPTOR
     );
+    expectPreparedSpriteToMatchDescriptor(
+      "invader-projectile",
+      INVADER_PROJECTILE_DESCRIPTOR
+    );
+    expectPreparedSpriteToMatchDescriptor("shield-cell", SHIELD_CELL_DESCRIPTOR);
 
     for (const descriptor of INVADER_ROW_DESCRIPTORS) {
       expectPreparedSpriteToMatchDescriptor(descriptor.id, descriptor);

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -38,9 +38,11 @@ export type PreparedSprite = {
 export const EMPTY_PIXEL = ".";
 
 export {
+  INVADER_PROJECTILE_DESCRIPTOR,
   INVADER_ROW_DESCRIPTORS,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTORS
 } from "./sprite-data";
 
@@ -65,6 +67,10 @@ const SPRITE_REGISTRY = {
   "player-projectile": prepareSprite(
     SPRITE_DESCRIPTOR_REGISTRY["player-projectile"]!
   ),
+  "invader-projectile": prepareSprite(
+    SPRITE_DESCRIPTOR_REGISTRY["invader-projectile"]!
+  ),
+  "shield-cell": prepareSprite(SPRITE_DESCRIPTOR_REGISTRY["shield-cell"]!),
   ...INVADER_ROW_SPRITES
 } satisfies Record<string, PreparedSprite>;
 


### PR DESCRIPTION
## Add shield-cell and invader-projectile sprite descriptors

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #475

### Changes
Add first-class sprite descriptors so the canvas renderer can draw shields and enemy shots procedurally (no external images). (1) Create src/render/sprite-data/shield-cell.ts exporting SHIELD_CELL_DESCRIPTOR (id: 'shield-cell') — a small blocky pixel-art frame with a single palette key; keep dimensions consistent with SHIELD_CELL_COLS / shield cell sizing in src/game/state.ts. (2) Extend src/render/sprite-data/projectiles.ts with INVADER_PROJECTILE_DESCRIPTOR (id: 'invader-projectile') — a distinct bitmap/palette from PLAYER_PROJECTILE_DESCRIPTOR so the two shot types are visually unambiguous (e.g. zig-zag bolt in a different color). (3) Update src/render/sprite-data/index.ts to re-export both new descriptors and include them in SPRITE_DESCRIPTORS so they flow through SPRITE_DESCRIPTOR_REGISTRY and getSprite(). (4) Create src/render/sprite-data/index.test.ts with Vitest cases that (a) assert SPRITE_DESCRIPTOR_REGISTRY contains 'shield-cell' and 'invader-projectile', (b) assert getSprite resolves both to a PreparedSprite with frames.length >= 1, (c) assert the two projectile descriptors have distinct palette colors.

Scope clarification: this task must register the new descriptors through the real sprite registry and public sprite lookup path. Update src/render/sprites.ts and src/render/sprites.test.ts as needed so shield-cell and invader-projectile are first-class sprite keys. Do not fake membership with Proxy/Object.defineProperty or other runtime indirection in sprite-data/index.ts.

Review clarification: do not use Proxy/Object.defineProperty/non-enumerable getters in src/render/sprite-data/index.ts. The new descriptors must be normal enumerable members of SPRITE_DESCRIPTORS and SPRITE_DESCRIPTOR_REGISTRY, and getSprite/SpriteKey in src/render/sprites.ts must expose them through the real public path. Also match sprite dimensions to gameplay constants: invader projectiles are `INVADER_PROJECTILE_WIDTH` by `INVADER_PROJECTILE_HEIGHT` (currently 6 by 18), and shield-cell descriptors should align with SHIELD_CELL_WIDTH/SHIELD_CELL_HEIGHT.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*