### PR TITLE
test: Test AudioEngine.arm reports muted when context creation throws

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -214,21 +214,29 @@ describe("createAudioEngine", () => {
     expect(engine.getStatus()).toBe("ready");
   });
 
-  it.each([
-    {
-      label: "context construction fails",
-      prepare: (mockHarness: MockWebAudioHarness) => {
-        mockHarness.failOnCreate = true;
-      }
-    },
-    {
-      label: "context resume fails",
-      prepare: (mockHarness: MockWebAudioHarness) => {
-        mockHarness.failOnResume = true;
-      }
-    }
-  ])("reports muted when $label", async ({ prepare }) => {
-    prepare(harness);
+  it("reports muted and skips scheduling when context creation fails", async () => {
+    harness.failOnCreate = true;
+    const engine = createAudioEngine({ createContext: harness.createContext });
+
+    await expect(engine.arm()).resolves.toBeUndefined();
+
+    expect(engine.getStatus()).toBe("muted");
+
+    engine.scheduleTone({
+      frequency: 440,
+      duration: 0.1,
+      gain: 0.06,
+      type: "square"
+    });
+
+    expect(harness.createContext).toHaveBeenCalledTimes(1);
+    expect(harness.contexts).toHaveLength(0);
+    expect(harness.oscillators).toHaveLength(0);
+    expect(harness.gains).toHaveLength(0);
+  });
+
+  it("reports muted when context resume fails", async () => {
+    harness.failOnResume = true;
     const engine = createAudioEngine({ createContext: harness.createContext });
 
     await engine.arm();


### PR DESCRIPTION
## Test AudioEngine.arm reports muted when context creation throws

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #782

### Changes
Add a new test case to src/audio/engine.test.ts that verifies the AudioEngine sets status to 'muted' when context creation fails. Inject a `createContext` factory (via the existing CreateAudioEngineOptions hook used elsewhere in the test file) that throws an Error when invoked. Call `engine.arm()` (await it — the engine should resolve, not reject, since the failure is caught internally), then assert `engine.getStatus()` returns 'muted'. Also call `engine.scheduleTone(...)` after the failed arm and assert it is a no-op (the injected factory's oscillator/gain mocks should not have been created — i.e., the throwing factory was only invoked once during arm and not on subsequent scheduleTone calls, or any mock createOscillator/createGain were never called). Mirror the existing test setup conventions in this file (mock builders, beforeEach/afterEach with vi timers if used). Do NOT modify src/audio/engine.ts — the try/catch behavior already exists; this test only exercises an existing documented failure path.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*