### PR TITLE
test: Unit-test assignInput, cloneInput, EMPTY_INPUT, and createPauseInput in state.test.ts

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -7,6 +7,7 @@ import {
   INVADER_PROJECTILE_WIDTH,
   assignInput,
   cloneInput,
+  createGameState,
   createInvaderProjectile,
   createPauseInput,
   createPlayingState,
@@ -16,9 +17,16 @@ import {
   type Invader,
   type Input
 } from "./state";
+import { step } from "./step";
 
 function getInputKeys(): Array<keyof Input> {
   return Object.keys(EMPTY_INPUT) as Array<keyof Input>;
+}
+
+function expectInputFields(actual: Input, expected: Input): void {
+  for (const key of getInputKeys()) {
+    expect(actual[key]).toBe(expected[key]);
+  }
 }
 
 describe("getFormationSpeed", () => {
@@ -115,20 +123,84 @@ describe("getFormationSpeed", () => {
   });
 });
 
-describe("input helpers", () => {
-  it("round-trips every EMPTY_INPUT field through cloneInput", () => {
-    const clonedInput = cloneInput(EMPTY_INPUT);
-
-    expect(clonedInput).toEqual(EMPTY_INPUT);
+describe("EMPTY_INPUT", () => {
+  it("uses neutral defaults for every field", () => {
+    expect(EMPTY_INPUT.moveX).toBe(0);
 
     for (const key of getInputKeys()) {
-      expect(clonedInput[key]).toEqual(EMPTY_INPUT[key]);
+      expect(EMPTY_INPUT[key]).toBe(key === "moveX" ? 0 : false);
     }
   });
+});
 
-  it("copies every Input field through assignInput", () => {
-    const target = cloneInput(EMPTY_INPUT);
+describe("cloneInput", () => {
+  it("copies every field into a distinct object without aliasing later mutations", () => {
+    const original: Input = {
+      moveX: -1,
+      firePressed: true,
+      pausePressed: true,
+      fireHeld: true,
+      pauseHeld: true,
+      mutePressed: true
+    };
+    const originalSnapshot: Input = { ...original };
+    const clonedInput = cloneInput(original);
+
+    expect(clonedInput).toEqual(original);
+    expect(clonedInput).not.toBe(original);
+    expectInputFields(clonedInput, original);
+
+    for (const key of getInputKeys()) {
+      if (key === "moveX") {
+        clonedInput[key] = 0;
+      } else {
+        clonedInput[key] = false;
+      }
+    }
+
+    expectInputFields(original, originalSnapshot);
+  });
+});
+
+describe("assignInput", () => {
+  it("copies every field into the existing target without aliasing later source mutations", () => {
+    const target: Input = {
+      moveX: -1,
+      firePressed: false,
+      pausePressed: true,
+      fireHeld: false,
+      pauseHeld: true,
+      mutePressed: false
+    };
     const source: Input = {
+      moveX: 1,
+      firePressed: true,
+      pausePressed: false,
+      fireHeld: true,
+      pauseHeld: false,
+      mutePressed: true
+    };
+    const targetReference = target;
+    const sourceSnapshot: Input = { ...source };
+
+    assignInput(target, source);
+
+    expect(target).toBe(targetReference);
+    expectInputFields(target, sourceSnapshot);
+
+    for (const key of getInputKeys()) {
+      if (key === "moveX") {
+        source[key] = 0;
+      } else {
+        source[key] = !source[key];
+      }
+    }
+
+    expectInputFields(target, sourceSnapshot);
+  });
+
+  it("clears a populated target when assigning EMPTY_INPUT", () => {
+    const target: Input = {
       moveX: 1,
       firePressed: true,
       pausePressed: true,
@@ -137,18 +209,17 @@ describe("input helpers", () => {
       mutePressed: true
     };
 
-    assignInput(target, source);
+    assignInput(target, EMPTY_INPUT);
 
-    for (const key of getInputKeys()) {
-      expect(target[key]).toBe(source[key]);
-    }
+    expectInputFields(target, EMPTY_INPUT);
   });
+});
 
-  it("creates a pause-only input from EMPTY_INPUT defaults", () => {
+describe("createPauseInput", () => {
+  it("sets only pausePressed and is accepted by step while paused", () => {
     const pauseInput = createPauseInput();
 
     expect(pauseInput.pausePressed).toBe(true);
-
     for (const key of getInputKeys()) {
       if (key === "pausePressed") {
         continue;
@@ -156,6 +227,15 @@ describe("input helpers", () => {
 
       expect(pauseInput[key]).toBe(EMPTY_INPUT[key]);
     }
+
+    const pausedState = createGameState({ phase: "paused" });
+    const advancePausedState = () => step(pausedState, 16, pauseInput);
+
+    expect(advancePausedState).not.toThrow();
+
+    const next = advancePausedState();
+
+    expect(next.state).toEqual(expect.objectContaining({ phase: "playing" }));
   });
 });
 


### PR DESCRIPTION
## Unit-test assignInput, cloneInput, EMPTY_INPUT, and createPauseInput in state.test.ts

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #625

### Changes
Add focused Vitest cases to src/game/state.test.ts that directly cover the pure input helpers exported from src/game/state.ts: (1) EMPTY_INPUT: assert moveX === 0 and that every edge/held boolean flag (firePressed, pausePressed, mutePressed, fireHeld, pauseHeld) is false; (2) cloneInput: given a fully-populated Input (all flags true, moveX === -1 or 1), assert the clone is structurally equal but is a distinct object reference, and that mutating the clone's fields afterwards does not affect the original; (3) assignInput: given a target Input populated with one set of values and a source with different values for every field, call assignInput(target, source) and assert that (a) every field on target now matches source, (b) target is returned/kept as the same object reference (no new allocation — verify identity), and (c) mutating source afterwards does not alias into target; also cover the reverse — assigning EMPTY_INPUT into a populated target clears every field; (4) createPauseInput: assert it returns an Input where pausePressed is true and every other edge flag is false, moveX === 0, and held flags are false — and confirm the returned object is accepted by step() while in a paused phase by calling step(pausedState, 16, createPauseInput()) and asserting it does not throw and returns a GameState. Use the getInputKeys() helper already present in the file or iterate Object.keys(EMPTY_INPUT) to make field-coverage exhaustive so future Input field additions are caught. Place the new describe() blocks alongside the existing ones in state.test.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*