### PR TITLE
test: Directly unit-test getProjectileSpawnX and getProjectileSpawnY in state.test.ts

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -12,8 +12,12 @@ import {
   getFormationSpeed,
   getInvaderProjectileSpawnX,
   getInvaderProjectileSpawnY,
+  getProjectileSpawnX,
+  getProjectileSpawnY,
   getPlayerMaxX,
   getPlayerMinX,
+  PROJECTILE_HEIGHT,
+  PROJECTILE_WIDTH,
   type Arena,
   type Invader,
   type Input,
@@ -354,6 +358,85 @@ describe("createPauseInput", () => {
     const next = advancePausedState();
 
     expect(next.state).toEqual(expect.objectContaining({ phase: "playing" }));
+  });
+});
+
+describe("getProjectileSpawnX", () => {
+  it("centers a projectile on a wider player using the exact width-based formula", () => {
+    const player = {
+      x: 442,
+      y: 634,
+      width: 76,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getProjectileSpawnX(player)).toBe(
+      player.x + (player.width - PROJECTILE_WIDTH) / 2
+    );
+  });
+
+  it("returns the player's x unchanged when the player width matches the projectile width", () => {
+    const player = {
+      x: 180,
+      y: 320,
+      width: PROJECTILE_WIDTH,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getProjectileSpawnX(player)).toBe(player.x);
+  });
+
+  it("returns a spawn x left of the player when the player is narrower than the projectile", () => {
+    const player = {
+      x: 120,
+      y: 320,
+      width: PROJECTILE_WIDTH - 2,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getProjectileSpawnX(player)).toBe(
+      player.x + (player.width - PROJECTILE_WIDTH) / 2
+    );
+    expect(getProjectileSpawnX(player)).toBeLessThan(player.x);
+  });
+});
+
+describe("getProjectileSpawnY", () => {
+  it("places a player projectile flush above the player's top edge", () => {
+    const player = {
+      x: 442,
+      y: 634,
+      width: 76,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getProjectileSpawnY(player)).toBe(player.y - PROJECTILE_HEIGHT);
+  });
+
+  it("does not clamp a player at y zero", () => {
+    const player = {
+      x: 180,
+      y: 0,
+      width: 76,
+      height: 30,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getProjectileSpawnY(player)).toBe(-PROJECTILE_HEIGHT);
   });
 });
 


### PR DESCRIPTION
## Directly unit-test getProjectileSpawnX and getProjectileSpawnY in state.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #669

### Changes
Add a new `describe('getProjectileSpawnX', ...)` block and a new `describe('getProjectileSpawnY', ...)` block to src/game/state.test.ts that import and exercise the player-side projectile spawn helpers from src/game/state.ts. For getProjectileSpawnX(player), assert the result centers a PROJECTILE_WIDTH-wide projectile on the player: `player.x + (player.width - PROJECTILE_WIDTH) / 2`. Cover at least: (a) a player whose width is wider than PROJECTILE_WIDTH (e.g. a fresh player from createPlayingState's player) returns an x equal to that exact centering formula; (b) a player whose width equals PROJECTILE_WIDTH returns player.x unchanged; (c) a player whose width is narrower than PROJECTILE_WIDTH returns an x to the left of player.x (negative offset). Construct minimal Player-shaped objects inline rather than mutating createPlayingState players, and import PROJECTILE_WIDTH from './state'. For getProjectileSpawnY(player), assert it returns exactly `player.y - PROJECTILE_HEIGHT` so a freshly spawned player projectile sits flush above the player's top edge. Cover at least: (a) a typical player y returns y - PROJECTILE_HEIGHT; (b) a player at y = 0 returns -PROJECTILE_HEIGHT (the helper must not clamp). Import PROJECTILE_HEIGHT from './state'. Add the new imports (getProjectileSpawnX, getProjectileSpawnY, PROJECTILE_WIDTH, PROJECTILE_HEIGHT, and Player type if needed) to the existing import block from './state'. Do not change implementation in src/game/state.ts; the helpers already exist and this task is pure test coverage.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*