### PR TITLE
test: Test createHighScoreStore.recordScore skips setItem when score does not beat stored high

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -225,6 +225,20 @@ describe("createHighScoreStore", () => {
     expect(storage.setItemCalls).toHaveLength(0);
   });
 
+  it("does not write when the score is less than or equal to the stored high score", () => {
+    const storage = new FakeStorage();
+    storage.seed(HIGH_SCORE_STORAGE_KEY, "500");
+    const store = createHighScoreStore(storage);
+
+    expect(store.recordScore(300)).toBe(500);
+    expect(storage.setItemCalls).toHaveLength(0);
+    expect(store.getHighScore()).toBe(500);
+
+    expect(store.recordScore(500)).toBe(500);
+    expect(storage.setItemCalls).toHaveLength(0);
+    expect(store.getHighScore()).toBe(500);
+  });
+
   it("does not write when the score does not exceed the stored high score", () => {
     const storage = new FakeStorage();
     storage.seed(HIGH_SCORE_STORAGE_KEY, "500");


### PR DESCRIPTION
## Test createHighScoreStore.recordScore skips setItem when score does not beat stored high

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #713

### Changes
Add a Vitest case to src/persistence.test.ts that verifies createHighScoreStore.recordScore does NOT call storage.setItem when the candidate score is less than or equal to the existing high score. Use the existing FakeStorage class in the test file, seed it via storage.seed(HIGH_SCORE_STORAGE_KEY, '500') before constructing the store, then call createHighScoreStore({ storage }). Call recordScore(300) and assert storage.setItemCalls is still empty and getHighScore() returns 500. Then call recordScore(500) (the equal-to case) and assert storage.setItemCalls is still empty and getHighScore() still returns 500. This exercises the `if (nextHighScore <= highScore) return highScore` short-circuit in src/persistence.ts that the existing normalization/throw tests don't cover. Place the new it() block inside an appropriate existing describe (e.g. one for createHighScoreStore / recordScore) — add a new describe if none fits. Do not modify src/persistence.ts. Do not weaken or change any other test in the file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*