### PR TITLE
test: Test createHighScoreStore normalizes invalid stored values to 0

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -295,14 +295,18 @@ describe("createHighScoreStore", () => {
     expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("260");
   });
 
-  it.each(["not-a-number", "-5", "NaN"])(
-    "recovers from malformed stored value %s",
+  it.each(["abc", "-50", "NaN", "Infinity"])(
+    "normalizes corrupt stored value %s to 0 and overwrites it on a new record",
     (storedValue) => {
       const storage = new FakeStorage();
       storage.seed(HIGH_SCORE_STORAGE_KEY, storedValue);
       const store = createHighScoreStore(storage);
 
       expect(store.getHighScore()).toBe(0);
+      expect(store.recordScore(10)).toBe(10);
+      expect(storage.setItemCalls).toEqual([
+        { key: HIGH_SCORE_STORAGE_KEY, value: "10" }
+      ]);
     }
   );
 


### PR DESCRIPTION
## Test createHighScoreStore normalizes invalid stored values to 0

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #699

### Changes
Add a new describe block (or extend an existing one) in src/persistence.test.ts that exercises createHighScoreStore with a FakeStorage seeded with each of the corrupted values "abc", "-50", "NaN", and "Infinity" under the key "space-invaders-hd.highScore". For each case: (1) construct the store, (2) assert getHighScore() === 0, and (3) call recordScore(10) and assert that a setItem call was recorded with key "space-invaders-hd.highScore" and value "10". Reuse the existing FakeStorage class and HIGH_SCORE_STORAGE_KEY constant already defined in the test file. Use the existing pattern of seeding via storage.seed(...). These tests must pass against the CURRENT src/persistence.ts without any production code changes — normalizeStoredValue/normalizeHighScore already handle these cases.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*