### PR TITLE
test: Test AudioEngine.setMuted(false) restores scheduling after a prior setMuted(true)

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -13,7 +13,8 @@ import {
   type AudioContextLike,
   type AudioDestinationLike,
   type AudioGainNodeLike,
-  type AudioOscillatorNodeLike
+  type AudioOscillatorNodeLike,
+  type ScheduleToneOptions
 } from "./engine";
 
 type MockDestination = {
@@ -292,6 +293,47 @@ describe("createAudioEngine", () => {
     expect(mutedEngine.getStatus()).toBe("muted");
     expect(harness.oscillators).toHaveLength(0);
     expect(harness.gains).toHaveLength(0);
+  });
+
+  it("restores scheduling after unmuting from a muted ready state", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+    const toneOptions: ScheduleToneOptions = {
+      frequency: 660,
+      duration: 0.08,
+      gain: 0.04,
+      type: "triangle"
+    };
+
+    await engine.arm();
+
+    const context = getLastContext(harness);
+
+    expect(engine.getStatus()).toBe("ready");
+
+    engine.setMuted(true);
+    engine.scheduleTone(toneOptions);
+
+    expect(context.createOscillator).not.toHaveBeenCalled();
+    expect(context.createGain).not.toHaveBeenCalled();
+
+    context.createOscillator.mockClear();
+    context.createGain.mockClear();
+
+    engine.setMuted(false);
+    engine.scheduleTone(toneOptions);
+
+    expect(engine.getStatus()).toBe("ready");
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+    expect(context.createGain).toHaveBeenCalledTimes(1);
+
+    const oscillator = harness.oscillators[0];
+
+    if (oscillator === undefined) {
+      throw new Error("Expected an oscillator after unmuting.");
+    }
+
+    expect(oscillator.start).toHaveBeenCalledTimes(1);
+    expect(oscillator.stop).toHaveBeenCalledTimes(1);
   });
 
   it("schedules oscillator playback through a gain envelope", async () => {


### PR DESCRIPTION
## Test AudioEngine.setMuted(false) restores scheduling after a prior setMuted(true)

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #700

### Changes
Add a new vitest case in src/audio/engine.test.ts that exercises the unmute restoration path of the existing AudioEngine. Steps: (1) construct the engine using the same fake AudioContext pattern already used in this test file; (2) await engine.arm() so status becomes 'ready'; (3) call engine.setMuted(true) and invoke engine.scheduleTone(...) once with a representative ScheduleToneOptions value, then assert that the fake context's createOscillator and createGain mocks were NOT called (mute suppression). Reset/clear those mocks; (4) call engine.setMuted(false) and invoke engine.scheduleTone(...) again, then assert createOscillator and createGain WERE each called exactly once and that the resulting oscillator's start and stop methods were invoked. This locks in the round-trip behavior the KeyM toggle relies on, complementing the existing 'setMuted(true) suppresses scheduleTone' case. Reuse the existing MockAudioContext / MockOscillatorNode / MockGainNode helpers and ScheduleToneOptions shape rather than introducing new fakes.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*