### PR TITLE
test: Test AudioEngine.setMuted(true) suppresses scheduleTone when armed

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -295,6 +295,43 @@ describe("createAudioEngine", () => {
     expect(harness.gains).toHaveLength(0);
   });
 
+  it("lets muted status override ready until scheduling is explicitly re-enabled", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+    const toneOptions: ScheduleToneOptions = {
+      frequency: 660,
+      duration: 0.08,
+      gain: 0.04,
+      type: "triangle"
+    };
+
+    await engine.arm();
+
+    const context = getLastContext(harness);
+
+    expect(engine.getStatus()).toBe("ready");
+
+    context.createOscillator.mockClear();
+    context.createGain.mockClear();
+
+    engine.setMuted(true);
+
+    expect(engine.getStatus()).toBe("muted");
+
+    engine.scheduleTone(toneOptions);
+
+    expect(context.createOscillator).not.toHaveBeenCalled();
+    expect(context.createGain).not.toHaveBeenCalled();
+
+    engine.setMuted(false);
+
+    expect(engine.getStatus()).toBe("ready");
+
+    engine.scheduleTone(toneOptions);
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+    expect(context.createGain).toHaveBeenCalledTimes(1);
+  });
+
   it("restores scheduling after unmuting from a muted ready state", async () => {
     const engine = createAudioEngine({ createContext: harness.createContext });
     const toneOptions: ScheduleToneOptions = {


### PR DESCRIPTION
## Test AudioEngine.setMuted(true) suppresses scheduleTone when armed

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #598

### Changes
Add a test case in src/audio/engine.test.ts that verifies mute takes precedence over the armed state. Steps: (1) construct the engine with the mock AudioContext, call arm() and await it so getStatus() returns 'ready'; (2) call setMuted(true) and assert getStatus() now returns 'muted'; (3) call scheduleTone(...) with a valid ScheduleToneOptions payload and assert that the mock context's createOscillator and createGain mocks were never invoked (use .not.toHaveBeenCalled() — remember any calls made during arm() should be cleared first, e.g. via mockClear(), so the assertion only covers post-mute behavior); (4) call setMuted(false), assert getStatus() returns 'ready' again without a second arm() call, then call scheduleTone(...) and assert createOscillator / createGain WERE invoked, proving scheduling is re-enabled. Reuse the existing MockAudioContext helpers/factories already in the file rather than introducing a parallel mock harness. This locks in the mute-overrides-ready precedence at src/audio/engine.ts:95.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*