### PR TITLE
test: Unit-test createHighScoreStore.recordScore persistence behavior

### DIFF
--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -310,6 +310,64 @@ describe("createHighScoreStore", () => {
     }
   );
 
+  describe("createHighScoreStore.recordScore", () => {
+    const parseSetItemCalls = (
+      storage: FakeStorage
+    ): Array<{ key: string; value: number }> =>
+      storage.setItemCalls.map(({ key, value }) => ({
+        key,
+        value: Number(value)
+      }));
+
+    it("persists a strictly higher score and returns the new high score", () => {
+      const storage = new FakeStorage();
+      storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+      const store = createHighScoreStore(storage);
+
+      expect(store.recordScore(360)).toBe(360);
+      expect(parseSetItemCalls(storage)).toEqual([
+        { key: HIGH_SCORE_STORAGE_KEY, value: 360 }
+      ]);
+    });
+
+    it("returns the existing high score without writing for lower or equal scores", () => {
+      const storage = new FakeStorage();
+      storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+      const store = createHighScoreStore(storage);
+
+      expect(store.recordScore(360)).toBe(360);
+      const setItemCallsAfterNewRecord = parseSetItemCalls(storage);
+
+      expect(setItemCallsAfterNewRecord).toEqual([
+        { key: HIGH_SCORE_STORAGE_KEY, value: 360 }
+      ]);
+
+      expect(store.recordScore(359)).toBe(360);
+      expect(parseSetItemCalls(storage)).toEqual(setItemCallsAfterNewRecord);
+
+      expect(store.recordScore(360)).toBe(360);
+      expect(parseSetItemCalls(storage)).toEqual(setItemCallsAfterNewRecord);
+    });
+
+    it("keeps the bumped high score in memory when persisting throws", () => {
+      const storage = new FakeStorage();
+      storage.seed(HIGH_SCORE_STORAGE_KEY, "220");
+      storage.throwOnSet = true;
+      const store = createHighScoreStore(storage);
+      let recordedHighScore = Number.NaN;
+
+      expect(() => {
+        recordedHighScore = store.recordScore(360);
+      }).not.toThrow();
+
+      expect(recordedHighScore).toBe(360);
+      expect(store.recordScore(360)).toBe(360);
+      expect(store.recordScore(300)).toBe(360);
+      expect(parseSetItemCalls(storage)).toEqual([]);
+      expect(storage.getItem(HIGH_SCORE_STORAGE_KEY)).toBe("220");
+    });
+  });
+
   describe("when storage throws", () => {
     it("returns 0 when reading the stored high score throws", () => {
       const storage = new FakeStorage();


### PR DESCRIPTION
## Unit-test createHighScoreStore.recordScore persistence behavior

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #775

### Changes
Extend src/persistence.test.ts with a `describe('createHighScoreStore.recordScore', ...)` block that uses the existing FakeStorage helper to drive the store created by `createHighScoreStore` from src/persistence.ts. Add at least three tests covering: (1) recording a strictly higher score persists via setItem under the HIGH_SCORE_STORAGE_KEY and returns the new score; (2) recording a score lower than or equal to the current high returns the existing high score and FakeStorage.setItemCalls remains unchanged (no setItem invocation for that record); (3) when FakeStorage.throwOnSet is true, recordScore must not throw and must still return the new in-memory high score (subsequent recordScore calls observe the bumped high in memory even though storage rejected the write). Seed the FakeStorage with prior values via `seed()` where helpful and assert both the return value and `setItemCalls` contents (key + parsed value) for each case.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*