### PR TITLE
test: Cover pickDisplayHighScore edge cases directly in persistence.test.ts

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -56,6 +56,48 @@ describe("pickDisplayHighScore", () => {
   });
 });
 
+describe("pickDisplayHighScore edge cases", () => {
+  it("keeps a positive stored high score when the current score is negative", () => {
+    const result = pickDisplayHighScore(100, -5);
+
+    expect(result).toBe(100);
+    expect(Number.isFinite(result)).toBe(true);
+    expect(result >= 0).toBe(true);
+  });
+
+  it.each([
+    { storedHighScore: 100, currentScore: Number.NaN },
+    { storedHighScore: Number.NaN, currentScore: 75 }
+  ])(
+    "returns a finite, non-negative score when one value is NaN",
+    ({ storedHighScore, currentScore }) => {
+      const result = pickDisplayHighScore(storedHighScore, currentScore);
+
+      expect(Number.isFinite(result)).toBe(true);
+      expect(result >= 0).toBe(true);
+    }
+  );
+
+  it.each([
+    { storedHighScore: Number.POSITIVE_INFINITY, currentScore: 50 },
+    { storedHighScore: Number.NEGATIVE_INFINITY, currentScore: 50 },
+    { storedHighScore: 50, currentScore: Number.POSITIVE_INFINITY },
+    { storedHighScore: 50, currentScore: Number.NEGATIVE_INFINITY }
+  ])(
+    "returns a finite, non-negative score when one value is infinite",
+    ({ storedHighScore, currentScore }) => {
+      const result = pickDisplayHighScore(storedHighScore, currentScore);
+
+      expect(Number.isFinite(result)).toBe(true);
+      expect(result >= 0).toBe(true);
+    }
+  );
+
+  it("returns the shared value when both scores are equal", () => {
+    expect(pickDisplayHighScore(42, 42)).toBe(42);
+  });
+});
+
 describe("createHighScoreStore", () => {
   it("returns 0 when storage is empty", () => {
     const store = createHighScoreStore(new FakeStorage());


### PR DESCRIPTION
## Cover pickDisplayHighScore edge cases directly in persistence.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #565

### Changes
Add a new describe block in src/persistence.test.ts that imports pickDisplayHighScore (already imported) and exercises it directly with edge-case inputs. Required cases: (a) negative currentScore (e.g. -5) against a positive storedHighScore (e.g. 100) — assert the result equals 100 and is finite and >= 0; (b) NaN as currentScore against a positive storedHighScore, and NaN as storedHighScore against a positive currentScore — assert the result is a finite, non-negative number (the non-NaN positive value or 0 if both sides normalize to 0); (c) Infinity and -Infinity for each argument — assert the result is finite and non-negative; (d) equal arguments (e.g. both 42) — assert the result equals that value. Use Number.isFinite and comparisons (>= 0) in assertions so the normalization contract is pinned regardless of the exact clamp choice. Do not modify src/persistence.ts — these tests must pass against the existing implementation.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*