### PR TITLE
feature: Add shield-cell and invader-projectile sprite descriptors

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -1,13 +1,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createGameState, createPlayingState } from "../game/state";
+import {
+  INVADER_PROJECTILE_HEIGHT,
+  INVADER_PROJECTILE_WIDTH,
+  PROJECTILE_HEIGHT,
+  PROJECTILE_WIDTH,
+  createGameState,
+  createPlayingState
+} from "../game/state";
 import { CONTROL_FOOTER, OVERLAY_PROMPTS } from "../input/bindings";
 import { createCanvasRenderer } from "./canvas";
-import { PLAYER_SHIP_DESCRIPTOR } from "./sprites";
+import {
+  INVADER_PROJECTILE_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  PLAYER_SHIP_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR
+} from "./sprites";
 
 const HUD_TOP = 18;
 const HUD_HEIGHT = 68;
 const HUD_SHIP_COLORS = new Set(Object.values(PLAYER_SHIP_DESCRIPTOR.palette));
+const SHIELD_CELL_COLORS = new Set(Object.values(SHIELD_CELL_DESCRIPTOR.palette));
+const PLAYER_PROJECTILE_COLORS = new Set(
+  Object.values(PLAYER_PROJECTILE_DESCRIPTOR.palette)
+);
+const INVADER_PROJECTILE_COLORS = new Set(
+  Object.values(INVADER_PROJECTILE_DESCRIPTOR.palette)
+);
 const PLAYER_INVULNERABILITY_HALO_COLOR = "rgba(123, 229, 255, 0.22)";
 const PLAYER_INVULNERABILITY_HALO_MARGIN = 12;
 const PLAYER_SHIP_PIXEL_COUNT = PLAYER_SHIP_DESCRIPTOR.frames.reduce(
@@ -160,6 +179,27 @@ function countClusters(values: number[]): number {
   }
 
   return clusterCount;
+}
+
+function getColoredFillRectsInBounds(
+  context: FakeCanvasContext,
+  colors: ReadonlySet<string>,
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+): FillRectCall[] {
+  return context.fillRectCalls.filter(
+    (call) =>
+      typeof call.fillStyle === "string" &&
+      colors.has(call.fillStyle) &&
+      call.x >= bounds.x &&
+      call.y >= bounds.y &&
+      call.x + call.width <= bounds.x + bounds.width &&
+      call.y + call.height <= bounds.y + bounds.height
+  );
 }
 
 function getPlayerShipFillRects(
@@ -327,6 +367,127 @@ describe("createCanvasRenderer", () => {
           call.y < HUD_TOP + HUD_HEIGHT
       )
     ).toBe(true);
+  });
+
+  it("renders live shield cells with the registered shield-cell sprite", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const baseState = createPlayingState();
+    const aliveCell = baseState.shields[0]?.cells[0];
+    const deadCell = baseState.shields[0]?.cells[1];
+
+    if (aliveCell === undefined || deadCell === undefined) {
+      throw new Error("Test state must include shield cells.");
+    }
+
+    const state = {
+      ...baseState,
+      invaders: [],
+      projectiles: [],
+      shields: [
+        {
+          id: 1,
+          cells: [aliveCell, { ...deadCell, alive: false }]
+        }
+      ]
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      audioStatus: "ready"
+    });
+
+    const aliveShieldRects = getColoredFillRectsInBounds(
+      context,
+      SHIELD_CELL_COLORS,
+      aliveCell
+    );
+    const deadShieldRects = getColoredFillRectsInBounds(
+      context,
+      SHIELD_CELL_COLORS,
+      deadCell
+    );
+
+    expect(aliveShieldRects.length).toBeGreaterThan(0);
+    expect(deadShieldRects).toHaveLength(0);
+
+    for (const call of aliveShieldRects) {
+      expect(call.width).toBe(SHIELD_CELL_DESCRIPTOR.pixelSize);
+      expect(call.height).toBe(SHIELD_CELL_DESCRIPTOR.pixelSize);
+    }
+  });
+
+  it("uses the invader projectile sprite for enemy shots and keeps player shots unchanged", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const context = new FakeCanvasContext();
+    const canvas = createFakeCanvas(context);
+    const renderer = createCanvasRenderer(canvas);
+    const state = {
+      ...createPlayingState(),
+      invaders: [],
+      shields: [],
+      projectiles: [
+        {
+          id: 1,
+          owner: "player" as const,
+          x: 180,
+          y: 220,
+          width: PROJECTILE_WIDTH,
+          height: PROJECTILE_HEIGHT,
+          velocityY: 0,
+          active: true
+        },
+        {
+          id: 2,
+          owner: "invader" as const,
+          x: 260,
+          y: 260,
+          width: INVADER_PROJECTILE_WIDTH,
+          height: INVADER_PROJECTILE_HEIGHT,
+          velocityY: 0,
+          active: true
+        }
+      ]
+    };
+
+    renderer.render(state, {
+      bootstrapping: false,
+      highScore: 0,
+      audioStatus: "ready"
+    });
+
+    const [playerProjectile, invaderProjectile] = state.projectiles;
+
+    if (playerProjectile === undefined || invaderProjectile === undefined) {
+      throw new Error("Test state must include both projectile types.");
+    }
+
+    expect(
+      getColoredFillRectsInBounds(
+        context,
+        PLAYER_PROJECTILE_COLORS,
+        playerProjectile
+      )
+    ).not.toHaveLength(0);
+    expect(
+      getColoredFillRectsInBounds(
+        context,
+        INVADER_PROJECTILE_COLORS,
+        invaderProjectile
+      )
+    ).not.toHaveLength(0);
+    expect(
+      getColoredFillRectsInBounds(
+        context,
+        PLAYER_PROJECTILE_COLORS,
+        invaderProjectile
+      )
+    ).toHaveLength(0);
   });
 
   it("renders distinct badge text for muted and unavailable audio", () => {

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -1,5 +1,5 @@
 import type { AudioStatus } from "../audio/sfx";
-import type { GameState, Invader, Projectile } from "../game/state";
+import type { GameState, Invader, Projectile, Shield } from "../game/state";
 import { CONTROL_FOOTER, OVERLAY_PROMPTS } from "../input/bindings";
 import {
   getSprite,
@@ -115,6 +115,7 @@ function drawScene(
   drawBackground(context, state);
   drawHud(context, state, flags);
   drawInvaders(context, state.invaders, state.marchFrame);
+  drawShields(context, state.shields);
   drawProjectiles(context, state.projectiles);
   drawPlayer(context, state);
   drawFloor(context, state);
@@ -284,9 +285,15 @@ function drawProjectiles(
   context: CanvasRenderingContext2D,
   projectiles: Projectile[]
 ): void {
-  const projectileSprite = getSprite("player-projectile");
+  const playerProjectileSprite = getSprite("player-projectile");
+  const invaderProjectileSprite = getSprite("invader-projectile");
 
   for (const projectile of projectiles) {
+    const projectileSprite =
+      projectile.owner === "invader"
+        ? invaderProjectileSprite
+        : playerProjectileSprite;
+
     context.fillStyle = "rgba(114, 226, 255, 0.25)";
     roundRect(context, projectile.x - 3, projectile.y - 6, projectile.width + 6, projectile.height + 12, 6);
     context.fill();
@@ -299,6 +306,31 @@ function drawProjectiles(
       projectile.width,
       projectile.height
     );
+  }
+}
+
+function drawShields(
+  context: CanvasRenderingContext2D,
+  shields: Shield[]
+): void {
+  const shieldCellSprite = getSprite("shield-cell");
+
+  for (const shield of shields) {
+    for (const cell of shield.cells) {
+      if (!cell.alive) {
+        continue;
+      }
+
+      drawSpriteInBounds(
+        context,
+        shieldCellSprite,
+        0,
+        cell.x,
+        cell.y,
+        cell.width,
+        cell.height
+      );
+    }
   }
 }
 

--- a/src/render/sprite-data/index.test.ts
+++ b/src/render/sprite-data/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { getSprite } from "../sprites";
+import {
+  INVADER_PROJECTILE_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
+  SPRITE_DESCRIPTOR_REGISTRY
+} from "./index";
+
+describe("SPRITE_DESCRIPTOR_REGISTRY", () => {
+  it("registers and resolves shield-cell and invader-projectile through the public path", () => {
+    const registryKeys = Object.keys(SPRITE_DESCRIPTOR_REGISTRY);
+
+    for (const descriptor of [
+      SHIELD_CELL_DESCRIPTOR,
+      INVADER_PROJECTILE_DESCRIPTOR
+    ]) {
+      const sprite = getSprite(descriptor.id);
+
+      expect(registryKeys).toContain(descriptor.id);
+      expect(SPRITE_DESCRIPTOR_REGISTRY[descriptor.id]).toBe(descriptor);
+      expect(descriptor.frames.length).toBeGreaterThanOrEqual(1);
+      expect(sprite.frameCount).toBeGreaterThanOrEqual(1);
+      expect(sprite.sheet.getFrameCount()).toBe(descriptor.frames.length);
+    }
+  });
+
+  it("keeps player and invader projectile palettes visually distinct", () => {
+    const playerColors = new Set(Object.values(PLAYER_PROJECTILE_DESCRIPTOR.palette));
+    const invaderColors = new Set(
+      Object.values(INVADER_PROJECTILE_DESCRIPTOR.palette)
+    );
+
+    expect(
+      [...playerColors].some((color) => invaderColors.has(color))
+    ).toBe(false);
+  });
+});

--- a/src/render/sprite-data/index.ts
+++ b/src/render/sprite-data/index.ts
@@ -1,7 +1,11 @@
 import type { SpriteDescriptor } from "../sprites";
 import { INVADER_ROW_DESCRIPTORS } from "./invaders";
 import { PLAYER_SHIP_DESCRIPTOR as SOURCE_PLAYER_SHIP_DESCRIPTOR } from "./player-ship";
-import { PLAYER_PROJECTILE_DESCRIPTOR as SOURCE_PLAYER_PROJECTILE_DESCRIPTOR } from "./projectiles";
+import {
+  INVADER_PROJECTILE_DESCRIPTOR as SOURCE_INVADER_PROJECTILE_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR as SOURCE_PLAYER_PROJECTILE_DESCRIPTOR
+} from "./projectiles";
+import { SHIELD_CELL_DESCRIPTOR as SOURCE_SHIELD_CELL_DESCRIPTOR } from "./shield-cell";
 
 export { INVADER_ROW_DESCRIPTORS };
 
@@ -19,10 +23,26 @@ export const PLAYER_PROJECTILE_DESCRIPTOR = {
   pixelSize: SOURCE_PLAYER_PROJECTILE_DESCRIPTOR.pixelSize
 } as const satisfies SpriteDescriptor;
 
+export const INVADER_PROJECTILE_DESCRIPTOR = {
+  id: "invader-projectile",
+  frames: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.frames,
+  palette: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.palette,
+  pixelSize: SOURCE_INVADER_PROJECTILE_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
+
+export const SHIELD_CELL_DESCRIPTOR = {
+  id: "shield-cell",
+  frames: SOURCE_SHIELD_CELL_DESCRIPTOR.frames,
+  palette: SOURCE_SHIELD_CELL_DESCRIPTOR.palette,
+  pixelSize: SOURCE_SHIELD_CELL_DESCRIPTOR.pixelSize
+} as const satisfies SpriteDescriptor;
+
 export const SPRITE_DESCRIPTORS = [
   PLAYER_SHIP_DESCRIPTOR,
   ...INVADER_ROW_DESCRIPTORS,
-  PLAYER_PROJECTILE_DESCRIPTOR
+  SHIELD_CELL_DESCRIPTOR,
+  PLAYER_PROJECTILE_DESCRIPTOR,
+  INVADER_PROJECTILE_DESCRIPTOR
 ] as const satisfies readonly SpriteDescriptor[];
 
 type SpriteDescriptorRegistry<
@@ -50,6 +70,8 @@ export const SPRITE_DESCRIPTOR_REGISTRY = buildSpriteDescriptorRegistry(
     "invader-row-2": INVADER_ROW_DESCRIPTORS[2],
     "invader-row-3": INVADER_ROW_DESCRIPTORS[3],
     "invader-row-4": INVADER_ROW_DESCRIPTORS[4],
-    "player-projectile": PLAYER_PROJECTILE_DESCRIPTOR
+    "shield-cell": SHIELD_CELL_DESCRIPTOR,
+    "player-projectile": PLAYER_PROJECTILE_DESCRIPTOR,
+    "invader-projectile": INVADER_PROJECTILE_DESCRIPTOR
   }
 );

--- a/src/render/sprite-data/projectiles.ts
+++ b/src/render/sprite-data/projectiles.ts
@@ -1,5 +1,9 @@
 import type { SpriteDescriptor } from "../sprites";
 
+const INVADER_PROJECTILE_FRAMES = [
+  [".vv.", "..vv", ".vv.", "vv..", ".vv.", "..vv", ".vv.", "vv..", ".vv."]
+] as const;
+
 export const PLAYER_PROJECTILE_DESCRIPTOR = {
   id: "player-projectile",
   frames: [["p.", "pp", "pp", "pp", "pp", ".p"]],
@@ -7,4 +11,13 @@ export const PLAYER_PROJECTILE_DESCRIPTOR = {
     p: "#f7fbff"
   },
   pixelSize: 3
+} satisfies SpriteDescriptor;
+
+export const INVADER_PROJECTILE_DESCRIPTOR = {
+  id: "invader-projectile",
+  frames: INVADER_PROJECTILE_FRAMES,
+  palette: {
+    v: "#ff9f68"
+  },
+  pixelSize: 2
 } satisfies SpriteDescriptor;

--- a/src/render/sprite-data/shield-cell.ts
+++ b/src/render/sprite-data/shield-cell.ts
@@ -1,0 +1,14 @@
+import type { SpriteDescriptor } from "../sprites";
+
+const SHIELD_CELL_FRAMES = [
+  [".ssssss.", "ssssssss", "ssssssss", "ssssssss", "ssssssss", ".ssssss."]
+] as const;
+
+export const SHIELD_CELL_DESCRIPTOR = {
+  id: "shield-cell",
+  frames: SHIELD_CELL_FRAMES,
+  palette: {
+    s: "#74f7a6"
+  },
+  pixelSize: 2
+} satisfies SpriteDescriptor;

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -4,8 +4,10 @@ import { SPRITE_DESCRIPTOR_REGISTRY } from "./sprite-data";
 import {
   EMPTY_PIXEL,
   INVADER_ROW_DESCRIPTORS,
+  INVADER_PROJECTILE_DESCRIPTOR,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTORS,
   createSpriteSheet,
   getSprite,
@@ -81,12 +83,16 @@ function countFilledPixels(frame: readonly string[]): number {
 }
 
 describe("createSpriteSheet", () => {
-  it("includes descriptors for the player, each invader row, and the projectile", () => {
-    expect(SPRITE_DESCRIPTORS).toHaveLength(7);
+  it("includes descriptors for the player, each invader row, the shield cell, and both projectile types", () => {
+    expect(SPRITE_DESCRIPTORS).toHaveLength(9);
     expect(INVADER_ROW_DESCRIPTORS).toHaveLength(5);
 
     expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(SHIELD_CELL_DESCRIPTOR).getFrameCount()).toBe(1);
     expect(createSpriteSheet(PLAYER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(INVADER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(
+      1
+    );
 
     for (const descriptor of INVADER_ROW_DESCRIPTORS) {
       expect(createSpriteSheet(descriptor).getFrameCount()).toBe(2);
@@ -253,9 +259,14 @@ describe("getSprite", () => {
       PLAYER_SHIP_DESCRIPTOR,
       2
     );
+    expectPreparedSpriteToMatchDescriptor("shield-cell", SHIELD_CELL_DESCRIPTOR);
     expectPreparedSpriteToMatchDescriptor(
       "player-projectile",
       PLAYER_PROJECTILE_DESCRIPTOR
+    );
+    expectPreparedSpriteToMatchDescriptor(
+      "invader-projectile",
+      INVADER_PROJECTILE_DESCRIPTOR
     );
 
     for (const descriptor of INVADER_ROW_DESCRIPTORS) {

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -39,8 +39,10 @@ export const EMPTY_PIXEL = ".";
 
 export {
   INVADER_ROW_DESCRIPTORS,
+  INVADER_PROJECTILE_DESCRIPTOR,
   PLAYER_PROJECTILE_DESCRIPTOR,
   PLAYER_SHIP_DESCRIPTOR,
+  SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTORS
 } from "./sprite-data";
 
@@ -62,8 +64,12 @@ const INVADER_ROW_SPRITES = Object.fromEntries(
 const SPRITE_REGISTRY = {
   "player-ship": prepareSprite(SPRITE_DESCRIPTOR_REGISTRY["player-ship"]!),
   "hud-player-ship": prepareSprite(HUD_PLAYER_SHIP_DESCRIPTOR),
+  "shield-cell": prepareSprite(SPRITE_DESCRIPTOR_REGISTRY["shield-cell"]!),
   "player-projectile": prepareSprite(
     SPRITE_DESCRIPTOR_REGISTRY["player-projectile"]!
+  ),
+  "invader-projectile": prepareSprite(
+    SPRITE_DESCRIPTOR_REGISTRY["invader-projectile"]!
   ),
   ...INVADER_ROW_SPRITES
 } satisfies Record<string, PreparedSprite>;


### PR DESCRIPTION
## Add shield-cell and invader-projectile sprite descriptors

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #475

### Changes
Add first-class sprite descriptors so the canvas renderer can draw shields and enemy shots procedurally (no external images). (1) Create src/render/sprite-data/shield-cell.ts exporting SHIELD_CELL_DESCRIPTOR (id: 'shield-cell') — a small blocky pixel-art frame with a single palette key; keep dimensions consistent with SHIELD_CELL_COLS / shield cell sizing in src/game/state.ts. (2) Extend src/render/sprite-data/projectiles.ts with INVADER_PROJECTILE_DESCRIPTOR (id: 'invader-projectile') — a distinct bitmap/palette from PLAYER_PROJECTILE_DESCRIPTOR so the two shot types are visually unambiguous (e.g. zig-zag bolt in a different color). (3) Update src/render/sprite-data/index.ts to re-export both new descriptors and include them in SPRITE_DESCRIPTORS so they flow through SPRITE_DESCRIPTOR_REGISTRY and getSprite(). (4) Create src/render/sprite-data/index.test.ts with Vitest cases that (a) assert SPRITE_DESCRIPTOR_REGISTRY contains 'shield-cell' and 'invader-projectile', (b) assert getSprite resolves both to a PreparedSprite with frames.length >= 1, (c) assert the two projectile descriptors have distinct palette colors.

Scope clarification: this task must register the new descriptors through the real sprite registry and public sprite lookup path. Update src/render/sprites.ts and src/render/sprites.test.ts as needed so shield-cell and invader-projectile are first-class sprite keys. Do not fake membership with Proxy/Object.defineProperty or other runtime indirection in sprite-data/index.ts.

Review clarification: do not use Proxy/Object.defineProperty/non-enumerable getters in src/render/sprite-data/index.ts. The new descriptors must be normal enumerable members of SPRITE_DESCRIPTORS and SPRITE_DESCRIPTOR_REGISTRY, and getSprite/SpriteKey in src/render/sprites.ts must expose them through the real public path. Also match sprite dimensions to gameplay constants: invader projectiles are `INVADER_PROJECTILE_WIDTH` by `INVADER_PROJECTILE_HEIGHT` (currently 6 by 18), and shield-cell descriptors should align with SHIELD_CELL_WIDTH/SHIELD_CELL_HEIGHT.

Render wiring clarification from review: this task now owns the complete public path for these descriptors. In src/render/canvas.ts, render live shield cells with getSprite("shield-cell") and render invader-owned projectiles with getSprite("invader-projectile") while preserving player projectiles. Add canvas tests that prove shields render via the shield-cell sprite and invader projectiles no longer use the player projectile sprite. This supersedes the older render-shields-and-enemy-bolts task.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*