### PR TITLE
test: Cover scheduleTone tag+cooldown suppression in engine.test.ts

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -358,4 +358,69 @@ describe("createAudioEngine", () => {
 
     expect(harness.oscillators).toHaveLength(scheduledOscillatorCount + 1);
   });
+
+  it("applies cooldown suppression independently for each scheduleTone tag", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+    await engine.arm();
+
+    const context = getLastContext(harness);
+    const cooldownSeconds = 0.05;
+
+    context.currentTime = 1;
+    engine.scheduleTone({
+      tag: "shoot",
+      cooldownSeconds,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+    engine.scheduleTone({
+      tag: "shoot",
+      cooldownSeconds,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+
+    context.currentTime += cooldownSeconds + 0.001;
+    engine.scheduleTone({
+      tag: "shoot",
+      cooldownSeconds,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(2);
+
+    context.currentTime = 2;
+    engine.scheduleTone({
+      tag: "shoot",
+      cooldownSeconds,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+
+    const createOscillatorCallsAfterShoot = context.createOscillator.mock.calls.length;
+
+    engine.scheduleTone({
+      tag: "hit",
+      cooldownSeconds,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(
+      createOscillatorCallsAfterShoot + 1
+    );
+  });
 });


### PR DESCRIPTION
## Cover scheduleTone tag+cooldown suppression in engine.test.ts

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #555

### Changes
Add a new Vitest case to src/audio/engine.test.ts that exercises the per-tag cooldown suppression inside createAudioEngine's scheduleTone. Use the existing mock AudioContext pattern already in the file (see the MockAudioContext/MockOscillatorNode/MockGainNode types at the top). Build a fake context where currentTime is mutable. Create the engine, arm it, then call scheduleTone twice in rapid succession with the SAME tag (e.g. tag: 'shoot') and a cooldownSeconds value (e.g. 0.05) while currentTime stays within the cooldown window — assert that createOscillator was called exactly once (second call suppressed). Then advance the fake context's currentTime past the cooldown (e.g. bump to cooldownSeconds + a small delta), call scheduleTone a third time with the same tag, and assert createOscillator was called a second time. Also verify that a DIFFERENT tag within the cooldown window is NOT suppressed (independent per-tag bookkeeping). Keep the test isolated; do not modify src/audio/engine.ts or any other files. Follow the existing style: strict types, Mock<> generics, no `any`, describe block (or an additional `it(...)` within an existing relevant describe) consistent with the rest of the file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*