### PR TITLE
test: Directly unit-test getPlayerMinX and getPlayerMaxX in state.test.ts

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -12,8 +12,12 @@ import {
   getFormationSpeed,
   getInvaderProjectileSpawnX,
   getInvaderProjectileSpawnY,
+  getPlayerMaxX,
+  getPlayerMinX,
+  type Arena,
   type Invader,
-  type Input
+  type Input,
+  type Player
 } from "./state";
 import { step } from "./step";
 
@@ -118,6 +122,122 @@ describe("getFormationSpeed", () => {
       expect(currentSpeed).toBeGreaterThanOrEqual(previousSpeed);
       previousSpeed = currentSpeed;
     }
+  });
+});
+
+describe("getPlayerMinX", () => {
+  it("returns the arena padding", () => {
+    const arena: Arena = {
+      width: 960,
+      height: 720,
+      floorY: 664,
+      padding: 56
+    };
+
+    expect(getPlayerMinX(arena)).toBe(arena.padding);
+  });
+
+  it("shifts upward when arena padding increases", () => {
+    const tightArena: Arena = {
+      width: 960,
+      height: 720,
+      floorY: 664,
+      padding: 32
+    };
+    const paddedArena: Arena = {
+      width: 960,
+      height: 720,
+      floorY: 664,
+      padding: 80
+    };
+
+    expect(getPlayerMinX(paddedArena)).toBe(getPlayerMinX(tightArena) + 48);
+  });
+});
+
+describe("getPlayerMaxX", () => {
+  it("returns arena.width minus padding and player width", () => {
+    const arena: Arena = {
+      width: 960,
+      height: 720,
+      floorY: 664,
+      padding: 56
+    };
+    const player: Player = {
+      x: 442,
+      y: 634,
+      width: 76,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    };
+
+    expect(getPlayerMaxX(arena, player)).toBe(
+      arena.width - arena.padding - player.width
+    );
+  });
+
+  it("reduces the maximum x by the player width delta for a wider player", () => {
+    const arena: Arena = {
+      width: 960,
+      height: 720,
+      floorY: 664,
+      padding: 56
+    };
+    const narrowPlayer: Player = {
+      x: 448,
+      y: 634,
+      width: 64,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    };
+    const widePlayer: Player = {
+      x: 436,
+      y: 634,
+      width: 88,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    };
+    const widthDelta = widePlayer.width - narrowPlayer.width;
+
+    expect(getPlayerMaxX(arena, narrowPlayer) - getPlayerMaxX(arena, widePlayer)).toBe(widthDelta);
+  });
+
+  it("shifts downward symmetrically when arena padding increases", () => {
+    const player: Player = {
+      x: 442,
+      y: 634,
+      width: 76,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    };
+    const tightArena: Arena = {
+      width: 960,
+      height: 720,
+      floorY: 664,
+      padding: 32
+    };
+    const paddedArena: Arena = {
+      width: 960,
+      height: 720,
+      floorY: 664,
+      padding: 80
+    };
+    const paddingDelta = paddedArena.padding - tightArena.padding;
+
+    expect(getPlayerMinX(paddedArena) - getPlayerMinX(tightArena)).toBe(
+      paddingDelta
+    );
+    expect(
+      getPlayerMaxX(tightArena, player) - getPlayerMaxX(paddedArena, player)
+    ).toBe(paddingDelta);
   });
 });
 


### PR DESCRIPTION
## Directly unit-test getPlayerMinX and getPlayerMaxX in state.test.ts

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #609

### Changes
Add a new `describe("getPlayerMinX" ...)` and `describe("getPlayerMaxX" ...)` block to src/game/state.test.ts that directly exercises the existing helpers exported from src/game/state.ts. Import `getPlayerMinX` and `getPlayerMaxX` (adding them to the existing import from "./state"), along with any `Arena` / `Player` types or factory helpers already exported for building test fixtures. Cover at minimum: (1) `getPlayerMinX(arena)` returns `arena.padding`; (2) `getPlayerMaxX(arena, player)` returns `arena.width - arena.padding - player.width`; (3) a wider player reduces the returned max by the width delta; (4) larger `arena.padding` shifts min up and max down symmetrically. Use small, explicit literal arena/player objects (constructed inline as typed literals) rather than mutating shared fixtures so each case is self-contained and matches the pure-helper coverage pattern already used in state.test.ts for `getFormationSpeed` and the projectile spawn helpers. Keep assertions direct (`expect(...).toBe(number)`); no step() invocation needed.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*