### PR TITLE
test: Test AudioEngine.scheduleTone with tag but no cooldown does not gate tones

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -470,6 +470,33 @@ describe("createAudioEngine", () => {
     expect(context.createGain).toHaveBeenCalledTimes(2);
   });
 
+  it("does not gate consecutive tones when tag is provided without cooldownSeconds", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+    await engine.arm();
+
+    const context = getLastContext(harness);
+    const toneOptions: ScheduleToneOptions = {
+      tag: "shoot",
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    };
+
+    engine.scheduleTone(toneOptions);
+    engine.scheduleTone(toneOptions);
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(2);
+    expect(context.createGain).toHaveBeenCalledTimes(2);
+    expect(harness.oscillators).toHaveLength(2);
+    expect(harness.gains).toHaveLength(2);
+
+    for (const oscillator of harness.oscillators) {
+      expect(oscillator.start).toHaveBeenCalledTimes(1);
+      expect(oscillator.stop).toHaveBeenCalledTimes(1);
+    }
+  });
+
   it("applies cooldown suppression independently for each scheduleTone tag", async () => {
     const engine = createAudioEngine({ createContext: harness.createContext });
     await engine.arm();


### PR DESCRIPTION
## Test AudioEngine.scheduleTone with tag but no cooldown does not gate tones

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #784

### Changes
Add a Vitest case in src/audio/engine.test.ts that exercises the branch in src/audio/engine.ts where `scheduleTone` is called with a `tag` but WITHOUT `cooldownSeconds`. The cooldown gate in engine.ts only triggers when both `tag !== undefined` AND `cooldownSeconds !== undefined` — this branch is currently uncovered. Steps the test should follow: (1) create the engine and `await engine.arm()` so it transitions to ready and the mock AudioContext is wired; (2) call `engine.scheduleTone({ frequency, duration, gain, type, tag: "shoot" })` twice back-to-back with no `cooldownSeconds`; (3) assert that BOTH calls produced oscillator and gain nodes (e.g. `createOscillator` and `createGain` were each called twice, both oscillators got `start`/`stop`, no suppression occurred). Reuse the existing mock context/oscillator/gain helpers already present at the top of engine.test.ts — do not redefine them. Place the new `it(...)` inside the existing `describe` block for `scheduleTone` (or the engine root describe) next to related cases, and give it a descriptive name like "does not gate consecutive tones when tag is provided without cooldownSeconds". Do NOT modify src/audio/engine.ts — this task only adds a test for already-existing behavior.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*