### PR TITLE
feature: Add firing frame to player ship sprite and verify it renders

### DIFF
--- a/src/render/canvas.test.ts
+++ b/src/render/canvas.test.ts
@@ -29,15 +29,12 @@ const INVADER_PROJECTILE_COLORS = new Set(
 );
 const PLAYER_INVULNERABILITY_HALO_COLOR = "rgba(123, 229, 255, 0.22)";
 const PLAYER_INVULNERABILITY_HALO_MARGIN = 12;
-const PLAYER_SHIP_PIXEL_COUNT = PLAYER_SHIP_DESCRIPTOR.frames.reduce(
-  (frameCount, frame) =>
-    frameCount +
-    frame.reduce(
-      (rowCount, row) => rowCount + [...row].filter((pixel) => pixel !== ".").length,
-      0
-    ),
-  0
-);
+const PLAYER_SHIP_IDLE_PIXEL_COUNT =
+  PLAYER_SHIP_DESCRIPTOR.frames[0]?.reduce(
+    (rowCount, row) =>
+      rowCount + [...row].filter((pixel) => pixel !== ".").length,
+    0
+  ) ?? 0;
 
 type FillRectCall = {
   fillStyle: string | CanvasGradient | CanvasPattern;
@@ -285,7 +282,43 @@ describe("createCanvasRenderer", () => {
       audioStatus: "ready"
     });
 
-    expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
+    expect(getPlayerShipFillRects(context, state)).toHaveLength(
+      PLAYER_SHIP_IDLE_PIXEL_COUNT
+    );
+  });
+
+  it("renders a distinct player sprite frame while the shoot animation is active", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1 });
+
+    const renderPlayerFillRectSequence = (playerShootFrame: number): string[] => {
+      const context = new FakeCanvasContext();
+      const canvas = createFakeCanvas(context);
+      const renderer = createCanvasRenderer(canvas);
+      const state = {
+        ...createPlayingState(),
+        invaders: [],
+        projectiles: [],
+        playerShootFrame
+      };
+
+      renderer.render(state, {
+        bootstrapping: false,
+        highScore: 0,
+        audioStatus: "ready"
+      });
+
+      return getPlayerShipFillRects(context, state).map(
+        ({ fillStyle, x, y, width, height }) =>
+          `${fillStyle}:${x},${y},${width},${height}`
+      );
+    };
+
+    const idleSequence = renderPlayerFillRectSequence(0);
+    const firingSequence = renderPlayerFillRectSequence(1);
+
+    expect(idleSequence).not.toHaveLength(0);
+    expect(firingSequence).not.toHaveLength(0);
+    expect(firingSequence).not.toEqual(idleSequence);
   });
 
   it("renders the HUD score, wave, and one ship glyph per remaining life", () => {
@@ -570,7 +603,9 @@ describe("createCanvasRenderer", () => {
     });
 
     expect(findPlayerInvulnerabilityHalo(context, state)).toBeUndefined();
-    expect(getPlayerShipFillRects(context, state)).toHaveLength(PLAYER_SHIP_PIXEL_COUNT);
+    expect(getPlayerShipFillRects(context, state)).toHaveLength(
+      PLAYER_SHIP_IDLE_PIXEL_COUNT
+    );
   });
 
   it("renders the shared control footer", () => {

--- a/src/render/sprite-data/player-ship.ts
+++ b/src/render/sprite-data/player-ship.ts
@@ -5,6 +5,11 @@ const PLAYER_SHIP_FRAMES = [
     ".........c.........", "........ccc........", ".......ccccc.......",
     "......cccbccc......", ".....ccbbbbbcc.....", "...ccbbbbbbbbbcc...",
     "..ccbbbbbbbbbbbcc.."
+  ],
+  [
+    "........cbc........", "........ccc........", ".......ccccc.......",
+    "......cccbccc......", ".....ccbbbbbcc.....", "...ccbbbbbbbbbcc...",
+    "..ccbbbbbbbbbbbcc.."
   ]
 ] as const;
 

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -87,7 +87,10 @@ describe("createSpriteSheet", () => {
     expect(SPRITE_DESCRIPTORS).toHaveLength(9);
     expect(INVADER_ROW_DESCRIPTORS).toHaveLength(5);
 
-    expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(1);
+    expect(createSpriteSheet(PLAYER_SHIP_DESCRIPTOR).getFrameCount()).toBe(2);
+    expect(PLAYER_SHIP_DESCRIPTOR.frames[1]).not.toEqual(
+      PLAYER_SHIP_DESCRIPTOR.frames[0]
+    );
     expect(createSpriteSheet(SHIELD_CELL_DESCRIPTOR).getFrameCount()).toBe(1);
     expect(createSpriteSheet(PLAYER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(1);
     expect(createSpriteSheet(INVADER_PROJECTILE_DESCRIPTOR).getFrameCount()).toBe(


### PR DESCRIPTION
## Add firing frame to player ship sprite and verify it renders

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #270

### Changes
Give the canonical player ship descriptor a second frame representing the firing pose. After the sprite-data extraction, the player descriptor lives in `src/render/sprite-data/player-ship.ts`; update that source of truth directly rather than shadowing `PLAYER_SHIP_DESCRIPTOR` in `src/render/sprites.ts`. The second frame must use the same width/height grid and palette keys as the idle frame, and it must differ visibly (for example a muzzle/cannon pixel at the ship nose) so frame 1 renders different pixels. Update `src/render/sprites.test.ts` so the player descriptor frame-count assertion expects 2 frames and asserts frame 1 differs from frame 0. Add or update a renderer test in `src/render/canvas.test.ts` that renders a playing state with `playerShootFrame === 0` and `playerShootFrame > 0`, captures the player-region fillRect calls, and asserts the sequences differ. Do not change `drawPlayer()` itself; it already selects frame 1 when `playerShootFrame > 0`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*