### PR TITLE
test: Test KeyM repeat-guard suppresses duplicate mutePressed edges while held

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -58,6 +58,12 @@ describe("createKeyboardController", () => {
       edgeField: "pausePressed",
       heldField: "pauseHeld",
       label: "pause"
+    },
+    {
+      code: "KeyM",
+      edgeField: "mutePressed",
+      heldField: undefined,
+      label: "mute"
     }
   ] as const;
 
@@ -201,11 +207,14 @@ describe("createKeyboardController", () => {
       const rearmedSnapshot = controller.snapshot();
 
       expect(firstSnapshot[edgeField]).toBe(true);
-      expect(firstSnapshot[heldField]).toBe(true);
       expect(secondSnapshot[edgeField]).toBe(false);
-      expect(secondSnapshot[heldField]).toBe(true);
       expect(rearmedSnapshot[edgeField]).toBe(true);
-      expect(rearmedSnapshot[heldField]).toBe(true);
+
+      if (heldField !== undefined) {
+        expect(firstSnapshot[heldField]).toBe(true);
+        expect(secondSnapshot[heldField]).toBe(true);
+        expect(rearmedSnapshot[heldField]).toBe(true);
+      }
     });
   }
 
@@ -248,28 +257,6 @@ describe("createKeyboardController", () => {
 
     expect(firstMuteSnapshot.mutePressed).toBe(true);
     expect(secondMuteSnapshot.mutePressed).toBe(false);
-  });
-
-  it("does not re-emit the mute edge on auto-repeat keydown and re-arms after keyup", () => {
-    const target = createTarget();
-    const controller = createKeyboardController(target);
-
-    dispatchKeyDown(target, "KeyM");
-
-    const firstSnapshot = controller.snapshot();
-
-    dispatchKeyDown(target, "KeyM");
-
-    const secondSnapshot = controller.snapshot();
-
-    dispatchKeyUp(target, "KeyM");
-    dispatchKeyDown(target, "KeyM");
-
-    const rearmedSnapshot = controller.snapshot();
-
-    expect(firstSnapshot.mutePressed).toBe(true);
-    expect(secondSnapshot.mutePressed).toBe(false);
-    expect(rearmedSnapshot.mutePressed).toBe(true);
   });
 
   describe("preventDefault behavior", () => {


### PR DESCRIPTION
## Test KeyM repeat-guard suppresses duplicate mutePressed edges while held

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #714

### Changes
Extend the repeat-guard coverage in src/input/keyboard.test.ts to include KeyM. The existing repeatGuardCases array covers Space (firePressed) and KeyP (pausePressed) but deliberately omits KeyM, leaving the `if (!held.mute) { held.muteEdge = true }` guard in keyboard.ts at line referencing the KeyM keydown branch untested. Add a case (either by extending repeatGuardCases or adding a parallel `it` block) that: (1) creates a controller via createKeyboardController on a FakeWindow target, (2) dispatches a first `keydown` for `KeyM` and snapshots the input — assert `mutePressed` is `true`, (3) dispatches a second `keydown` for `KeyM` WITHOUT an intervening `keyup` and snapshots again — assert `mutePressed` is `false` on this second snapshot. Use the existing dispatchKeyDown / dispatchKeyUp / createTarget helpers in the file. Mirror the style of the existing Space/KeyP repeat-guard tests exactly so the new case integrates cleanly. Do NOT modify src/input/keyboard.ts — the guard already exists; this task only adds the regression test for it.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*