### PR TITLE
feature: Refactor renderFallback in main.ts to DOM-safe, injectable implementation

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -44,6 +44,90 @@ class FakeBeforeUnloadTarget {
   }
 }
 
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly tagName: string;
+  className = "";
+  textContent: string | null = null;
+  private readonly attributes = new Map<string, string>();
+
+  constructor(tagName: string) {
+    this.tagName = tagName.toUpperCase();
+  }
+
+  append(...nodes: FakeElement[]): void {
+    this.children.push(...nodes);
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    this.children.length = 0;
+    this.children.push(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    for (const child of this.children) {
+      if (child.matches(selector)) {
+        return child;
+      }
+
+      const match = child.querySelector(selector);
+      if (match !== null) {
+        return match;
+      }
+    }
+
+    return null;
+  }
+
+  private matches(selector: string): boolean {
+    if (selector.startsWith(".")) {
+      return this.className
+        .split(/\s+/u)
+        .filter((token) => token.length > 0)
+        .includes(selector.slice(1));
+    }
+
+    return this.tagName === selector.toUpperCase();
+  }
+}
+
+class FakeCanvasElement extends FakeElement {
+  constructor() {
+    super("canvas");
+  }
+
+  getContext(): null {
+    return null;
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement("body");
+  hidden = false;
+
+  addEventListener(): void {}
+
+  removeEventListener(): void {}
+
+  createElement(tagName: "canvas"): FakeCanvasElement;
+  createElement(tagName: string): FakeElement;
+  createElement(tagName: string): FakeElement {
+    return tagName === "canvas" ? new FakeCanvasElement() : new FakeElement(tagName);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.body.querySelector(selector);
+  }
+}
+
 function createInput(input: Partial<Input> = {}): Input { return { ...EMPTY_INPUT, ...input }; }
 function createHarness(options: HarnessOptions = {}) {
   const storage = new FakeStorage({
@@ -209,6 +293,39 @@ describe("bootstrap", () => {
   });
   it("throws when the game canvas is missing", () => {
     expect(() => bootstrap({ findCanvas: () => null })).toThrowError("Game canvas not found.");
+  });
+
+  it("renders the canvas fallback into the injected document as plain text", () => {
+    const fallbackDocument = new FakeDocument();
+    const frame = fallbackDocument.createElement("section");
+    frame.className = "frame";
+    frame.setAttribute("aria-label", "Game shell");
+    fallbackDocument.body.append(frame);
+
+    const canvas = fallbackDocument.createElement("canvas");
+    const title = 'Canvas <script type="text/javascript">window.hacked = true</script>';
+    const detail = "Use <strong>Canvas 2D</strong> support instead.";
+
+    expect(() =>
+      bootstrap({
+        canvasUnavailableFallback: { title, detail },
+        document: fallbackDocument as unknown as Document,
+        findCanvas: () => canvas as unknown as HTMLCanvasElement
+      })
+    ).toThrowError("Canvas 2D is unavailable.");
+
+    const fallback = frame.querySelector(".fallback");
+    const children = fallback === null ? [] : Array.from(fallback.children);
+
+    expect(fallback).not.toBeNull();
+    expect(fallback?.getAttribute("role")).toBe("alert");
+    expect(children).toHaveLength(2);
+    expect(children[0]?.tagName).toBe("H1");
+    expect(children[0]?.textContent).toBe(title);
+    expect(children[1]?.tagName).toBe("P");
+    expect(children[1]?.textContent).toBe(detail);
+    expect(fallbackDocument.querySelector("script")).toBeNull();
+    expect(fallbackDocument.querySelector("strong")).toBeNull();
   });
 
   it("removes the beforeunload listener when disposed", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,13 +19,32 @@ import { createVisibilityPauseController } from "./visibility";
 const FIXED_TIMESTEP_MS = 1000 / 60;
 type RuntimeRenderFlags = Parameters<CanvasRenderer["render"]>[1];
 type KeyboardController = ReturnType<typeof createKeyboardController>;
+type BootstrapDocument = Pick<
+  Document,
+  | "addEventListener"
+  | "removeEventListener"
+  | "createElement"
+  | "hidden"
+  | "querySelector"
+>;
+type FallbackContent = Readonly<{
+  title: string;
+  detail: string;
+}>;
+
+const CANVAS_UNAVAILABLE_FALLBACK: FallbackContent = {
+  title: "Canvas 2D is unavailable in this browser.",
+  detail: "This MVP needs a browser with Canvas 2D support."
+};
 
 export function bootstrap(
   options: {
     beforeUnloadTarget?: Pick<Window, "addEventListener" | "removeEventListener">;
+    canvasUnavailableFallback?: FallbackContent;
     createLoop?: typeof createFixedStepLoop;
     createVisibilityPauseController?: typeof createVisibilityPauseController;
     deriveSfxEvents?: typeof deriveSfxEvents;
+    document?: BootstrapDocument;
     findCanvas?: () => HTMLCanvasElement | null;
     highScoreStore?: ReturnType<typeof createHighScoreStore>;
     initialState?: GameState;
@@ -40,9 +59,16 @@ export function bootstrap(
     visibilityTarget?: Pick<Document, "addEventListener" | "removeEventListener">;
   } = {}
 ) {
-  const resolveHidden = options.isHidden ?? (() => getDefaultDocument().hidden);
+  const getBootstrapDocument = (): BootstrapDocument =>
+    options.document ?? getDefaultDocument();
+  const resolveHidden = options.isHidden ?? (() => getBootstrapDocument().hidden);
   const renderer =
-    options.renderer ?? createRenderer(getRequiredCanvas(options.findCanvas));
+    options.renderer ??
+    createRenderer(
+      getRequiredCanvas(options.findCanvas, getBootstrapDocument),
+      getBootstrapDocument(),
+      options.canvasUnavailableFallback ?? CANVAS_UNAVAILABLE_FALLBACK
+    );
   const keyboard =
     options.keyboard ??
     createKeyboardController(options.keyboardTarget ?? getDefaultWindow());
@@ -54,7 +80,7 @@ export function bootstrap(
   const createVisibilityController =
     options.createVisibilityPauseController ?? createVisibilityPauseController;
   const advanceGameState = options.step ?? step;
-  const visibilityTarget = options.visibilityTarget ?? getDefaultDocument();
+  const visibilityTarget = options.visibilityTarget ?? getBootstrapDocument();
   const beforeUnloadTarget =
     options.beforeUnloadTarget ?? getDefaultWindow();
   let bootstrapping = true;
@@ -164,28 +190,39 @@ export function bootstrap(
   };
 }
 
-function renderFallback(title: string, detail: string): void {
-  const shell = document.querySelector(".frame");
+function renderFallback(
+  documentRef: Pick<BootstrapDocument, "createElement" | "querySelector">,
+  title: string,
+  detail: string
+): void {
+  const shell = documentRef.querySelector<HTMLElement>(".frame");
   if (shell === null) {
     return;
   }
 
-  shell.innerHTML = `
-    <section class="fallback" role="alert">
-      <h1>${title}</h1>
-      <p>${detail}</p>
-    </section>
-  `;
+  const fallback = documentRef.createElement("section");
+  fallback.className = "fallback";
+  fallback.setAttribute("role", "alert");
+
+  const heading = documentRef.createElement("h1");
+  heading.textContent = title;
+
+  const copy = documentRef.createElement("p");
+  copy.textContent = detail;
+
+  fallback.append(heading, copy);
+  shell.replaceChildren(fallback);
 }
 
-function createRenderer(canvasElement: HTMLCanvasElement): CanvasRenderer {
+function createRenderer(
+  canvasElement: HTMLCanvasElement,
+  documentRef: Pick<BootstrapDocument, "createElement" | "querySelector">,
+  fallbackContent: FallbackContent
+): CanvasRenderer {
   try {
     return createCanvasRenderer(canvasElement);
   } catch (error) {
-    renderFallback(
-      "Canvas 2D is unavailable in this browser.",
-      "This MVP needs a browser with Canvas 2D support."
-    );
+    renderFallback(documentRef, fallbackContent.title, fallbackContent.detail);
     throw error;
   }
 }
@@ -211,11 +248,12 @@ function maybeGetWindow(): Window | undefined {
 }
 
 function getRequiredCanvas(
-  findCanvas: (() => HTMLCanvasElement | null) | undefined
+  findCanvas: (() => HTMLCanvasElement | null) | undefined,
+  getDocument: () => Pick<BootstrapDocument, "querySelector">
 ): HTMLCanvasElement {
   const canvas =
     findCanvas === undefined
-      ? getDefaultDocument().querySelector<HTMLCanvasElement>("#game")
+      ? getDocument().querySelector<HTMLCanvasElement>("#game")
       : findCanvas();
 
   if (canvas === null) {


### PR DESCRIPTION
## Refactor renderFallback in main.ts to DOM-safe, injectable implementation

**Category:** `feature` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #505

### Changes
In src/main.ts, rewrite the `renderFallback` helper so it does not use `shell.innerHTML` or interpolate `title`/`detail` into a template literal. Instead build the fallback DOM with typed `document.createElement` calls (e.g. a `<div>` wrapper containing an `<h1>` or `<h2>` for the title and a `<p>` for the detail) and assign text via `textContent` only — no `innerHTML` anywhere in the fallback path. Replace the direct `document.querySelector('.frame')` lookup with a lookup routed through the existing bootstrap options bag: reuse the same `visibilityTarget`/`getDefaultDocument` (or equivalent) pattern already used elsewhere in `bootstrap`, so the fallback picks up the injected document rather than the ambient global. Preserve any existing class names / ARIA attributes on the fallback node so the CSS + a11y semantics do not regress. Then update src/main.test.ts: add (or extend) a test that drives the canvas-unavailable fallback path using an injected fake document and asserts the rendered nodes — check that the title and detail appear as `textContent` on distinct child elements (not via innerHTML), and that no `<script>`/HTML from the title or detail strings is ever parsed as markup (e.g. pass a string containing `<script>` and assert it appears as text, not as a real element). Keep the happy-path bootstrap tests green.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*