### PR TITLE
test: Test scheduleTone suppresses repeat calls within the cooldown window

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -323,40 +323,44 @@ describe("createAudioEngine", () => {
 
     const context = getLastContext(harness);
 
-    context.currentTime = 1;
+    context.currentTime = 3;
     engine.scheduleTone({
-      tag: "laser",
-      cooldownSeconds: 0.05,
+      tag: "shoot",
+      cooldownSeconds: 0.25,
       frequency: 720,
       duration: 0.09,
       gain: 0.06,
       type: "square"
     });
 
-    const scheduledOscillatorCount = harness.oscillators.length;
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+    expect(context.createGain).toHaveBeenCalledTimes(1);
 
+    context.currentTime += 0.1;
     engine.scheduleTone({
-      tag: "laser",
-      cooldownSeconds: 0.05,
+      tag: "shoot",
+      cooldownSeconds: 0.25,
       frequency: 720,
       duration: 0.09,
       gain: 0.06,
       type: "square"
     });
 
-    expect(harness.oscillators).toHaveLength(scheduledOscillatorCount);
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+    expect(context.createGain).toHaveBeenCalledTimes(1);
 
-    context.currentTime += 0.051;
+    context.currentTime += 0.2;
     engine.scheduleTone({
-      tag: "laser",
-      cooldownSeconds: 0.05,
+      tag: "shoot",
+      cooldownSeconds: 0.25,
       frequency: 720,
       duration: 0.09,
       gain: 0.06,
       type: "square"
     });
 
-    expect(harness.oscillators).toHaveLength(scheduledOscillatorCount + 1);
+    expect(context.createOscillator).toHaveBeenCalledTimes(2);
+    expect(context.createGain).toHaveBeenCalledTimes(2);
   });
 
   it("applies cooldown suppression independently for each scheduleTone tag", async () => {


### PR DESCRIPTION
## Test scheduleTone suppresses repeat calls within the cooldown window

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #679

### Changes
Add a Vitest case in src/audio/engine.test.ts that verifies the `lastScheduledAtByTag` cooldown branch in src/audio/engine.ts. Steps: (1) create the engine with the existing mock AudioContext factory and call `arm()` so it transitions to 'ready'; (2) advance the mock context's `currentTime` to a known baseline; (3) call `scheduleTone({ ... tag: 'shoot', cooldownSeconds: 0.25 })` and assert `createOscillator`/`createGain` were each invoked exactly once; (4) advance `currentTime` by less than the cooldown (e.g. 0.1s) and call `scheduleTone` again with the same tag — assert the oscillator/gain call counts did NOT increase (no second pair created); (5) advance `currentTime` past the cooldown (e.g. by another 0.2s so total elapsed > 0.25s) and call `scheduleTone` again with the same tag — assert a fresh oscillator/gain pair was created (call counts now 2). Reuse the existing MockAudioContext / MockOscillatorNode / MockGainNode helpers in the file rather than introducing new fixtures. Keep the new `it(...)` co-located with the existing scheduleTone tests and follow the file's existing style (vi.fn mocks, beforeEach/afterEach already set up). Do not modify src/audio/engine.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*