### PR TITLE
test: Test recordScore short-circuits and skips setItem when score <= stored high score

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -84,6 +84,24 @@ describe("createHighScoreStore", () => {
     expect(storage.setItemCalls).toHaveLength(0);
   });
 
+  it("does not write when the score does not exceed the stored high score", () => {
+    const storage = new FakeStorage();
+    storage.seed(HIGH_SCORE_STORAGE_KEY, "500");
+    const store = createHighScoreStore(storage);
+
+    storage.setItemCalls.splice(0);
+
+    expect(store.recordScore(499)).toBe(500);
+    expect(
+      storage.setItemCalls.filter(({ key }) => key === HIGH_SCORE_STORAGE_KEY)
+    ).toEqual([]);
+
+    expect(store.recordScore(500)).toBe(500);
+    expect(
+      storage.setItemCalls.filter(({ key }) => key === HIGH_SCORE_STORAGE_KEY)
+    ).toEqual([]);
+  });
+
   it("persists scores above the stored high score", () => {
     const storage = new FakeStorage();
     storage.seed(HIGH_SCORE_STORAGE_KEY, "220");


### PR DESCRIPTION
## Test recordScore short-circuits and skips setItem when score <= stored high score

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #560

### Changes
Add a test case in src/persistence.test.ts that exercises the early-return branch of HighScoreStore.recordScore in src/persistence.ts. Instantiate a FakeStorage, seed it with the high-score key (HIGH_SCORE_STORAGE_KEY = 'space-invaders-hd.highScore') set to '500', and construct the store via createHighScoreStore with that storage. Clear or snapshot storage.setItemCalls after the initial load so any prior seeding writes are not counted. Then (a) call recordScore(499) and assert the return value is 500 and setItemCalls has no new entries for the high-score key; (b) call recordScore(500) and assert the return value is 500 and setItemCalls still has no new entries for the high-score key. This pins the write-avoidance contract: setItem must not be invoked when nextHighScore <= highScore. Place the new test inside an appropriate describe block (create one for createHighScoreStore if none exists for recordScore already) and reuse the existing FakeStorage helper — do not introduce a new mock class. Keep imports consistent with the existing file (vitest describe/expect/it, createHighScoreStore).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*