### PR TITLE
test: Assert INVADER_ROW_DESCRIPTORS length matches INVADER_ROWS and id pattern

### DIFF
--- a/src/render/sprite-data/index.test.ts
+++ b/src/render/sprite-data/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   INVADER_PROJECTILE_HEIGHT,
   INVADER_PROJECTILE_WIDTH,
+  INVADER_ROWS,
   PROJECTILE_HEIGHT,
   PROJECTILE_WIDTH
 } from "../../game/state";
@@ -10,6 +11,7 @@ import { getSprite } from "../sprites";
 import type { SpriteDescriptor } from "../sprites";
 import {
   INVADER_PROJECTILE_DESCRIPTOR,
+  INVADER_ROW_DESCRIPTORS,
   PLAYER_PROJECTILE_DESCRIPTOR,
   SHIELD_CELL_DESCRIPTOR,
   SPRITE_DESCRIPTOR_REGISTRY
@@ -74,6 +76,16 @@ describe("SPRITE_DESCRIPTOR_REGISTRY", () => {
     expect(
       [...playerColors].some((color) => invaderColors.has(color))
     ).toBe(false);
+  });
+});
+
+describe("INVADER_ROW_DESCRIPTORS", () => {
+  it("matches the simulation row count and uses stable row ids", () => {
+    expect(INVADER_ROW_DESCRIPTORS).toHaveLength(INVADER_ROWS);
+
+    for (const [index, descriptor] of INVADER_ROW_DESCRIPTORS.entries()) {
+      expect(descriptor.id).toBe(`invader-row-${index}`);
+    }
   });
 });
 


### PR DESCRIPTION
## Assert INVADER_ROW_DESCRIPTORS length matches INVADER_ROWS and id pattern

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #639

### Changes
Add a new `describe` block (or extend the existing suite) in src/render/sprite-data/index.test.ts that imports INVADER_ROWS from src/game/state.ts and INVADER_ROW_DESCRIPTORS from ./index (or ./invaders). Assert that INVADER_ROW_DESCRIPTORS.length === INVADER_ROWS. Then iterate over INVADER_ROW_DESCRIPTORS with an index and assert each descriptor.id strictly equals `invader-row-${index}`. This locks the simulation row count and renderer descriptor count to a single source of truth so drift is caught by tests rather than manifesting as a subtle rendering bug.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*