### PR TITLE
test: Test Space keydown repeat does not re-set firePressed edge in keyboard.test.ts

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -208,6 +208,19 @@ describe("createKeyboardController", () => {
     expect(snapshot.fireHeld).toBe(true);
   });
 
+  it("does not re-arm firePressed when Space keydown repeats while held", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "Space");
+
+    expect(controller.snapshot().firePressed).toBe(true);
+
+    dispatchKeyDown(target, "Space");
+
+    expect(controller.snapshot().firePressed).toBe(false);
+  });
+
   for (const { code, edgeField, heldField, label } of repeatGuardCases) {
     it(`does not re-emit the ${label} edge on auto-repeat keydown and re-arms after keyup`, () => {
       const target = createTarget();


### PR DESCRIPTION
## Test Space keydown repeat does not re-set firePressed edge in keyboard.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #766

### Changes
Add a focused test in src/input/keyboard.test.ts that verifies the OS key-repeat suppression for Space's firePressed edge. The test should: (1) create a keyboard controller against a fake Window target (use the existing helpers in the file: createTarget, dispatchKeyDown), (2) dispatch a first 'keydown' for 'Space', (3) call snapshot() and assert firePressed === true (consuming the edge), (4) dispatch a second 'keydown' for 'Space' WITHOUT an intervening keyup (simulating OS auto-repeat), (5) call snapshot() again and assert firePressed === false. This locks in the `if (!held.fire)` guard at src/input/keyboard.ts:28-32 that prevents repeat keydown events from re-arming the fire edge while the key is still held. Place the new test inside the existing `describe('createKeyboardController', ...)` block. Use only the helpers and shims already present in the file — do not import new modules or create new fakes. Name the test something like 'does not re-arm firePressed when Space keydown repeats while held'.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*