### PR TITLE
test: Test blur clears unconsumed fire/pause/mute edges in keyboard.test.ts

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -124,25 +124,35 @@ describe("createKeyboardController", () => {
     expect(snapshot.fireHeld).toBe(false);
   });
 
-  it("clears fire, pause, and mute edges on blur before snapshot", () => {
+  it("clears an unconsumed fire edge on blur before snapshot", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);
 
     dispatchKeyDown(target, "Space");
     dispatchBlur(target);
 
-    const fireSnapshot = controller.snapshot();
+    const snapshot = controller.snapshot();
 
-    expect(fireSnapshot.firePressed).toBe(false);
-    expect(fireSnapshot.fireHeld).toBe(false);
+    expect(snapshot.firePressed).toBe(false);
+    expect(snapshot.fireHeld).toBe(false);
+  });
+
+  it("clears an unconsumed pause edge on blur before snapshot", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
 
     dispatchKeyDown(target, "KeyP");
     dispatchBlur(target);
 
-    const pauseSnapshot = controller.snapshot();
+    const snapshot = controller.snapshot();
 
-    expect(pauseSnapshot.pausePressed).toBe(false);
-    expect(pauseSnapshot.pauseHeld).toBe(false);
+    expect(snapshot.pausePressed).toBe(false);
+    expect(snapshot.pauseHeld).toBe(false);
+  });
+
+  it("clears an unconsumed mute edge on blur before snapshot", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
 
     dispatchKeyDown(target, "KeyM");
     dispatchBlur(target);


### PR DESCRIPTION
## Test blur clears unconsumed fire/pause/mute edges in keyboard.test.ts

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #608

### Changes
Add test cases to src/input/keyboard.test.ts that verify `onBlur` clears unconsumed edges for fire (Space), pause (KeyP), and mute (KeyM) BEFORE any snapshot has consumed them. For each of the three keys, write a separate `it(...)` case that: (1) creates a controller via `createKeyboardController(target)` with a FakeWindow target from the existing helpers, (2) dispatches a `keydown` for the key using the existing `dispatchKeyDown` helper, (3) dispatches a `blur` event using the existing `dispatchBlur` helper WITHOUT calling `snapshot()` in between, (4) then calls `snapshot()` and asserts the corresponding edge field (`firePressed`/`pausePressed`/`mutePressed`) is `false`. Also assert `fireHeld` is false for Space and `pauseHeld` is false for KeyP. The current Input type has no `muteHeld`; for KeyM, assert only `mutePressed` is false after blur. Reuse the existing `describe("createKeyboardController", ...)` block, helpers, and KeyboardEvent shim at the top of the file — do not duplicate them. Keep the new cases colocated with the other edge-related tests.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*