### PR TITLE
test: Test OS auto-repeat keydowns do not re-emit fire/pause/mute edges in keyboard.test.ts

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -33,11 +33,30 @@ function dispatchKeyDown(target: Window, code: string): void {
   target.dispatchEvent(new KeyboardEvent("keydown", { code }));
 }
 
+function dispatchKeyUp(target: Window, code: string): void {
+  target.dispatchEvent(new KeyboardEvent("keyup", { code }));
+}
+
 function dispatchBlur(target: Window): void {
   target.dispatchEvent(new Event("blur"));
 }
 
 describe("createKeyboardController", () => {
+  const repeatGuardCases = [
+    {
+      code: "Space",
+      edgeField: "firePressed",
+      heldField: "fireHeld",
+      label: "fire"
+    },
+    {
+      code: "KeyP",
+      edgeField: "pausePressed",
+      heldField: "pauseHeld",
+      label: "pause"
+    }
+  ] as const;
+
   it("clears held ArrowLeft input on blur", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);
@@ -128,6 +147,55 @@ describe("createKeyboardController", () => {
 
     expect(snapshot.firePressed).toBe(true);
     expect(snapshot.fireHeld).toBe(true);
+  });
+
+  for (const { code, edgeField, heldField, label } of repeatGuardCases) {
+    it(`does not re-emit the ${label} edge on auto-repeat keydown and re-arms after keyup`, () => {
+      const target = createTarget();
+      const controller = createKeyboardController(target);
+
+      dispatchKeyDown(target, code);
+
+      const firstSnapshot = controller.snapshot();
+
+      dispatchKeyDown(target, code);
+
+      const secondSnapshot = controller.snapshot();
+
+      dispatchKeyUp(target, code);
+      dispatchKeyDown(target, code);
+
+      const rearmedSnapshot = controller.snapshot();
+
+      expect(firstSnapshot[edgeField]).toBe(true);
+      expect(firstSnapshot[heldField]).toBe(true);
+      expect(secondSnapshot[edgeField]).toBe(false);
+      expect(secondSnapshot[heldField]).toBe(true);
+      expect(rearmedSnapshot[edgeField]).toBe(true);
+      expect(rearmedSnapshot[heldField]).toBe(true);
+    });
+  }
+
+  it("does not re-emit the mute edge on auto-repeat keydown and re-arms after keyup", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "KeyM");
+
+    const firstSnapshot = controller.snapshot();
+
+    dispatchKeyDown(target, "KeyM");
+
+    const secondSnapshot = controller.snapshot();
+
+    dispatchKeyUp(target, "KeyM");
+    dispatchKeyDown(target, "KeyM");
+
+    const rearmedSnapshot = controller.snapshot();
+
+    expect(firstSnapshot.mutePressed).toBe(true);
+    expect(secondSnapshot.mutePressed).toBe(false);
+    expect(rearmedSnapshot.mutePressed).toBe(true);
   });
 
   it("removes the blur listener on dispose", () => {


### PR DESCRIPTION
## Test OS auto-repeat keydowns do not re-emit fire/pause/mute edges in keyboard.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #559

### Changes
Add vitest cases to src/input/keyboard.test.ts that exercise the edge-trigger guards in src/input/keyboard.ts for Space (fire), KeyP (pause), and KeyM (mute). For each key: dispatch a first keydown, take a snapshot, dispatch a second keydown WITHOUT an intervening keyup (simulating OS key auto-repeat), and take a second snapshot. Assert that on the first snapshot the corresponding edge flag (firePressed / pausePressed / mutePressed — match the exact field names produced by the Input snapshot in src/game/state.ts and keyboard.ts) is true, and on the second snapshot it is false, while the held flag (fireHeld / pauseHeld / muteHeld) remains true across both. Then add a follow-up assertion: after dispatching a keyup followed by a fresh keydown, the edge flag re-arms and fires true again. Reuse the existing FakeWindow / createTarget / dispatchKeyDown helpers already in the file, and add a dispatchKeyUp helper mirroring dispatchKeyDown. Do NOT modify src/input/keyboard.ts — this test must pass against the CURRENT implementation, which already contains the `if (!held.fire)` / `if (!held.pause)` / `if (!held.mute)` guards.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*