### PR TITLE
bug_fix: Remove duplicate high-score persistence from main.ts

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -22,13 +22,14 @@ type ListenerRecord = {
 
 class FakeStorage implements Storage {
   private readonly entries = new Map<string, string>();
+  readonly setItemCalls: Array<{ key: string; value: string }> = [];
   constructor(seed: Record<string, string>) { for (const [key, value] of Object.entries(seed)) this.entries.set(key, value); }
   get length(): number { return this.entries.size; }
   clear(): void { this.entries.clear(); }
   getItem(key: string): string | null { return this.entries.get(key) ?? null; }
   key(index: number): string | null { return [...this.entries.keys()][index] ?? null; }
   removeItem(key: string): void { this.entries.delete(key); }
-  setItem(key: string, value: string): void { this.entries.set(key, value); }
+  setItem(key: string, value: string): void { this.setItemCalls.push({ key, value }); this.entries.set(key, value); }
 }
 
 class FakeBeforeUnloadTarget {
@@ -243,15 +244,18 @@ describe("bootstrap", () => {
 
     expect(harness.latestRender().flags.audioStatus).toBe("unavailable");
   });
-  it("records a new high score when gameplay reaches game over", () => {
+  it("records a new high score when the runtime reports a score increase", () => {
     const harness = createHarness({
       initialHighScore: 200,
       initialState: createPlayingState({ score: 180 }),
-      step: (state) => ({ ...state, phase: "gameOver", hud: { ...state.hud, score: 320 } })
+      step: (state) => ({ ...state, hud: { ...state.hud, score: 320 } })
     });
     harness.frame();
+    expect(harness.storage.setItemCalls).toEqual([
+      { key: HIGH_SCORE_STORAGE_KEY, value: "320" }
+    ]);
     expect(harness.storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("320");
-    expect(harness.latestRender().state.phase).toBe("gameOver");
+    expect(harness.latestRender().state.phase).toBe("playing");
     expect(harness.latestRender().flags.highScore).toBe(320);
   });
   it("auto-pauses on hide and skips simulation work while hidden", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { deriveSfxEvents, mapGameEventsToSfxEvents } from "./audio/events";
 import { createMuteStore } from "./audio/mute";
 import { createSfxController } from "./audio/sfx";
-import { deriveGameEvents, type GameEvent } from "./game/events";
+import { deriveGameEvents } from "./game/events";
 import {
   EMPTY_INPUT,
   createInitialGameState,
@@ -102,13 +102,13 @@ export function bootstrap(
     previousState: GameState,
     nextState: GameState
   ) => {
-    const gameEvents = deriveGameEvents(previousState, nextState);
+    if (options.deriveSfxEvents !== undefined) {
+      return options.deriveSfxEvents(previousState, nextState);
+    }
 
-    recordHighScoreFromEvents(highScoreStore, gameEvents);
-
-    return options.deriveSfxEvents === undefined
-      ? mapGameEventsToSfxEvents(gameEvents)
-      : options.deriveSfxEvents(previousState, nextState);
+    return mapGameEventsToSfxEvents(
+      deriveGameEvents(previousState, nextState)
+    );
   };
 
   const runtime = createGameRuntime({
@@ -119,7 +119,9 @@ export function bootstrap(
     readInput,
     sfxController: sfx,
     step: (state, dtMs, input) => advanceGameState(state, dtMs, cloneInput(input)),
-    writeHighScore: () => undefined
+    writeHighScore: (score) => {
+      highScoreStore.recordScore(score);
+    }
   });
 
   const renderRuntime = (): void => {
@@ -284,17 +286,6 @@ function createPauseInput(): Input {
     ...EMPTY_INPUT,
     pausePressed: true
   };
-}
-
-function recordHighScoreFromEvents(
-  highScoreStore: Pick<ReturnType<typeof createHighScoreStore>, "recordScore">,
-  events: readonly GameEvent[]
-): void {
-  for (const event of events) {
-    if (event.type === "scoreChanged") {
-      highScoreStore.recordScore(event.nextScore);
-    }
-  }
 }
 
 if (typeof window !== "undefined" && typeof document !== "undefined") {


### PR DESCRIPTION
## Remove duplicate high-score persistence from main.ts

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #540

### Changes
Consolidate high-score persistence in the runtime. In src/main.ts: (1) delete the `recordHighScoreFromEvents` helper and any code inside `deriveTransitionAudioEvents` (or similar) that calls `highScoreStore.recordScore` based on game events; (2) change the `writeHighScore: () => undefined` stub passed to `createGameRuntime` into `writeHighScore: (score) => { highScoreStore.recordScore(score); }` (or equivalent forwarding to the store). The runtime's 'Persist high score on score change events' path should now be the sole writer. Then update src/main.test.ts so the persistence assertion exercises the runtime path: verify that when the runtime reports a score change (e.g. via `runtime.tick`/harness flow that mutates score), `highScoreStore.recordScore` is invoked (or that `FakeStorage.setItemCalls` records a write to the high-score key). Remove any tests that exclusively covered the deleted `recordHighScoreFromEvents` helper. Keep behavior equivalent — high scores must still persist end-to-end after the change.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*