### PR TITLE
test: Directly unit-test getFormationSpeed in state.test.ts

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -1,5 +1,8 @@
+/// <reference types="vite/client" />
+
 import { describe, expect, it } from "vitest";
 
+import stateSource from "./state?raw";
 import {
   EMPTY_INPUT,
   FORMATION_SPEED_BASE,
@@ -16,6 +19,24 @@ import {
   type Invader,
   type Input
 } from "./state";
+
+const formationSpeedKillMultiplierMatch = stateSource.match(
+  /const FORMATION_SPEED_KILL_MULTIPLIER = ([0-9.]+);/
+);
+
+if (!formationSpeedKillMultiplierMatch) {
+  throw new Error("FORMATION_SPEED_KILL_MULTIPLIER not found in state.ts");
+}
+
+const [, formationSpeedKillMultiplierText] = formationSpeedKillMultiplierMatch;
+
+if (!formationSpeedKillMultiplierText) {
+  throw new Error("FORMATION_SPEED_KILL_MULTIPLIER value not found in state.ts");
+}
+
+const FORMATION_SPEED_KILL_MULTIPLIER = Number.parseFloat(
+  formationSpeedKillMultiplierText
+);
 
 function getInputKeys(): Array<keyof Input> {
   return Object.keys(EMPTY_INPUT) as Array<keyof Input>;
@@ -54,6 +75,51 @@ describe("getFormationSpeed", () => {
     expect(getFormationSpeed(5, waveStartSpeed, 10)).toBe(
       waveStartSpeed + (FORMATION_SPEED_MAX - waveStartSpeed) / 2
     );
+  });
+
+  it("returns the wave start speed when all invaders are still alive", () => {
+    const totalInvaders = 10;
+    const waveStartSpeed = FORMATION_SPEED_BASE;
+
+    expect(
+      getFormationSpeed(totalInvaders, waveStartSpeed, totalInvaders)
+    ).toBe(waveStartSpeed);
+  });
+
+  it("applies the kill multiplier for a cleared formation below the cap", () => {
+    const waveStartSpeed = FORMATION_SPEED_BASE;
+
+    expect(getFormationSpeed(0, waveStartSpeed, 10)).toBeCloseTo(
+      waveStartSpeed * FORMATION_SPEED_KILL_MULTIPLIER
+    );
+  });
+
+  it("clamps a cleared formation to FORMATION_SPEED_MAX when the multiplied speed exceeds the cap", () => {
+    expect(getFormationSpeed(0, FORMATION_SPEED_MAX * 2, 10)).toBe(
+      FORMATION_SPEED_MAX
+    );
+  });
+
+  it("interpolates halfway between the wave start speed and kill-multiplied speed when the formation is half cleared", () => {
+    const waveStartSpeed = FORMATION_SPEED_BASE;
+    const waveMaxSpeed =
+      waveStartSpeed * FORMATION_SPEED_KILL_MULTIPLIER;
+
+    expect(getFormationSpeed(5, waveStartSpeed, 10)).toBeCloseTo(
+      waveStartSpeed + (waveMaxSpeed - waveStartSpeed) / 2
+    );
+  });
+
+  it("does not decrease as invaderCount drops", () => {
+    const waveStartSpeed = FORMATION_SPEED_BASE;
+    let previousSpeed = -Infinity;
+
+    for (const invaderCount of [10, 8, 5, 2, 0]) {
+      const speed = getFormationSpeed(invaderCount, waveStartSpeed, 10);
+
+      expect(speed).toBeGreaterThanOrEqual(previousSpeed);
+      previousSpeed = speed;
+    }
   });
 });
 


### PR DESCRIPTION
## Directly unit-test getFormationSpeed in state.test.ts

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #599

### Changes
Extend the existing `describe("getFormationSpeed", ...)` block in src/game/state.test.ts with direct unit tests for the pure helper `getFormationSpeed(invaderCount, waveStartSpeed, totalInvaders)`. Read src/game/state.ts to confirm the exact formula, the constants exported (`FORMATION_SPEED_BASE`, `FORMATION_SPEED_MAX`, and the kill multiplier — import whatever the current export name is, e.g. `FORMATION_SPEED_KILL_MULTIPLIER`), and the clamping behavior. Add at least these new cases without duplicating the four already present in the file:

1. When all invaders are alive (`invaderCount === totalInvaders`) and `waveStartSpeed` is below `FORMATION_SPEED_MAX`, the result equals `waveStartSpeed` exactly.
2. When `invaderCount === 0` with a moderate `waveStartSpeed` (well below the cap), the result equals `waveStartSpeed * FORMATION_SPEED_KILL_MULTIPLIER` (use `toBeCloseTo` for float tolerance).
3. When `invaderCount === 0` with a very large `waveStartSpeed` that would exceed the cap after multiplying, the result is clamped to `FORMATION_SPEED_MAX`.
4. Halfway-killed interpolation: with `totalInvaders = 10` and `invaderCount = 5`, the result is the midpoint between `waveStartSpeed` and `waveStartSpeed * FORMATION_SPEED_KILL_MULTIPLIER` (use `toBeCloseTo`).
5. Monotonicity: as `invaderCount` decreases from `totalInvaders` to `0` (sampled at 3-4 intermediate values), the returned speed is non-decreasing.

Keep the new tests inside the same `describe("getFormationSpeed", ...)` block. Do not modify the pre-existing `it(...)` cases. Do not modify src/game/state.ts. Avoid `any` and keep strict mode clean.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*