### PR TITLE
feature: Refactor createSfxController to delegate context/unlock/mute/scheduling to the audio engine

### DIFF
--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -8,6 +8,7 @@ import {
   type Mock
 } from "vitest";
 
+import type { AudioEngine, AudioEngineStatus, ScheduleToneOptions } from "./engine";
 import { createSfxController, type SfxName } from "./sfx";
 
 type MockDestination = {
@@ -69,6 +70,14 @@ type MockWebAudioHarness = {
   readonly gainConstructor: Mock<() => MockGainNode>;
 };
 
+type MockAudioEngine = {
+  arm: Mock<() => Promise<void>>;
+  getStatus: Mock<() => AudioEngineStatus>;
+  now: Mock<() => number>;
+  scheduleTone: Mock<(options: ScheduleToneOptions) => void>;
+  setMuted: Mock<(muted: boolean) => void>;
+} & AudioEngine;
+
 type MockOscillatorConstructor = new () => MockOscillatorNode;
 type MockGainConstructor = new () => MockGainNode;
 
@@ -81,6 +90,45 @@ const SFX_NAMES = [
 const AFTER_SFX_COOLDOWN_SECONDS = 0.031;
 
 let harness: MockWebAudioHarness;
+
+function createMockAudioEngine(
+  initialStatus: AudioEngineStatus = "ready"
+): MockAudioEngine {
+  let status = initialStatus;
+
+  return {
+    arm: vi.fn(async () => {
+      if (status !== "muted") {
+        status = "ready";
+      }
+    }),
+    getStatus: vi.fn(() => status),
+    now: vi.fn(() => 0),
+    scheduleTone: vi.fn<(options: ScheduleToneOptions) => void>(),
+    setMuted: vi.fn((muted) => {
+      status = muted ? "muted" : "ready";
+    })
+  };
+}
+
+function getScheduledToneCall(
+  engine: MockAudioEngine,
+  index: number
+): ScheduleToneOptions {
+  const call = engine.scheduleTone.mock.calls[index];
+
+  if (call === undefined) {
+    throw new Error(`Expected scheduleTone call ${index}.`);
+  }
+
+  const [options] = call;
+
+  if (options === undefined) {
+    throw new Error(`Expected scheduleTone options for call ${index}.`);
+  }
+
+  return options;
+}
 
 function createMockAudioParam(initialValue: number): MockAudioParam {
   const audioParam: MockAudioParam = {
@@ -348,10 +396,26 @@ describe("createSfxController", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns idle before arming", () => {
-    const controller = createSfxController();
+  it("forwards arm, getStatus, and setMuted to the engine", async () => {
+    const engine = createMockAudioEngine("idle");
+    const controller = createSfxController(engine);
 
     expect(controller.getStatus()).toBe("idle");
+
+    await controller.arm();
+
+    expect(engine.arm).toHaveBeenCalledTimes(1);
+    expect(controller.getStatus()).toBe("ready");
+
+    controller.setMuted(true);
+
+    expect(engine.setMuted).toHaveBeenCalledWith(true);
+    expect(controller.getStatus()).toBe("muted");
+
+    controller.setMuted(false);
+
+    expect(engine.setMuted).toHaveBeenLastCalledWith(false);
+    expect(controller.getStatus()).toBe("ready");
   });
 
   it("arms the controller, resumes a suspended context, and becomes ready", async () => {
@@ -368,40 +432,48 @@ describe("createSfxController", () => {
     expect(controller.getStatus()).toBe("ready");
   });
 
-  it("reports unavailable when AudioContext construction fails and play becomes a no-op", async () => {
-    harness.throwOnAudioContextConstruction = true;
+  it("schedules the expected shoot tones through the engine", () => {
+    const engine = createMockAudioEngine();
+    const controller = createSfxController(engine);
 
-    const controller = createSfxController();
-
-    await controller.arm();
-    controller.play("shoot");
-    controller.setMuted(true);
-
-    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
-    expect(controller.getStatus()).toBe("unavailable");
-    expect(harness.oscillators).toHaveLength(0);
-    expect(harness.gains).toHaveLength(0);
-  });
-
-  it("reports unavailable when AudioContext.resume fails and only recovers through a fresh context", async () => {
-    harness.throwOnResume = true;
-
-    const controller = createSfxController();
-
-    await controller.arm();
     controller.play("shoot");
 
-    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(1);
-    expect(controller.getStatus()).toBe("unavailable");
-    expect(harness.oscillators).toHaveLength(0);
-    expect(harness.gains).toHaveLength(0);
+    expect(engine.scheduleTone).toHaveBeenCalledTimes(2);
 
-    harness.throwOnResume = false;
-    await controller.arm();
+    const firstTone = getScheduledToneCall(engine, 0);
+    const secondTone = getScheduledToneCall(engine, 1);
 
-    expect(harness.audioContextConstructor).toHaveBeenCalledTimes(2);
-    expect(controller.getStatus()).toBe("ready");
+    expect(firstTone).toMatchObject({
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square",
+      cooldownSeconds: 0.03,
+      tag: "shoot"
+    });
+    expect(firstTone.startOffset).toBe(0);
+
+    expect(secondTone).toMatchObject({
+      frequency: 940,
+      duration: 0.06,
+      gain: 0.04,
+      type: "triangle",
+      tag: "shoot"
+    });
+    expect(secondTone.startOffset).toBeCloseTo(0.0612);
   });
+
+  it.each(["idle", "muted"] as const)(
+    "does not call scheduleTone while %s",
+    (status) => {
+      const engine = createMockAudioEngine(status);
+      const controller = createSfxController(engine);
+
+      controller.play("shoot");
+
+      expect(engine.scheduleTone).not.toHaveBeenCalled();
+    }
+  );
 
   it("reports muted while the user mute preference is enabled, even after arming", async () => {
     const controller = createSfxController();
@@ -529,17 +601,17 @@ describe("createSfxController", () => {
     });
   });
 
-  it("tracks cooldowns independently for each SFX name", async () => {
-    const controller = createSfxController();
-    await controller.arm();
-    const context = getLastContext(harness);
+  it("forwards each SFX name as the cooldown tag", () => {
+    const engine = createMockAudioEngine();
+    const controller = createSfxController(engine);
 
-    context.currentTime = 1;
-    const hitPlayback = capturePlayback(harness, controller, "hit");
-    const shootPlayback = capturePlayback(harness, controller, "shoot");
+    controller.play("hit");
+    controller.play("shoot");
 
-    expect(hitPlayback.oscillators.length).toBeGreaterThan(0);
-    expect(shootPlayback.oscillators.length).toBeGreaterThan(0);
+    expect(getScheduledToneCall(engine, 0).tag).toBe("hit");
+    expect(getScheduledToneCall(engine, 1).tag).toBe("hit");
+    expect(getScheduledToneCall(engine, 2).tag).toBe("shoot");
+    expect(getScheduledToneCall(engine, 3).tag).toBe("shoot");
   });
 
   it("anchors the cooldown to AudioContext.currentTime", async () => {

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,3 +1,5 @@
+import { createAudioEngine, type AudioEngine } from "./engine";
+
 export type SfxName = "shoot" | "hit" | "playerDeath" | "waveClear";
 export type AudioStatus = "idle" | "ready" | "muted" | "unavailable";
 
@@ -16,55 +18,43 @@ type Tone = {
 };
 
 const SFX_COOLDOWN_SECONDS = 0.03;
+const SFX_TONE_OFFSET_SCALE = 0.68;
 
-export function createSfxController(): SfxController {
-  let context: AudioContext | null = null;
-  let status: Exclude<AudioStatus, "muted"> = "idle";
-  let muted = false;
+const SFX_TONE_PATTERNS: Record<SfxName, readonly Tone[]> = {
+  shoot: [
+    { frequency: 720, duration: 0.09, gain: 0.06, type: "square" },
+    { frequency: 940, duration: 0.06, gain: 0.04, type: "triangle" }
+  ],
+  hit: [
+    { frequency: 320, duration: 0.05, gain: 0.08, type: "square" },
+    { frequency: 250, duration: 0.08, gain: 0.05, type: "sawtooth" }
+  ],
+  playerDeath: [
+    { frequency: 220, duration: 0.16, gain: 0.08, type: "sawtooth" },
+    { frequency: 160, duration: 0.2, gain: 0.07, type: "square" },
+    { frequency: 110, duration: 0.25, gain: 0.05, type: "triangle" }
+  ],
+  waveClear: [
+    { frequency: 520, duration: 0.1, gain: 0.05, type: "triangle" },
+    { frequency: 660, duration: 0.1, gain: 0.05, type: "triangle" },
+    { frequency: 840, duration: 0.16, gain: 0.06, type: "triangle" }
+  ]
+};
+
+export function createSfxController(
+  engine: AudioEngine = createAudioEngine()
+): SfxController {
   const lastPlayedAtByName = new Map<SfxName, number>();
 
-  const getStatus = (): AudioStatus => {
-    if (status === "unavailable") {
-      return "unavailable";
-    }
-
-    if (muted) {
-      return "muted";
-    }
-
-    return status;
-  };
-
   return {
-    arm: async () => {
-      try {
-        if (context === null) {
-          context = new AudioContext();
-          lastPlayedAtByName.clear();
-        }
-        if (context.state === "suspended") {
-          await context.resume();
-        }
-        status = "ready";
-      } catch {
-        context = null;
-        status = "unavailable";
-      }
-    },
-    getStatus,
+    arm: engine.arm,
+    getStatus: engine.getStatus,
     play: (name) => {
-      const currentStatus = getStatus();
-
-      if (
-        currentStatus === "muted" ||
-        currentStatus === "unavailable" ||
-        status !== "ready" ||
-        context === null
-      ) {
+      if (engine.getStatus() !== "ready") {
         return;
       }
 
-      const now = context.currentTime;
+      const now = engine.now();
       const lastPlayedAt = lastPlayedAtByName.get(name);
 
       if (
@@ -75,64 +65,27 @@ export function createSfxController(): SfxController {
       }
 
       lastPlayedAtByName.set(name, now);
-      const tones = getTonePattern(name);
-      let offset = 0;
 
-      for (const tone of tones) {
-        playTone(context, now + offset, tone);
-        offset += tone.duration * 0.68;
+      let startOffset = 0;
+      let isFirstTone = true;
+
+      for (const tone of getTonePattern(name)) {
+        engine.scheduleTone({
+          ...tone,
+          startOffset,
+          tag: name,
+          ...(isFirstTone
+            ? { cooldownSeconds: SFX_COOLDOWN_SECONDS }
+            : {})
+        });
+        startOffset += tone.duration * SFX_TONE_OFFSET_SCALE;
+        isFirstTone = false;
       }
     },
-    setMuted: (value) => {
-      muted = value;
-    }
+    setMuted: engine.setMuted
   };
 }
 
-function playTone(
-  context: AudioContext,
-  startTime: number,
-  tone: Tone
-): void {
-  const oscillator = context.createOscillator();
-  const gain = context.createGain();
-  const endTime = startTime + tone.duration;
-
-  oscillator.type = tone.type;
-  oscillator.frequency.setValueAtTime(tone.frequency, startTime);
-  gain.gain.setValueAtTime(0.0001, startTime);
-  gain.gain.exponentialRampToValueAtTime(tone.gain, startTime + 0.02);
-  gain.gain.exponentialRampToValueAtTime(0.0001, endTime);
-
-  oscillator.connect(gain);
-  gain.connect(context.destination);
-  oscillator.start(startTime);
-  oscillator.stop(endTime + 0.02);
-}
-
-function getTonePattern(name: SfxName): Tone[] {
-  switch (name) {
-    case "shoot":
-      return [
-        { frequency: 720, duration: 0.09, gain: 0.06, type: "square" },
-        { frequency: 940, duration: 0.06, gain: 0.04, type: "triangle" }
-      ];
-    case "hit":
-      return [
-        { frequency: 320, duration: 0.05, gain: 0.08, type: "square" },
-        { frequency: 250, duration: 0.08, gain: 0.05, type: "sawtooth" }
-      ];
-    case "playerDeath":
-      return [
-        { frequency: 220, duration: 0.16, gain: 0.08, type: "sawtooth" },
-        { frequency: 160, duration: 0.2, gain: 0.07, type: "square" },
-        { frequency: 110, duration: 0.25, gain: 0.05, type: "triangle" }
-      ];
-    case "waveClear":
-      return [
-        { frequency: 520, duration: 0.1, gain: 0.05, type: "triangle" },
-        { frequency: 660, duration: 0.1, gain: 0.05, type: "triangle" },
-        { frequency: 840, duration: 0.16, gain: 0.06, type: "triangle" }
-      ];
-  }
+function getTonePattern(name: SfxName): readonly Tone[] {
+  return SFX_TONE_PATTERNS[name];
 }


### PR DESCRIPTION
## Refactor createSfxController to delegate context/unlock/mute/scheduling to the audio engine

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #429

### Changes
Rework src/audio/sfx.ts so createSfxController becomes a thin layer over createAudioEngine. The exported SfxController type (arm, getStatus, play, setMuted) and SfxName union must stay byte-identical at the public-API level so existing callers in src/main.ts, src/runtime.ts, and src/audio/events.ts compile unchanged. Internally: accept an optional engine parameter (defaulting to createAudioEngine()) for test injection; delegate arm, getStatus, and setMuted directly to the engine; keep only the SFX-specific tone table (shoot / hit / playerDeath / waveClear) and call engine.scheduleTone for each tone, passing the SfxName as the cooldown tag so per-sound cooldown semantics match today's behavior. Update src/audio/sfx.test.ts to inject a fake engine (exposing arm, getStatus, setMuted, scheduleTone mocks) and assert (a) play('shoot') invokes scheduleTone with the expected frequency/duration/gain/type, (b) muted or idle states short-circuit before scheduleTone is called, (c) per-name cooldown tag is forwarded, (d) setMuted/getStatus are forwarded to the engine. Remove any logic that is now owned by the engine (context construction, resume, mute flag bookkeeping, oscillator graph wiring, currentTime reads) from sfx.ts — do not duplicate it.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*