### PR TITLE
test: Test createHighScoreStore falls back to in-memory storage when localStorage is unavailable

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createHighScoreStore, pickDisplayHighScore } from "./persistence";
 
@@ -356,70 +356,51 @@ describe("createHighScoreStore", () => {
       expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("220");
     });
 
-    it("falls back to memory storage when localStorage access throws", () => {
+    describe("when default storage is unavailable", () => {
       const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
         globalThis,
         "localStorage"
       );
 
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        get() {
-          throw new Error("localStorage unavailable");
-        }
-      });
+      afterEach(() => {
+        vi.unstubAllGlobals();
 
-      try {
-        const store = createHighScoreStore();
-        const initialHighScore = store.getHighScore();
-        const nextHighScore = initialHighScore + 1;
-
-        expect(store.recordScore(nextHighScore)).toBe(nextHighScore);
-        expect(store.getHighScore()).toBe(nextHighScore);
-      } finally {
         if (originalLocalStorageDescriptor) {
           Object.defineProperty(
             globalThis,
             "localStorage",
             originalLocalStorageDescriptor
           );
-        } else {
-          Reflect.deleteProperty(globalThis, "localStorage");
+          return;
         }
-      }
-    });
 
-    it("falls back to memory storage when localStorage is undefined", () => {
-      const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
-        globalThis,
-        "localStorage"
-      );
-
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: undefined,
-        writable: true
+        Reflect.deleteProperty(globalThis, "localStorage");
       });
 
-      try {
+      it("falls back to memory storage when localStorage access throws", () => {
+        Object.defineProperty(globalThis, "localStorage", {
+          configurable: true,
+          get() {
+            throw new Error("localStorage unavailable");
+          }
+        });
+
         const store = createHighScoreStore();
-        const initialHighScore = store.getHighScore();
-        const nextHighScore = initialHighScore + 1;
+        const nextHighScore = store.getHighScore() + 1;
 
         expect(store.recordScore(nextHighScore)).toBe(nextHighScore);
         expect(store.getHighScore()).toBe(nextHighScore);
-        expect(createHighScoreStore().getHighScore()).toBe(nextHighScore);
-      } finally {
-        if (originalLocalStorageDescriptor) {
-          Object.defineProperty(
-            globalThis,
-            "localStorage",
-            originalLocalStorageDescriptor
-          );
-        } else {
-          Reflect.deleteProperty(globalThis, "localStorage");
-        }
-      }
+      });
+
+      it("falls back to memory storage when localStorage is undefined", () => {
+        vi.stubGlobal("localStorage", undefined);
+
+        const store = createHighScoreStore();
+        const nextHighScore = store.getHighScore() + 1;
+
+        expect(store.recordScore(nextHighScore)).toBe(nextHighScore);
+        expect(store.getHighScore()).toBe(nextHighScore);
+      });
     });
   });
 });


### PR DESCRIPTION
## Test createHighScoreStore falls back to in-memory storage when localStorage is unavailable

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #774

### Changes
Add a new describe block (or it cases inside an appropriate describe) in src/persistence.test.ts that exercises createHighScoreStore's fallback behavior when no Storage is available. Cover at minimum: (1) constructing createHighScoreStore() with no storage argument under a globalThis where accessing localStorage throws — verify recordScore(value) followed by getHighScore() returns the recorded value within the same store instance, locking in the in-memory fallback path in src/persistence.ts around lines 5 and 41-48. (2) The same flow when localStorage is undefined on globalThis. Use vi.stubGlobal / Object.defineProperty on globalThis to simulate the unavailable localStorage and restore it in afterEach so other tests are unaffected. Do NOT modify src/persistence.ts — this test must pass against the current implementation. Reuse the existing FakeStorage helper only where applicable; the fallback cases should NOT pass any storage argument so the default getDefaultStorage path is exercised.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*