### PR TITLE
test: Test dispose() removes keydown/keyup listeners in keyboard.test.ts

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -314,6 +314,31 @@ describe("createKeyboardController", () => {
     });
   });
 
+  it("removes the keydown and keyup listeners on dispose", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    controller.dispose();
+
+    const leftKeyDownEvent = dispatchKeyDown(target, "ArrowLeft");
+    const leftKeyUpEvent = dispatchKeyUp(target, "ArrowLeft");
+    const fireKeyDownEvent = dispatchKeyDown(target, "Space");
+    const fireKeyUpEvent = dispatchKeyUp(target, "Space");
+
+    expect(leftKeyDownEvent.defaultPrevented).toBe(false);
+    expect(leftKeyUpEvent.defaultPrevented).toBe(false);
+    expect(fireKeyDownEvent.defaultPrevented).toBe(false);
+    expect(fireKeyUpEvent.defaultPrevented).toBe(false);
+    expect(controller.snapshot()).toEqual({
+      moveX: 0,
+      firePressed: false,
+      pausePressed: false,
+      fireHeld: false,
+      pauseHeld: false,
+      mutePressed: false
+    });
+  });
+
   it("removes the blur listener on dispose", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);


### PR DESCRIPTION
## Test dispose() removes keydown/keyup listeners in keyboard.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #556

### Changes
Add a new Vitest case to `src/input/keyboard.test.ts` inside the existing `describe("createKeyboardController", ...)` block that verifies `controller.dispose()` detaches BOTH the `keydown` and `keyup` listeners (not just `blur`). The test should: (1) create a fake window target and controller via `createKeyboardController(target)`, (2) call `controller.dispose()`, (3) dispatch a `keydown` for `ArrowLeft` (or another movement/fire code handled by the controller) on the target, (4) dispatch a matching `keyup` for the same code, (5) call `controller.snapshot()` and assert the returned `Input` shows no held movement (`moveX === 0`) and no edge flags set (e.g., `fireEdge`/`pauseEdge`/`muteEdge` are false, or whatever the current `Input` shape exposes — mirror what existing tests in the file already check). Prefer sending both a movement key (ArrowLeft) and an edge key (Space) so the test covers both held-state mutation and edge-flag mutation paths. Reuse the existing `createTarget`, `dispatchKeyDown`, and helper patterns already defined at the top of the file; add a `dispatchKeyUp` helper alongside them if one does not yet exist. Do NOT modify `src/input/keyboard.ts` — the listeners are already removed on dispose; this test simply locks that contract in.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*