### PR TITLE
test: Test that blur clears unconsumed firePressed and pausePressed edges in keyboard.test.ts

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -167,6 +167,22 @@ describe("createKeyboardController", () => {
     expect(snapshot.fireHeld).toBe(false);
   });
 
+  it("clears unconsumed fire and pause edges on blur before snapshot", () => {
+    const target = createTarget();
+    const controller = createKeyboardController(target);
+
+    dispatchKeyDown(target, "Space");
+    dispatchKeyDown(target, "KeyP");
+    dispatchBlur(target);
+
+    const snapshot = controller.snapshot();
+
+    expect(snapshot.firePressed).toBe(false);
+    expect(snapshot.pausePressed).toBe(false);
+    expect(snapshot.fireHeld).toBe(false);
+    expect(snapshot.pauseHeld).toBe(false);
+  });
+
   it("clears an unconsumed pause edge on blur before snapshot", () => {
     const target = createTarget();
     const controller = createKeyboardController(target);


### PR DESCRIPTION
## Test that blur clears unconsumed firePressed and pausePressed edges in keyboard.test.ts

**Category:** `test` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #749

### Changes
Add a new `it(...)` case inside the existing `describe("createKeyboardController", ...)` block in src/input/keyboard.test.ts that asserts the blur reset path in src/input/keyboard.ts clears unconsumed fire and pause edges. The test must: (1) create a controller bound to a FakeWindow target via the existing `createTarget()` helper; (2) dispatch a `Space` keydown and a `KeyP` keydown via `dispatchKeyDown(target, ...)` WITHOUT calling `snapshot()` in between (so the edges remain unconsumed); (3) dispatch `blur` via `dispatchBlur(target)`; (4) call `snapshot()` once and assert the returned `Input.firePressed === false` AND `Input.pausePressed === false`. Optionally also assert `fireHeld === false` and `pauseHeld === false` to round out the blur-reset contract. Use the existing helpers and FakeWindow harness already defined in the file — do not introduce new helpers or alter existing tests. Do not modify src/input/keyboard.ts. The test must pass against the current implementation; if it fails, that indicates a real regression in onBlur and you should report it rather than weakening the assertion.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*