### PR TITLE
test: Lock projectile sprite dimensions to simulation hitbox constants

### DIFF
--- a/src/render/sprite-data/index.test.ts
+++ b/src/render/sprite-data/index.test.ts
@@ -1,12 +1,51 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  INVADER_PROJECTILE_HEIGHT,
+  INVADER_PROJECTILE_WIDTH,
+  PROJECTILE_HEIGHT,
+  PROJECTILE_WIDTH
+} from "../../game/state";
 import { getSprite } from "../sprites";
+import type { SpriteDescriptor } from "../sprites";
 import {
   INVADER_PROJECTILE_DESCRIPTOR,
   PLAYER_PROJECTILE_DESCRIPTOR,
   SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTOR_REGISTRY
 } from "./index";
+
+function expectSpriteFootprintToMatchHitbox(
+  descriptor: SpriteDescriptor,
+  expectedWidth: number,
+  expectedHeight: number
+): void {
+  expect(descriptor.frames.length).toBeGreaterThanOrEqual(1);
+
+  const firstFrame = descriptor.frames[0];
+  const frameRowCount = firstFrame?.length ?? 0;
+
+  expect(frameRowCount).toBeGreaterThan(0);
+
+  let maxRowLength = 0;
+
+  for (const frame of descriptor.frames) {
+    expect(frame.length).toBe(frameRowCount);
+
+    const frameRowLength = frame[0]?.length ?? 0;
+
+    expect(frameRowLength).toBeGreaterThan(0);
+
+    for (const row of frame) {
+      expect(row.length).toBe(frameRowLength);
+    }
+
+    maxRowLength = Math.max(maxRowLength, frameRowLength);
+  }
+
+  expect(maxRowLength * descriptor.pixelSize).toBe(expectedWidth);
+  expect(frameRowCount * descriptor.pixelSize).toBe(expectedHeight);
+}
 
 describe("SPRITE_DESCRIPTOR_REGISTRY", () => {
   it("registers and resolves shield-cell and invader-projectile through the public path", () => {
@@ -35,5 +74,23 @@ describe("SPRITE_DESCRIPTOR_REGISTRY", () => {
     expect(
       [...playerColors].some((color) => invaderColors.has(color))
     ).toBe(false);
+  });
+});
+
+describe("projectile sprite footprints", () => {
+  it("matches the player projectile sprite dimensions to the simulation hitbox", () => {
+    expectSpriteFootprintToMatchHitbox(
+      PLAYER_PROJECTILE_DESCRIPTOR,
+      PROJECTILE_WIDTH,
+      PROJECTILE_HEIGHT
+    );
+  });
+
+  it("matches the invader projectile sprite dimensions to the simulation hitbox", () => {
+    expectSpriteFootprintToMatchHitbox(
+      INVADER_PROJECTILE_DESCRIPTOR,
+      INVADER_PROJECTILE_WIDTH,
+      INVADER_PROJECTILE_HEIGHT
+    );
   });
 });


### PR DESCRIPTION
## Lock projectile sprite dimensions to simulation hitbox constants

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #638

### Changes
Extend src/render/sprite-data/index.test.ts with assertions that the rendered pixel footprint of PLAYER_PROJECTILE_DESCRIPTOR matches the simulation hitbox constants PROJECTILE_WIDTH/PROJECTILE_HEIGHT from src/game/state.ts, and that INVADER_PROJECTILE_DESCRIPTOR matches INVADER_PROJECTILE_WIDTH/INVADER_PROJECTILE_HEIGHT. For each descriptor, compute width = max row length across all frames × pixelSize, and height = number of rows in a frame × pixelSize (assert every frame has the same row count and a consistent row length). Expect those products to equal the corresponding hitbox constant exactly. Import the constants from './' / '../../game/state' as already done in the codebase. These tests must pass against the current code with no implementation changes — if a constant name differs (e.g. the player projectile width constant), read state.ts to find the actual exported name and use it. Keep the new `describe` block focused and co-located with the existing suite in the file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*