### PR TITLE
test: Test recordScore skips storage writes for non-records

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -144,6 +144,21 @@ describe("createHighScoreStore", () => {
     ).toEqual([]);
   });
 
+  it("only writes to storage when a score sets a new record", () => {
+    const storage = new FakeStorage();
+    const store = createHighScoreStore(storage);
+
+    expect(store.recordScore(500)).toBe(500);
+    expect(store.recordScore(500)).toBe(500);
+    expect(store.recordScore(250)).toBe(500);
+
+    expect(storage.setItemCalls).toHaveLength(1);
+    expect(storage.setItemCalls[0]).toEqual({
+      key: HIGH_SCORE_STORAGE_KEY,
+      value: "500"
+    });
+  });
+
   it("persists scores above the stored high score", () => {
     const storage = new FakeStorage();
     storage.seed(HIGH_SCORE_STORAGE_KEY, "220");


### PR DESCRIPTION
## Test recordScore skips storage writes for non-records

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #637

### Changes
Add a new test case to src/persistence.test.ts that verifies createHighScoreStore.recordScore only writes to Storage when the score is a new record. Construct a FakeStorage (the helper class already in the file), create a store via createHighScoreStore with that storage, call recordScore with an initial score (e.g. 500) to establish a high score, then call recordScore again with an equal score (500) and a lower score (250). Assert that FakeStorage.setItemCalls has length 1 (only the initial record triggered a write) and that the single entry uses HIGH_SCORE_STORAGE_KEY with the serialized initial score. This locks in the `if (nextHighScore <= highScore) return highScore;` fast-path in src/persistence.ts that avoids redundant per-frame writes once a session has peaked. Place the test inside an appropriate describe block (create one for createHighScoreStore if none exists) using the existing vitest imports.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*