### PR TITLE
test: Test KeyM keyup restores mutePressed edge for press-release-press cycle

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -218,6 +218,23 @@ describe("createKeyboardController", () => {
     });
   }
 
+  it("re-emits the mute edge after KeyM is released and pressed again", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    try {
+      dispatchKeyDown(target, "KeyM");
+      controller.snapshot();
+
+      dispatchKeyUp(target, "KeyM");
+      dispatchKeyDown(target, "KeyM");
+
+      expect(controller.snapshot().mutePressed).toBe(true);
+    } finally {
+      controller.dispose();
+    }
+  });
+
   it("consumes returned fire, pause, and mute edges on the next snapshot", () => {
     const heldEdgeCases = [
       {


### PR DESCRIPTION
## Test KeyM keyup restores mutePressed edge for press-release-press cycle

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #729

### Changes
Add a new test case to the existing describe('createKeyboardController') block in src/input/keyboard.test.ts that exercises a press-release-press cycle on KeyM and asserts the edge is re-emitted. The test should: (1) create a controller via createKeyboardController(target) using the existing createTarget() helper, (2) dispatch keydown KeyM via dispatchKeyDown, (3) call snapshot() once to consume the initial mutePressed edge (mirroring the per-frame snapshot semantics), (4) dispatch keyup KeyM via dispatchKeyUp, (5) dispatch keydown KeyM again, (6) assert that snapshot().mutePressed is true after the second keydown. This guards the invariant that onKeyUp clears held.mute = false so the next keydown re-arms the edge — distinct from the existing repeat-guard case (which only verifies held-keydown suppression) and the blur case (which only verifies blur→repress). Reuse the existing FakeWindow / dispatchKeyDown / dispatchKeyUp helpers at the top of the file. Remember to call controller.dispose() at the end of the test to avoid leaking listeners, matching the pattern used in other cases in this file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*