### PR TITLE
test: Test symmetric ArrowLeft + ArrowRight cancel to moveX=0 in keyboard.test.ts

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -67,6 +67,25 @@ describe("createKeyboardController", () => {
     expect(controller.snapshot().moveX).toBe(0);
   });
 
+  it("cancels symmetric left and right input until one side is released", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "ArrowLeft");
+    dispatchKeyDown(target, "ArrowRight");
+
+    expect(controller.snapshot().moveX).toBe(0);
+
+    dispatchKeyUp(target, "ArrowLeft");
+
+    expect(controller.snapshot().moveX).toBe(1);
+
+    dispatchKeyDown(target, "ArrowLeft");
+    dispatchKeyUp(target, "ArrowRight");
+
+    expect(controller.snapshot().moveX).toBe(-1);
+  });
+
   it("clears held ArrowRight, Space, and KeyP input and resets mute gating on blur", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);


### PR DESCRIPTION
## Test symmetric ArrowLeft + ArrowRight cancel to moveX=0 in keyboard.test.ts

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #554

### Changes
Add a new test case to src/input/keyboard.test.ts that pins the symmetric-cancellation semantics of createKeyboardController. The test must: (1) create a controller against a FakeWindow target using the existing helpers in the file; (2) dispatch keydown for 'ArrowLeft' and then 'ArrowRight'; (3) assert controller.snapshot().moveX === 0 (both held cancel); (4) dispatch a keyup for 'ArrowLeft' (add a dispatchKeyUp helper if one does not already exist in the file) and assert moveX === 1; (5) re-press ArrowLeft, then release ArrowRight, and assert moveX === -1. Use the existing KeyboardEvent shim, FakeWindow, and createTarget helpers already defined at the top of the test file — do not duplicate them. Place the new test inside the existing describe('createKeyboardController', ...) block as an additional it(...) case. Do not modify src/input/keyboard.ts — the behavior already exists via `held.left === held.right ? 0 : held.left ? -1 : 1` and this task only pins it.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*