### PR TITLE
test: Cover in-memory Storage fallback in persistence.test.ts

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -339,6 +339,23 @@ describe("createHighScoreStore", () => {
       expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("220");
     });
 
+    it("continues returning the in-memory high score after setItem throws", () => {
+      const storage = new FakeStorage();
+      storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+      storage.throwOnSet = true;
+      const store = createHighScoreStore(storage);
+      let recordedHighScore = Number.NaN;
+
+      expect(() => {
+        recordedHighScore = store.recordScore(360);
+      }).not.toThrow();
+
+      expect(recordedHighScore).toBe(360);
+      expect(store.getHighScore()).toBe(360);
+      expect(store.getHighScore()).toBe(360);
+      expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("220");
+    });
+
     it("falls back to memory storage when localStorage access throws", () => {
       const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
         globalThis,
@@ -359,6 +376,39 @@ describe("createHighScoreStore", () => {
 
         expect(store.recordScore(nextHighScore)).toBe(nextHighScore);
         expect(store.getHighScore()).toBe(nextHighScore);
+      } finally {
+        if (originalLocalStorageDescriptor) {
+          Object.defineProperty(
+            globalThis,
+            "localStorage",
+            originalLocalStorageDescriptor
+          );
+        } else {
+          Reflect.deleteProperty(globalThis, "localStorage");
+        }
+      }
+    });
+
+    it("falls back to memory storage when localStorage is undefined", () => {
+      const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "localStorage"
+      );
+
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: undefined,
+        writable: true
+      });
+
+      try {
+        const store = createHighScoreStore();
+        const initialHighScore = store.getHighScore();
+        const nextHighScore = initialHighScore + 1;
+
+        expect(store.recordScore(nextHighScore)).toBe(nextHighScore);
+        expect(store.getHighScore()).toBe(nextHighScore);
+        expect(createHighScoreStore().getHighScore()).toBe(nextHighScore);
       } finally {
         if (originalLocalStorageDescriptor) {
           Object.defineProperty(


### PR DESCRIPTION
## Cover in-memory Storage fallback in persistence.test.ts

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #727

### Changes
Append new it() cases to src/persistence.test.ts that exercise the unprotected fallback paths in persistence.ts. (1) Construct a FakeStorage with throwOnSet=true (the harness already supports this), pass it to createHighScoreStore, then call recordScore with a score higher than the current high; assert it does not throw, that the returned store's getter (or recordScore return value) reflects the new in-memory high score, and that subsequent reads continue to return the in-memory value. Optionally also assert that recordScore returns true / updates the high even though setItem failed. (2) Save the original globalThis.localStorage descriptor, delete (or set to undefined) globalThis.localStorage, then call createHighScoreStore() with NO storage argument; assert the resulting store can record a score and read it back via the in-memory fallback created by getDefaultStorage's catch path. Restore the original localStorage descriptor in a try/finally (or afterEach) so other tests are unaffected. Use the existing FakeStorage class for case (1); do not modify persistence.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*