### PR TITLE
test: Test AudioEngine.scheduleTone cooldown drops tagged tones within window and re-allows after

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -430,6 +430,45 @@ describe("createAudioEngine", () => {
     expect(context.createGain).toHaveBeenCalledTimes(2);
   });
 
+  it("drops tagged tones within the cooldown window and re-allows them after", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+    await engine.arm();
+
+    const context = getLastContext(harness);
+    const toneOptions: ScheduleToneOptions = {
+      tag: "shoot",
+      cooldownSeconds: 0.1,
+      frequency: 720,
+      duration: 0.09,
+      gain: 0.06,
+      type: "square"
+    };
+
+    context.currentTime = 3;
+    engine.scheduleTone(toneOptions);
+
+    const firstOscillator = harness.oscillators[0];
+
+    if (firstOscillator === undefined) {
+      throw new Error("Expected the first oscillator to be scheduled.");
+    }
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+    expect(context.createGain).toHaveBeenCalledTimes(1);
+    expect(firstOscillator.start).toHaveBeenCalledWith(3);
+
+    engine.scheduleTone(toneOptions);
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(1);
+    expect(context.createGain).toHaveBeenCalledTimes(1);
+
+    context.currentTime += 0.2;
+    engine.scheduleTone(toneOptions);
+
+    expect(context.createOscillator).toHaveBeenCalledTimes(2);
+    expect(context.createGain).toHaveBeenCalledTimes(2);
+  });
+
   it("does not gate consecutive tones when tag is provided without cooldownSeconds", async () => {
     const engine = createAudioEngine({ createContext: harness.createContext });
     await engine.arm();


### PR DESCRIPTION
## Test AudioEngine.scheduleTone cooldown drops tagged tones within window and re-allows after

**Category:** `test` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #790

### Changes
Add a new test case (or describe block) in src/audio/engine.test.ts that exercises the cooldown branch of scheduleTone in src/audio/engine.ts. Build a mock AudioContextLike whose currentTime is mutable (mirroring the existing MockAudioContext shape already in this test file), arm the engine, then: (1) call scheduleTone with a tag (e.g. 'shoot') and cooldownSeconds: 0.1 — assert createOscillator/createGain were called once and the oscillator's start was scheduled; (2) without advancing currentTime, call scheduleTone again with the same tag and cooldown — assert no new oscillator or gain node was created (createOscillator call count unchanged); (3) advance the mock context's currentTime past the cooldown window (e.g. set currentTime += 0.2) and call scheduleTone a third time with the same tag — assert a new oscillator and gain node were created (createOscillator call count increments). Reuse the existing mock helpers and ScheduleToneOptions type already imported at the top of the file. Do NOT modify src/audio/engine.ts — the cooldown behavior already exists; this test fills the coverage gap.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*