### PR TITLE
test: Test AudioEngine.arm() resumes suspended AudioContext and skips resume when running

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -185,6 +185,34 @@ describe("createAudioEngine", () => {
     expect(engine.getStatus()).toBe("ready");
   });
 
+  it("resumes a suspended context during arm and reports ready", async () => {
+    const suspendedHarness = createMockWebAudioHarness("suspended");
+    const engine = createAudioEngine({
+      createContext: suspendedHarness.createContext
+    });
+
+    await engine.arm();
+
+    const context = getLastContext(suspendedHarness);
+
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(engine.getStatus()).toBe("ready");
+  });
+
+  it("skips resume for a running context during arm and reports ready", async () => {
+    const runningHarness = createMockWebAudioHarness("running");
+    const engine = createAudioEngine({
+      createContext: runningHarness.createContext
+    });
+
+    await engine.arm();
+
+    const context = getLastContext(runningHarness);
+
+    expect(context.resume).toHaveBeenCalledTimes(0);
+    expect(engine.getStatus()).toBe("ready");
+  });
+
   it.each([
     {
       label: "context construction fails",


### PR DESCRIPTION
## Test AudioEngine.arm() resumes suspended AudioContext and skips resume when running

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #692

### Changes
Add two new test cases to src/audio/engine.test.ts that exercise the suspended-context branch of AudioEngine.arm(). Case 1: build a fake AudioContext whose initial `state` is 'suspended' (its `resume` mock should flip `state` to 'running' and resolve), call `engine.arm()`, and assert that `resume` was called exactly once AND `engine.getStatus()` returns 'ready' after the awaited arm. Case 2: build a fake AudioContext whose initial `state` is 'running', call `engine.arm()`, and assert that `resume` was NOT called (call count 0) AND `engine.getStatus()` returns 'ready'. Reuse the existing MockAudioContext / mock factory patterns already present in the test file (createOscillator, createGain, MockAudioParam, etc.) so the new cases match the surrounding style. Place the new tests inside the existing describe block(s) for arm() behavior, or add a focused describe('arm() resume behavior') block if no suitable one exists. Do not modify src/audio/engine.ts — these tests must pass against the current implementation.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*