### PR TITLE
test: Test preventDefault behavior for recognized vs unknown keys in keyboard.test.ts

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -29,12 +29,16 @@ function createTarget(): Window {
   return target as Window;
 }
 
-function dispatchKeyDown(target: Window, code: string): void {
-  target.dispatchEvent(new KeyboardEvent("keydown", { code }));
+function dispatchKeyDown(target: Window, code: string): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { code, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
 }
 
-function dispatchKeyUp(target: Window, code: string): void {
-  target.dispatchEvent(new KeyboardEvent("keyup", { code }));
+function dispatchKeyUp(target: Window, code: string): KeyboardEvent {
+  const event = new KeyboardEvent("keyup", { code, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
 }
 
 function dispatchBlur(target: Window): void {
@@ -266,6 +270,48 @@ describe("createKeyboardController", () => {
     expect(firstSnapshot.mutePressed).toBe(true);
     expect(secondSnapshot.mutePressed).toBe(false);
     expect(rearmedSnapshot.mutePressed).toBe(true);
+  });
+
+  describe("preventDefault behavior", () => {
+    const recognizedCodes = [
+      "ArrowLeft",
+      "ArrowRight",
+      "Space",
+      "KeyP",
+      "KeyM"
+    ] as const;
+
+    for (const code of recognizedCodes) {
+      it(`prevents default for ${code} on keydown and keyup`, () => {
+        const target = createTarget();
+        const controller = createKeyboardController(target);
+
+        try {
+          const keyDownEvent = dispatchKeyDown(target, code);
+          const keyUpEvent = dispatchKeyUp(target, code);
+
+          expect(keyDownEvent.defaultPrevented).toBe(true);
+          expect(keyUpEvent.defaultPrevented).toBe(true);
+        } finally {
+          controller.dispose();
+        }
+      });
+    }
+
+    it("does not prevent default for unrecognized keys on keydown and keyup", () => {
+      const target = createTarget();
+      const controller = createKeyboardController(target);
+
+      try {
+        const keyDownEvent = dispatchKeyDown(target, "Tab");
+        const keyUpEvent = dispatchKeyUp(target, "Tab");
+
+        expect(keyDownEvent.defaultPrevented).toBe(false);
+        expect(keyUpEvent.defaultPrevented).toBe(false);
+      } finally {
+        controller.dispose();
+      }
+    });
   });
 
   it("removes the blur listener on dispose", () => {


### PR DESCRIPTION
## Test preventDefault behavior for recognized vs unknown keys in keyboard.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #626

### Changes
Extend src/input/keyboard.test.ts with cases that verify the keydown and keyup handlers installed by createKeyboardController call event.preventDefault() for each recognized code (ArrowLeft, ArrowRight, Space, KeyP, KeyM) on both keydown AND keyup, and that dispatching an unrecognized code (e.g. 'Tab') leaves defaultPrevented false on both keydown and keyup. Construct real KeyboardEvent instances with { code, cancelable: true } and dispatch them via the FakeWindow target already set up in the file — then assert on event.defaultPrevented after dispatch. Reuse the existing FakeWindow / createTarget / dispatchKeyDown / dispatchKeyUp helpers; if the helpers do not return the event, either refactor them to return it or construct the event inline in the new cases and call target.dispatchEvent directly. Place the new describe block near the bottom of the file, mount the controller via createKeyboardController(target) per case, and dispose it afterwards. Do NOT modify src/input/keyboard.ts — this task only guards the current behavior.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*