### PR TITLE
test: Cover storage-throws fallback paths in persistence.test.ts

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -150,21 +150,57 @@ describe("createHighScoreStore", () => {
     }
   );
 
-  it("swallows getItem failures", () => {
-    const storage = new FakeStorage();
-    storage.throwOnGet = true;
-    const store = createHighScoreStore(storage);
+  describe("when storage throws", () => {
+    it("returns 0 when reading the stored high score throws", () => {
+      const storage = new FakeStorage();
+      storage.throwOnGet = true;
+      const store = createHighScoreStore(storage);
 
-    expect(store.getHighScore()).toBe(0);
-  });
+      expect(store.getHighScore()).toBe(0);
+    });
 
-  it("swallows setItem failures", () => {
-    const storage = new FakeStorage();
-    storage.throwOnSet = true;
-    const store = createHighScoreStore(storage);
+    it("keeps the in-memory high score when writing the stored high score throws", () => {
+      const storage = new FakeStorage();
+      storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+      storage.throwOnSet = true;
+      const store = createHighScoreStore(storage);
 
-    expect(store.recordScore(400)).toBe(400);
-    expect(store.getHighScore()).toBe(400);
-    expect(storage.key(0)).toBeNull();
+      expect(store.recordScore(360)).toBe(360);
+      expect(store.getHighScore()).toBe(360);
+      expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("220");
+    });
+
+    it("falls back to memory storage when localStorage access throws", () => {
+      const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "localStorage"
+      );
+
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        get() {
+          throw new Error("localStorage unavailable");
+        }
+      });
+
+      try {
+        const store = createHighScoreStore();
+        const initialHighScore = store.getHighScore();
+        const nextHighScore = initialHighScore + 1;
+
+        expect(store.recordScore(nextHighScore)).toBe(nextHighScore);
+        expect(store.getHighScore()).toBe(nextHighScore);
+      } finally {
+        if (originalLocalStorageDescriptor) {
+          Object.defineProperty(
+            globalThis,
+            "localStorage",
+            originalLocalStorageDescriptor
+          );
+        } else {
+          Reflect.deleteProperty(globalThis, "localStorage");
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION
## Cover storage-throws fallback paths in persistence.test.ts

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #577

### Changes
Extend src/persistence.test.ts with three new test cases that exercise the currently uncovered swallowed-exception paths in src/persistence.ts. Reuse the existing FakeStorage class (which already exposes `throwOnGet` and `throwOnSet` flags) rather than duplicating it. Required cases: (1) when a FakeStorage whose `throwOnGet` is true is passed to `createHighScoreStore`, the initial `getHighScore()` still returns 0 instead of propagating the thrown error — this exercises the `readStoredHighScore` catch branch; (2) with a FakeStorage whose `throwOnSet` is true, a `recordScore(store, value)` call where value exceeds the current high score still returns the new high score and `getHighScore()` reflects it afterward (the in-memory update survives even though persistence silently fails) — this exercises the `writeStoredHighScore` catch branch; (3) `getDefaultStorage` returns a usable Storage-shaped object when accessing `globalThis.localStorage` throws (Safari private-mode style). Implement case 3 by temporarily replacing `globalThis.localStorage` with a property whose getter throws (use `Object.defineProperty` and restore in an `afterEach` or try/finally), then assert that `createHighScoreStore()` — invoked with no argument so it falls through to `getDefaultStorage` — can still `recordScore` and `getHighScore` without throwing. Do NOT modify src/persistence.ts; all three fallback paths already exist and the tests must pass against the current implementation. Place the new tests inside the existing `describe` blocks where they fit, or add focused `describe` blocks named after the behavior (e.g. `describe("when storage throws", ...)`). Import only what is needed from `./persistence` — follow the existing import style at the top of the file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*