### PR TITLE
test: Directly unit-test getPlayerMinX and getPlayerMaxX in state.test.ts

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -254,6 +254,143 @@ describe("getPlayerMaxX", () => {
   });
 });
 
+describe("getPlayerMinX", () => {
+  it("returns arena.padding for a typical arena", () => {
+    const arena = {
+      width: 800,
+      height: 600,
+      floorY: 560,
+      padding: 24
+    } satisfies Arena;
+
+    expect(getPlayerMinX(arena)).toBe(24);
+  });
+
+  it("returns 0 when arena.padding is 0", () => {
+    const arena = {
+      width: 800,
+      height: 600,
+      floorY: 560,
+      padding: 0
+    } satisfies Arena;
+
+    expect(getPlayerMinX(arena)).toBe(0);
+  });
+
+  it("depends only on padding and ignores arena width, height, and floorY", () => {
+    const compactArena = {
+      width: 800,
+      height: 600,
+      floorY: 560,
+      padding: 24
+    } satisfies Arena;
+    const oversizedArena = {
+      width: 1280,
+      height: 900,
+      floorY: 840,
+      padding: 24
+    } satisfies Arena;
+
+    expect(getPlayerMinX(compactArena)).toBe(24);
+    expect(getPlayerMinX(oversizedArena)).toBe(24);
+  });
+});
+
+describe("getPlayerMaxX", () => {
+  it("returns the rightmost x for a typical arena and player", () => {
+    const arena = {
+      width: 800,
+      height: 600,
+      floorY: 560,
+      padding: 24
+    } satisfies Arena;
+    const player = {
+      x: 384,
+      y: 528,
+      width: 32,
+      height: 32,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getPlayerMaxX(arena, player)).toBe(744);
+  });
+
+  it("shrinks by exactly the player width delta as the player gets wider", () => {
+    const arena = {
+      width: 800,
+      height: 600,
+      floorY: 560,
+      padding: 24
+    } satisfies Arena;
+    const narrowPlayer = {
+      x: 384,
+      y: 528,
+      width: 32,
+      height: 32,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+    const widePlayer = {
+      x: 378,
+      y: 528,
+      width: 44,
+      height: 32,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getPlayerMaxX(arena, narrowPlayer)).toBe(744);
+    expect(getPlayerMaxX(arena, widePlayer)).toBe(732);
+    expect(getPlayerMaxX(arena, narrowPlayer) - getPlayerMaxX(arena, widePlayer)).toBe(12);
+  });
+
+  it("ignores right-side padding when arena.padding is 0", () => {
+    const arena = {
+      width: 800,
+      height: 600,
+      floorY: 560,
+      padding: 0
+    } satisfies Arena;
+    const player = {
+      x: 384,
+      y: 528,
+      width: 32,
+      height: 32,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getPlayerMaxX(arena, player)).toBe(768);
+  });
+
+  it("stays strictly greater than getPlayerMinX for a normal-sized player", () => {
+    const arena = {
+      width: 800,
+      height: 600,
+      floorY: 560,
+      padding: 24
+    } satisfies Arena;
+    const player = {
+      x: 384,
+      y: 528,
+      width: 32,
+      height: 32,
+      speed: 420,
+      shootCooldownMs: 0,
+      invulnerableUntilMs: 0
+    } satisfies Player;
+
+    expect(getPlayerMinX(arena)).toBe(24);
+    expect(getPlayerMaxX(arena, player)).toBe(744);
+    expect(getPlayerMaxX(arena, player)).toBeGreaterThan(getPlayerMinX(arena));
+  });
+});
+
 describe("EMPTY_INPUT", () => {
   it("uses neutral defaults for every field", () => {
     expect(EMPTY_INPUT.moveX).toBe(0);


### PR DESCRIPTION
## Directly unit-test getPlayerMinX and getPlayerMaxX in state.test.ts

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #748

### Changes
Add a new `describe('getPlayerMinX', ...)` block and a new `describe('getPlayerMaxX', ...)` block to src/game/state.test.ts (do NOT modify existing describe blocks or other tests). Both helpers are already exported from src/game/state.ts and imported in state.test.ts — verify before writing. For getPlayerMinX(arena): cover at least (a) returns arena.padding for a typical arena, (b) returns 0 when arena.padding is 0, (c) returns the same arena.padding regardless of arena.width/height/floorY (i.e., depends only on padding). For getPlayerMaxX(arena, player): cover at least (a) returns arena.width - arena.padding - player.width for a typical arena/player, (b) shrinks the max as player.width grows (test two different widths and assert the difference equals the width delta), (c) ignores arena.padding on the right when padding is 0 (returns arena.width - player.width), (d) returns a value strictly greater than getPlayerMinX(arena) for a normal-sized player so the playfield is non-empty. Construct Arena and Player literals inline with realistic numbers (e.g. width 800, height 600, floorY 560, padding 24, player.width 32). Use `expect(...).toBe(...)` with the exact arithmetic result rather than recomputing the formula via the same expression you're testing. Keep tests pure — no step() invocation, no GameState construction. Do not change src/game/state.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*