### PR TITLE
feature: Extract getInvaderProjectileSpawnX/Y helpers and wire through createInvaderProjectile

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -4,10 +4,16 @@ import {
   EMPTY_INPUT,
   FORMATION_SPEED_BASE,
   FORMATION_SPEED_MAX,
+  INVADER_PROJECTILE_WIDTH,
   assignInput,
   cloneInput,
+  createInvaderProjectile,
   createPauseInput,
+  createPlayingState,
   getFormationSpeed,
+  getInvaderProjectileSpawnX,
+  getInvaderProjectileSpawnY,
+  type Invader,
   type Input
 } from "./state";
 
@@ -92,5 +98,40 @@ describe("input helpers", () => {
 
       expect(pauseInput[key]).toBe(EMPTY_INPUT[key]);
     }
+  });
+});
+
+describe("invader projectile spawn helpers", () => {
+  const invader: Invader = {
+    id: 7,
+    row: 2,
+    col: 3,
+    x: 111,
+    y: 222,
+    width: 54,
+    height: 31,
+    points: 20
+  };
+
+  it("centers the projectile horizontally on the invader", () => {
+    expect(getInvaderProjectileSpawnX(invader)).toBe(
+      invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2
+    );
+  });
+
+  it("places the projectile flush with the invader bottom edge", () => {
+    expect(getInvaderProjectileSpawnY(invader)).toBe(
+      invader.y + invader.height
+    );
+  });
+
+  it("uses the helper coordinates when creating an invader projectile", () => {
+    const projectile = createInvaderProjectile(
+      createPlayingState({ nextProjectileId: 42 }),
+      invader
+    );
+
+    expect(projectile.x).toBe(getInvaderProjectileSpawnX(invader));
+    expect(projectile.y).toBe(getInvaderProjectileSpawnY(invader));
   });
 });

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -394,8 +394,8 @@ export function createInvaderProjectile(
   return {
     id: state.nextProjectileId,
     owner: "invader",
-    x: invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2,
-    y: invader.y + invader.height,
+    x: getInvaderProjectileSpawnX(invader),
+    y: getInvaderProjectileSpawnY(invader),
     width: INVADER_PROJECTILE_WIDTH,
     height: INVADER_PROJECTILE_HEIGHT,
     velocityY: INVADER_PROJECTILE_SPEED,
@@ -450,4 +450,12 @@ export function getProjectileSpawnX(player: Player): number {
 
 export function getProjectileSpawnY(player: Player): number {
   return player.y - PROJECTILE_HEIGHT;
+}
+
+export function getInvaderProjectileSpawnX(invader: Invader): number {
+  return invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2;
+}
+
+export function getInvaderProjectileSpawnY(invader: Invader): number {
+  return invader.y + invader.height;
 }


### PR DESCRIPTION
## Extract getInvaderProjectileSpawnX/Y helpers and wire through createInvaderProjectile

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #566

### Changes
In src/game/state.ts, add two named helpers `getInvaderProjectileSpawnX(invader: Invader): number` returning `invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2` and `getInvaderProjectileSpawnY(invader: Invader): number` returning `invader.y + invader.height`. Export them alongside the existing `getProjectileSpawnX` / `getProjectileSpawnY` player helpers. Update `createInvaderProjectile` to call these new helpers instead of inlining the arithmetic, so the spawn math lives in exactly one place. Behavior must remain identical — the existing step/events tests that depend on invader projectile positions should continue passing untouched. Then extend src/game/state.test.ts with a new `describe` block (e.g. `describe("invader projectile spawn helpers", ...)`) that constructs an Invader with known dimensions and asserts: (1) `getInvaderProjectileSpawnX(invader)` equals `invader.x + invader.width / 2 - INVADER_PROJECTILE_WIDTH / 2` (horizontally centered on the invader), (2) `getInvaderProjectileSpawnY(invader)` equals `invader.y + invader.height` (top edge sits flush with invader bottom), and (3) a projectile built via `createInvaderProjectile` uses those same x/y values. Import the helpers and `INVADER_PROJECTILE_WIDTH` from `./state`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*