### PR TITLE
feature: Co-locate Input copy helpers with the Input type and make assignInput exhaustive

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  EMPTY_INPUT,
   FORMATION_SPEED_BASE,
   FORMATION_SPEED_MAX,
-  getFormationSpeed
+  assignInput,
+  cloneInput,
+  createPauseInput,
+  getFormationSpeed,
+  type Input
 } from "./state";
+
+function getInputKeys(): Array<keyof Input> {
+  return Object.keys(EMPTY_INPUT) as Array<keyof Input>;
+}
 
 describe("getFormationSpeed", () => {
   it("returns the wave start speed when invaderCount exceeds totalInvaders", () => {
@@ -39,5 +48,49 @@ describe("getFormationSpeed", () => {
     expect(getFormationSpeed(5, waveStartSpeed, 10)).toBe(
       waveStartSpeed + (FORMATION_SPEED_MAX - waveStartSpeed) / 2
     );
+  });
+});
+
+describe("input helpers", () => {
+  it("round-trips every EMPTY_INPUT field through cloneInput", () => {
+    const clonedInput = cloneInput(EMPTY_INPUT);
+
+    expect(clonedInput).toEqual(EMPTY_INPUT);
+
+    for (const key of getInputKeys()) {
+      expect(clonedInput[key]).toEqual(EMPTY_INPUT[key]);
+    }
+  });
+
+  it("copies every Input field through assignInput", () => {
+    const target = cloneInput(EMPTY_INPUT);
+    const source: Input = {
+      moveX: 1,
+      firePressed: true,
+      pausePressed: true,
+      fireHeld: true,
+      pauseHeld: true,
+      mutePressed: true
+    };
+
+    assignInput(target, source);
+
+    for (const key of getInputKeys()) {
+      expect(target[key]).toBe(source[key]);
+    }
+  });
+
+  it("creates a pause-only input from EMPTY_INPUT defaults", () => {
+    const pauseInput = createPauseInput();
+
+    expect(pauseInput.pausePressed).toBe(true);
+
+    for (const key of getInputKeys()) {
+      if (key === "pausePressed") {
+        continue;
+      }
+
+      expect(pauseInput[key]).toBe(EMPTY_INPUT[key]);
+    }
   });
 });

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -163,8 +163,55 @@ export const EMPTY_INPUT: Input = {
   mutePressed: false
 };
 
+type KeysEqual<A extends PropertyKey, B extends PropertyKey> =
+  [Exclude<A, B>, Exclude<B, A>] extends [never, never] ? true : false;
+
+function defineInputKeys<const T extends readonly (keyof Input)[]>(
+  keys: KeysEqual<keyof Input, T[number]> extends true ? T : never
+): T {
+  return keys;
+}
+
+const INPUT_KEYS = defineInputKeys([
+  "moveX",
+  "firePressed",
+  "pausePressed",
+  "fireHeld",
+  "pauseHeld",
+  "mutePressed"
+] as const);
+
 const ROW_POINTS = [50, 40, 30, 20, 10] as const;
 const FORMATION_SPEED_KILL_MULTIPLIER = 2.7;
+
+function assignInputKey<K extends keyof Input>(
+  target: Input,
+  input: Input,
+  key: K
+): void {
+  target[key] = input[key];
+}
+
+export function cloneInput(input: Input): Input {
+  const clonedInput: Input = { ...EMPTY_INPUT };
+
+  assignInput(clonedInput, input);
+
+  return clonedInput;
+}
+
+export function assignInput(target: Input, input: Input): void {
+  for (const key of INPUT_KEYS) {
+    assignInputKey(target, input, key);
+  }
+}
+
+export function createPauseInput(): Input {
+  return {
+    ...EMPTY_INPUT,
+    pausePressed: true
+  };
+}
 
 export function createInitialGameState(): GameState {
   return createGameState({ phase: "start" });

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,9 @@ import { createSfxController } from "./audio/sfx";
 import { deriveGameEvents } from "./game/events";
 import {
   EMPTY_INPUT,
+  assignInput,
+  cloneInput,
+  createPauseInput,
   createInitialGameState,
   type GameState,
   type Input
@@ -263,29 +266,6 @@ function getRequiredCanvas(
   }
 
   return canvas;
-}
-
-function cloneInput(input: Input): Input {
-  return {
-    ...EMPTY_INPUT,
-    ...input
-  };
-}
-
-function assignInput(target: Input, input: Input): void {
-  target.moveX = input.moveX;
-  target.firePressed = input.firePressed;
-  target.pausePressed = input.pausePressed;
-  target.fireHeld = input.fireHeld;
-  target.pauseHeld = input.pauseHeld;
-  target.mutePressed = input.mutePressed;
-}
-
-function createPauseInput(): Input {
-  return {
-    ...EMPTY_INPUT,
-    pausePressed: true
-  };
 }
 
 if (typeof window !== "undefined" && typeof document !== "undefined") {


### PR DESCRIPTION
## Co-locate Input copy helpers with the Input type and make assignInput exhaustive

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #539

### Changes
Move cloneInput, assignInput, and createPauseInput from src/main.ts into src/game/state.ts and export them alongside the Input type. Rewrite assignInput so that adding a new field to Input becomes a compile error if the helper is not updated — either (a) drive the assignment from a const-typed key list `const INPUT_KEYS: readonly (keyof Input)[] = [...]` combined with a compile-time exhaustiveness check (e.g. a helper type `AssertKeysEqual<keyof Input, (typeof INPUT_KEYS)[number]>` that fails to compile if the sets diverge), or (b) write an explicit property-by-property assignment whose return type is typed such that omitting a field is a type error. Do NOT use `Object.assign(target, input as Input)` with a widening cast that hides missing fields — the whole point is to turn field drift into a compile error. Update src/main.ts to import cloneInput/assignInput/createPauseInput from ./game/state instead of defining them locally; remove the now-duplicate definitions. Add a test in src/game/state.test.ts that: (1) asserts every key of EMPTY_INPUT round-trips through cloneInput (deep-equal), (2) starts from EMPTY_INPUT, mutates every field to a non-default value, calls assignInput(target, source), and asserts every field of target equals the source field (iterate over Object.keys to catch drops), and (3) asserts createPauseInput returns an Input whose pausePressed is true and every other field equals EMPTY_INPUT. Keep EMPTY_INPUT as the canonical default — the new helpers must not change its shape or values. Preserve existing main.ts behavior exactly; this is a pure move + exhaustiveness hardening.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*