### PR TITLE
bug_fix: Test createMuteStore falls back to in-memory storage when localStorage throws

### DIFF
--- a/src/audio/mute.test.ts
+++ b/src/audio/mute.test.ts
@@ -7,6 +7,9 @@ const MUTE_STORAGE_KEY = "audio:muted";
 class FakeStorage implements Storage {
   private readonly entries = new Map<string, string>();
 
+  public throwOnGet = false;
+  public throwOnSet = false;
+
   get length(): number {
     return this.entries.size;
   }
@@ -16,6 +19,10 @@ class FakeStorage implements Storage {
   }
 
   getItem(key: string): string | null {
+    if (this.throwOnGet) {
+      throw new Error("getItem failed");
+    }
+
     return this.entries.get(key) ?? null;
   }
 
@@ -28,6 +35,10 @@ class FakeStorage implements Storage {
   }
 
   setItem(key: string, value: string): void {
+    if (this.throwOnSet) {
+      throw new Error("setItem failed");
+    }
+
     this.entries.set(key, value);
   }
 
@@ -77,6 +88,41 @@ describe("createMuteStore", () => {
       expect(store.isMuted()).toBe(false);
     }
   );
+
+  it("falls back to in-memory state when getItem and setItem throw", () => {
+    const storage = new FakeStorage();
+    storage.throwOnGet = true;
+    storage.throwOnSet = true;
+    let store!: ReturnType<typeof createMuteStore>;
+    let nextMuted = false;
+
+    expect(() => {
+      store = createMuteStore(storage);
+    }).not.toThrow();
+
+    expect(store.isMuted()).toBe(false);
+    expect(() => {
+      nextMuted = store.toggle();
+    }).not.toThrow();
+    expect(nextMuted).toBe(true);
+    expect(store.isMuted()).toBe(true);
+    expect(store.toggle()).toBe(false);
+  });
+
+  it("keeps the seeded muted value in memory when only setItem throws", () => {
+    const storage = new FakeStorage();
+    storage.seed(MUTE_STORAGE_KEY, "true");
+    storage.throwOnSet = true;
+    const store = createMuteStore(storage);
+    let nextMuted = true;
+
+    expect(store.isMuted()).toBe(true);
+    expect(() => {
+      nextMuted = store.toggle();
+    }).not.toThrow();
+    expect(nextMuted).toBe(false);
+    expect(store.isMuted()).toBe(false);
+  });
 
   it("notifies subscribers on toggle and stops after unsubscribe", () => {
     const storage = new FakeStorage();


### PR DESCRIPTION
## Test createMuteStore falls back to in-memory storage when localStorage throws

**Category:** `bug_fix` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #803

### Changes
Add a vitest case in src/audio/mute.test.ts that constructs createMuteStore with a Storage stub whose getItem/setItem throw (use a flag like throwOnGet/throwOnSet in the FakeStorage class, mirroring src/persistence.test.ts). Verify the constructor does not throw, isMuted() defaults to false when getItem throws, toggle() returns the new value (true) without throwing when setItem throws, a subsequent isMuted() returns the in-memory value (true), and a second toggle() returns false. Also add a case where storage is the FakeStorage that throws only on setItem, seeded with `audio:muted=true` for getItem, asserting isMuted() reads true initially and toggle() flips to false in memory without crashing. If the current implementation of readStoredMuted/writeStoredMuted does not already wrap getItem/setItem in try/catch (so a throwing Storage propagates the error), update src/audio/mute.ts to catch storage errors in those helpers and fall back to the in-memory value, mirroring how src/persistence.ts guards localStorage access. Use the MUTE_STORAGE_KEY constant 'audio:muted' already declared in the test file. Do not change the public MuteStore API.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*