### PR TITLE
test: Directly unit-test getFormationSpeed in state.test.ts

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -22,6 +22,9 @@ function getInputKeys(): Array<keyof Input> {
 }
 
 describe("getFormationSpeed", () => {
+  // Mirrors the private FORMATION_SPEED_KILL_MULTIPLIER implementation constant.
+  const expectedKillMultiplier = 2.7;
+
   it("returns the wave start speed when invaderCount exceeds totalInvaders", () => {
     const waveStartSpeed = FORMATION_SPEED_BASE * 2;
 
@@ -54,6 +57,61 @@ describe("getFormationSpeed", () => {
     expect(getFormationSpeed(5, waveStartSpeed, 10)).toBe(
       waveStartSpeed + (FORMATION_SPEED_MAX - waveStartSpeed) / 2
     );
+  });
+
+  it("returns the wave start speed exactly when all invaders are alive below the cap", () => {
+    const waveStartSpeed = 100;
+
+    expect(getFormationSpeed(10, waveStartSpeed, 10)).toBe(waveStartSpeed);
+  });
+
+  it("uses the uncapped kill multiplier when no invaders remain and the scaled speed stays below the cap", () => {
+    const waveStartSpeed = 100;
+
+    expect(getFormationSpeed(0, waveStartSpeed, 10)).toBeCloseTo(
+      waveStartSpeed * expectedKillMultiplier
+    );
+  });
+
+  it("clamps the fully cleared formation speed to FORMATION_SPEED_MAX", () => {
+    const waveStartSpeed = FORMATION_SPEED_MAX;
+
+    expect(getFormationSpeed(0, waveStartSpeed, 10)).toBe(
+      FORMATION_SPEED_MAX
+    );
+  });
+
+  it("interpolates halfway between the wave start speed and the uncapped kill-multiplied speed", () => {
+    const totalInvaders = 10;
+    const invaderCount = 5;
+    const waveStartSpeed = 100;
+    const expectedMaxSpeed = waveStartSpeed * expectedKillMultiplier;
+
+    expect(
+      getFormationSpeed(invaderCount, waveStartSpeed, totalInvaders)
+    ).toBeCloseTo(waveStartSpeed + (expectedMaxSpeed - waveStartSpeed) / 2);
+  });
+
+  it("never decreases as invaderCount drops toward zero", () => {
+    const waveStartSpeed = 100;
+    const totalInvaders = 10;
+    const sampledInvaderCounts = [10, 8, 5, 2, 0] as const;
+    let previousSpeed = getFormationSpeed(
+      sampledInvaderCounts[0],
+      waveStartSpeed,
+      totalInvaders
+    );
+
+    for (const invaderCount of sampledInvaderCounts.slice(1)) {
+      const currentSpeed = getFormationSpeed(
+        invaderCount,
+        waveStartSpeed,
+        totalInvaders
+      );
+
+      expect(currentSpeed).toBeGreaterThanOrEqual(previousSpeed);
+      previousSpeed = currentSpeed;
+    }
   });
 });
 


### PR DESCRIPTION
## Directly unit-test getFormationSpeed in state.test.ts

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #599

### Changes
Extend the existing `describe("getFormationSpeed", ...)` block in src/game/state.test.ts with direct unit tests for the pure helper `getFormationSpeed(invaderCount, waveStartSpeed, totalInvaders)`. Read src/game/state.ts to confirm the exact formula and the exported constants `FORMATION_SPEED_BASE` and `FORMATION_SPEED_MAX`. `FORMATION_SPEED_KILL_MULTIPLIER` is intentionally not exported; do not use raw-source imports or regex parsing. In the tests, define a local expected multiplier literal matching the current formula and add a short comment that it mirrors the private implementation constant. Add at least these new cases without duplicating the four already present in the file:

1. When all invaders are alive (`invaderCount === totalInvaders`) and `waveStartSpeed` is below `FORMATION_SPEED_MAX`, the result equals `waveStartSpeed` exactly.
2. When `invaderCount === 0` with a moderate `waveStartSpeed` (well below the cap), the result equals `waveStartSpeed * expectedKillMultiplier` where `expectedKillMultiplier` is a local test constant mirroring the private implementation constant (use `toBeCloseTo` for float tolerance).
3. When `invaderCount === 0` with a very large `waveStartSpeed` that would exceed the cap after multiplying, the result is clamped to `FORMATION_SPEED_MAX`.
4. Halfway-killed interpolation: with `totalInvaders = 10` and `invaderCount = 5`, the result is the midpoint between `waveStartSpeed` and `waveStartSpeed * expectedKillMultiplier` (use `toBeCloseTo`).
5. Monotonicity: as `invaderCount` decreases from `totalInvaders` to `0` (sampled at 3-4 intermediate values), the returned speed is non-decreasing.

Keep the new tests inside the same `describe("getFormationSpeed", ...)` block. Do not modify the pre-existing `it(...)` cases. Do not modify src/game/state.ts. Avoid `any` and keep strict mode clean.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*