### PR TITLE
test: Test ArrowLeft/ArrowRight keyup does not consume firePressed/pausePressed/mutePressed edges

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -96,6 +96,26 @@ describe("createKeyboardController", () => {
     expect(controller.snapshot().moveX).toBe(-1);
   });
 
+  it("preserves pending fire, pause, and mute edges across movement keyup events", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "Space");
+    dispatchKeyDown(target, "KeyP");
+    dispatchKeyDown(target, "KeyM");
+    dispatchKeyUp(target, "ArrowLeft");
+    dispatchKeyUp(target, "ArrowRight");
+
+    const snapshot = controller.snapshot();
+
+    expect(snapshot.moveX).toBe(0);
+    expect(snapshot.firePressed).toBe(true);
+    expect(snapshot.pausePressed).toBe(true);
+    expect(snapshot.mutePressed).toBe(true);
+
+    controller.dispose();
+  });
+
   it("clears held ArrowRight, Space, and KeyP input and resets mute gating on blur", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);


### PR DESCRIPTION
## Test ArrowLeft/ArrowRight keyup does not consume firePressed/pausePressed/mutePressed edges

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #760

### Changes
Add a vitest case in src/input/keyboard.test.ts inside the existing describe('createKeyboardController') block that verifies movement keyup events do not clear pending fire/pause/mute edges. The case should: (1) create a controller via createKeyboardController(target) with a FakeWindow target produced by the existing createTarget() helper; (2) dispatch keydown events for Space, KeyP, and KeyM (using the existing dispatchKeyDown helper) so fireEdge, pauseEdge, and muteEdge are all set; (3) dispatch keyup events for ArrowLeft and ArrowRight (using the existing dispatchKeyUp helper) BEFORE calling snapshot(); (4) call controller.snapshot() and assert that the returned Input has firePressed === true, pausePressed === true, and mutePressed === true. Also assert that left and right are false on the snapshot (since those keys were never pressed and only released). End by calling controller.dispose(). This guards against accidental edge-clearing in the ArrowLeft/ArrowRight keyup branches of createKeyboardController.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*