### PR TITLE
test: Test snapshot() consumes fire/pause/mute edge flags after returning them

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -176,6 +176,47 @@ describe("createKeyboardController", () => {
     });
   }
 
+  it("consumes returned fire, pause, and mute edges on the next snapshot", () => {
+    const heldEdgeCases = [
+      {
+        code: "Space",
+        edgeField: "firePressed",
+        heldField: "fireHeld"
+      },
+      {
+        code: "KeyP",
+        edgeField: "pausePressed",
+        heldField: "pauseHeld"
+      }
+    ] as const;
+
+    for (const { code, edgeField, heldField } of heldEdgeCases) {
+      const target = createTarget();
+      const controller = createKeyboardController(target);
+
+      dispatchKeyDown(target, code);
+
+      const firstSnapshot = controller.snapshot();
+      const secondSnapshot = controller.snapshot();
+
+      expect(firstSnapshot[edgeField]).toBe(true);
+      expect(firstSnapshot[heldField]).toBe(true);
+      expect(secondSnapshot[edgeField]).toBe(false);
+      expect(secondSnapshot[heldField]).toBe(true);
+    }
+
+    const muteTarget = createTarget();
+    const muteController = createKeyboardController(muteTarget);
+
+    dispatchKeyDown(muteTarget, "KeyM");
+
+    const firstMuteSnapshot = muteController.snapshot();
+    const secondMuteSnapshot = muteController.snapshot();
+
+    expect(firstMuteSnapshot.mutePressed).toBe(true);
+    expect(secondMuteSnapshot.mutePressed).toBe(false);
+  });
+
   it("does not re-emit the mute edge on auto-repeat keydown and re-arms after keyup", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);


### PR DESCRIPTION
## Test snapshot() consumes fire/pause/mute edge flags after returning them

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #576

### Changes
Add a test case in src/input/keyboard.test.ts that verifies createKeyboardController.snapshot() consumes edge flags after returning them. For each of Space (fire), KeyP (pause), and KeyM (mute): dispatch a single keydown, then call snapshot() and assert the appropriate *Pressed field is true AND the corresponding *Held field is true. Call snapshot() a second time with no further events and assert *Pressed is now false while *Held remains true. This locks in the edge-vs-held contract that step.ts and the runtime depend on — one edge frame per discrete keydown. Reuse the existing FakeWindow/createTarget/dispatchKeyDown helpers already in the file. Do NOT modify keyboard.ts or any other file; the behavior is already implemented and these tests should pass against current code.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*