### PR TITLE
test: Add direct unit tests for getFormationSpeed

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -53,8 +53,8 @@ describe("getFormationSpeed", () => {
     );
   });
 
-  it("caps waveStartSpeed at FORMATION_SPEED_MAX before interpolation", () => {
-    expect(getFormationSpeed(5, FORMATION_SPEED_MAX * 2, 10)).toBe(
+  it("caps waveStartSpeed at FORMATION_SPEED_MAX before scaling when all invaders are alive", () => {
+    expect(getFormationSpeed(10, FORMATION_SPEED_MAX * 2, 10)).toBe(
       FORMATION_SPEED_MAX
     );
   });
@@ -62,14 +62,6 @@ describe("getFormationSpeed", () => {
   it("returns a finite number when totalInvaders is zero", () => {
     expect(Number.isFinite(getFormationSpeed(0, FORMATION_SPEED_BASE, 0))).toBe(
       true
-    );
-  });
-
-  it("interpolates halfway between the capped wave start speed and FORMATION_SPEED_MAX", () => {
-    const waveStartSpeed = FORMATION_SPEED_BASE * 2;
-
-    expect(getFormationSpeed(5, waveStartSpeed, 10)).toBe(
-      waveStartSpeed + (FORMATION_SPEED_MAX - waveStartSpeed) / 2
     );
   });
 
@@ -87,23 +79,34 @@ describe("getFormationSpeed", () => {
     );
   });
 
-  it("clamps the fully cleared formation speed to FORMATION_SPEED_MAX", () => {
-    const waveStartSpeed = FORMATION_SPEED_MAX;
+  it("clamps the fully cleared formation speed to FORMATION_SPEED_MAX when the kill multiplier would exceed it", () => {
+    const waveStartSpeed = 120;
+
+    expect(waveStartSpeed * expectedKillMultiplier).toBeGreaterThan(
+      FORMATION_SPEED_MAX
+    );
 
     expect(getFormationSpeed(0, waveStartSpeed, 10)).toBe(
       FORMATION_SPEED_MAX
     );
   });
 
-  it("interpolates halfway between the wave start speed and the uncapped kill-multiplied speed", () => {
+  it("returns the linearly interpolated halfway speed between the wave start and fully cleared speeds", () => {
     const totalInvaders = 10;
-    const invaderCount = 5;
+    const invaderCount = totalInvaders / 2;
     const waveStartSpeed = 100;
-    const expectedMaxSpeed = waveStartSpeed * expectedKillMultiplier;
+    const fullyClearedSpeed = waveStartSpeed * expectedKillMultiplier;
+    const halfwaySpeed = getFormationSpeed(
+      invaderCount,
+      waveStartSpeed,
+      totalInvaders
+    );
 
-    expect(
-      getFormationSpeed(invaderCount, waveStartSpeed, totalInvaders)
-    ).toBeCloseTo(waveStartSpeed + (expectedMaxSpeed - waveStartSpeed) / 2);
+    expect(halfwaySpeed).toBeGreaterThan(waveStartSpeed);
+    expect(halfwaySpeed).toBeLessThan(fullyClearedSpeed);
+    expect(halfwaySpeed).toBeCloseTo(
+      waveStartSpeed + (fullyClearedSpeed - waveStartSpeed) / 2
+    );
   });
 
   it("never decreases as invaderCount drops toward zero", () => {


### PR DESCRIPTION
## Add direct unit tests for getFormationSpeed

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #693

### Changes
Extend the existing `describe('getFormationSpeed', ...)` block in src/game/state.test.ts with direct unit tests that pin the speed-up-as-invaders-are-killed invariant. Add cases that explicitly cover: (a) a full formation (invaderCount === totalInvaders) returns exactly waveStartSpeed; (b) a fully-killed formation (invaderCount === 0) returns waveStartSpeed * FORMATION_SPEED_KILL_MULTIPLIER, capped at FORMATION_SPEED_MAX — exercise both a waveStartSpeed where the multiplied result stays below FORMATION_SPEED_MAX and one where it would exceed FORMATION_SPEED_MAX so the cap is observable; (c) a half-killed formation (invaderCount === totalInvaders / 2) falls between the wave start speed and the fully-killed speed and matches a linearly-interpolated value within a small tolerance; (d) when waveStartSpeed itself exceeds FORMATION_SPEED_MAX, the function caps the wave-start input at FORMATION_SPEED_MAX before scaling (e.g. a full formation with waveStartSpeed = FORMATION_SPEED_MAX * 2 returns FORMATION_SPEED_MAX, not the inflated input). Reuse the existing `expectedKillMultiplier = 2.7` constant already declared in the describe block — do not redeclare it. Do not change FORMATION_SPEED_KILL_MULTIPLIER's exported visibility; mirror it in the test file as is already done. Do not modify src/game/state.ts or any production code — these tests must pass against the current implementation. Avoid duplicating the two cases already present (`invaderCount exceeds totalInvaders`, `negative invaderCount`).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*