### PR TITLE
test: Test createHighScoreStore persists in-memory when storage.setItem throws

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -216,6 +216,15 @@ describe("createHighScoreStore", () => {
       expect(store.getHighScore()).toBe(0);
     });
 
+    it("keeps the in-memory high score when the first storage write throws", () => {
+      const storage = new FakeStorage();
+      storage.throwOnSet = true;
+      const store = createHighScoreStore(storage);
+
+      expect(store.recordScore(500)).toBe(500);
+      expect(store.getHighScore()).toBe(500);
+    });
+
     it("keeps the in-memory high score when writing the stored high score throws", () => {
       const storage = new FakeStorage();
       storage.seed(HIGH_SCORE_STORAGE_KEY, "220");


### PR DESCRIPTION
## Test createHighScoreStore persists in-memory when storage.setItem throws

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #655

### Changes
Add a new test case to src/persistence.test.ts that verifies createHighScoreStore tolerates a failing storage.setItem. Use the existing FakeStorage helper (already defined at the top of the file) and set its throwOnSet flag to true before calling recordScore. Wire up createHighScoreStore with the fake storage, call recordScore(500), and assert: (1) recordScore returns 500, (2) a subsequent getHighScore() call also returns 500, confirming the in-memory high score was still updated despite the thrown exception. The test should live inside a describe block for createHighScoreStore (add one if not already present) and should use the HIGH_SCORE_STORAGE_KEY constant already declared in the file only if asserting on storage contents (optional — the primary assertions are on return values). Do not modify src/persistence.ts — this task locks in current behavior against regression.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*