### PR TITLE
test: Directly unit-test getFormationSpeed clamping in state.test.ts

### DIFF
--- a/src/game/state.test.ts
+++ b/src/game/state.test.ts
@@ -51,16 +51,28 @@ describe("getFormationSpeed", () => {
     expect(getFormationSpeed(99, waveStartSpeed, 10)).toBe(waveStartSpeed);
   });
 
-  it("treats negative invaderCount as a fully cleared formation", () => {
-    const waveStartSpeed = FORMATION_SPEED_BASE * 2;
-
-    expect(getFormationSpeed(-1, waveStartSpeed, 10)).toBe(
+  it("returns the per-wave max speed when invaderCount is zero or negative", () => {
+    const waveStartSpeed = FORMATION_SPEED_BASE;
+    const expectedWaveMaxSpeed = Math.min(
+      waveStartSpeed * expectedKillMultiplier,
       FORMATION_SPEED_MAX
+    );
+
+    expect(getFormationSpeed(0, waveStartSpeed, 10)).toBeCloseTo(
+      expectedWaveMaxSpeed
+    );
+    expect(getFormationSpeed(-1, waveStartSpeed, 10)).toBeCloseTo(
+      expectedWaveMaxSpeed
     );
   });
 
-  it("caps waveStartSpeed at FORMATION_SPEED_MAX before scaling when all invaders are alive", () => {
-    expect(getFormationSpeed(10, FORMATION_SPEED_MAX * 2, 10)).toBe(
+  it("caps an over-max waveStartSpeed to FORMATION_SPEED_MAX at both the start and clear states", () => {
+    const waveStartSpeed = FORMATION_SPEED_MAX * 1.5;
+
+    expect(getFormationSpeed(10, waveStartSpeed, 10)).toBe(
+      FORMATION_SPEED_MAX
+    );
+    expect(getFormationSpeed(0, waveStartSpeed, 10)).toBe(
       FORMATION_SPEED_MAX
     );
   });
@@ -75,14 +87,6 @@ describe("getFormationSpeed", () => {
     const waveStartSpeed = 100;
 
     expect(getFormationSpeed(10, waveStartSpeed, 10)).toBe(waveStartSpeed);
-  });
-
-  it("uses the uncapped kill multiplier when no invaders remain and the scaled speed stays below the cap", () => {
-    const waveStartSpeed = 100;
-
-    expect(getFormationSpeed(0, waveStartSpeed, 10)).toBeCloseTo(
-      waveStartSpeed * expectedKillMultiplier
-    );
   });
 
   it("clamps the fully cleared formation speed to FORMATION_SPEED_MAX when the kill multiplier would exceed it", () => {
@@ -100,18 +104,22 @@ describe("getFormationSpeed", () => {
   it("returns the linearly interpolated halfway speed between the wave start and fully cleared speeds", () => {
     const totalInvaders = 10;
     const invaderCount = totalInvaders / 2;
-    const waveStartSpeed = 100;
-    const fullyClearedSpeed = waveStartSpeed * expectedKillMultiplier;
+    const waveStartSpeed = FORMATION_SPEED_BASE;
+    const fullyClearedSpeed = Math.min(
+      waveStartSpeed * expectedKillMultiplier,
+      FORMATION_SPEED_MAX
+    );
     const halfwaySpeed = getFormationSpeed(
       invaderCount,
       waveStartSpeed,
       totalInvaders
     );
 
+    expect(fullyClearedSpeed).toBeLessThan(FORMATION_SPEED_MAX);
     expect(halfwaySpeed).toBeGreaterThan(waveStartSpeed);
     expect(halfwaySpeed).toBeLessThan(fullyClearedSpeed);
     expect(halfwaySpeed).toBeCloseTo(
-      waveStartSpeed + (fullyClearedSpeed - waveStartSpeed) / 2
+      (waveStartSpeed + fullyClearedSpeed) / 2
     );
   });
 


### PR DESCRIPTION
## Directly unit-test getFormationSpeed clamping in state.test.ts

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #767

### Changes
Extend the existing `describe("getFormationSpeed", ...)` block in src/game/state.test.ts with direct unit tests for the pure helper exported from src/game/state.ts. Add at least the following four cases: (1) when `invaderCount > totalInvaders`, the function returns `waveStartSpeed` (kill ratio clamps to 0). (2) When `invaderCount <= 0` (e.g. 0 and a negative value), the function returns the per-wave max speed, which is `min(waveStartSpeed * FORMATION_SPEED_KILL_MULTIPLIER, FORMATION_SPEED_MAX)` — use the existing `expectedKillMultiplier = 2.7` constant already declared in the file. (3) When `waveStartSpeed` is set above `FORMATION_SPEED_MAX` (e.g. `FORMATION_SPEED_MAX * 1.5`), the result at `invaderCount = 0` is capped to exactly `FORMATION_SPEED_MAX` (and at `invaderCount = totalInvaders` returns `waveStartSpeed`, since the start clamp is just the input). (4) Linear interpolation at the midpoint: with `totalInvaders = 10`, `invaderCount = 5`, the result equals the average of `waveStartSpeed` and the capped wave-max speed (use a `waveStartSpeed` low enough that the multiplied max stays under `FORMATION_SPEED_MAX`, then assert with `toBeCloseTo`). Pick concrete numeric inputs based on `FORMATION_SPEED_BASE` and `FORMATION_SPEED_MAX` already imported at the top of the file. Do NOT modify src/game/state.ts — these tests target the existing implementation.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*