### PR TITLE
bug_fix: Allow AudioEngine.arm() to retry after a failed unlock

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -207,6 +207,36 @@ describe("createAudioEngine", () => {
     expect(engine.getStatus()).toBe("muted");
   });
 
+  it("retries arming after an initial context creation failure", async () => {
+    const createContext = vi
+      .fn<() => MockAudioContext>()
+      .mockImplementationOnce(() => {
+        throw new Error("AudioContext unavailable");
+      })
+      .mockImplementation(() => harness.createContext());
+    const engine = createAudioEngine({ createContext });
+
+    await engine.arm();
+
+    expect(engine.getStatus()).not.toBe("ready");
+    expect(harness.contexts).toHaveLength(0);
+
+    await engine.arm();
+
+    expect(engine.getStatus()).toBe("ready");
+
+    const context = getLastContext(harness);
+
+    engine.scheduleTone({
+      frequency: 440,
+      duration: 0.1,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+  });
+
   it("does not schedule anything while idle or muted", async () => {
     const idleEngine = createAudioEngine({ createContext: harness.createContext });
 

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -75,7 +75,7 @@ export function createAudioEngine(
 
   return {
     arm: async () => {
-      if (status === "muted") {
+      if (muted) {
         return;
       }
 


### PR DESCRIPTION
## Allow AudioEngine.arm() to retry after a failed unlock

**Category:** `bug_fix` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #578

### Changes
In src/audio/engine.ts, arm() currently early-returns when status === 'muted', but its own catch block sets status = 'muted' on a thrown createContext or resume(). That makes the engine permanently un-armable after any transient failure. Fix arm() so a failure-derived muted status does NOT block retry: either reset status back to 'idle' in the catch block on failure (so the next arm() call re-enters the unlock path), or distinguish the user-muted short-circuit from the failure state (e.g. only early-return when setMuted(true) was called, not when an exception set it). Do NOT change behavior for the real user-mute path (setMuted(true) must still prevent arm() from creating/resuming a context). Also add a test in src/audio/engine.test.ts under the existing createAudioEngine describe block that: (1) constructs an engine whose createContext factory throws on the first call and returns a working MockAudioContext on the second, (2) awaits a first arm() and asserts it resolved without creating a usable context (status is not 'ready'), (3) awaits a second arm() and asserts status becomes 'ready' and scheduleTone() successfully goes through (e.g. createOscillator is called on the second context). Keep the existing mock helpers and patterns already used in the file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*