### PR TITLE
test: Test AudioEngine.arm() is idempotent and reuses the same AudioContext

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -171,6 +171,26 @@ describe("createAudioEngine", () => {
     vi.restoreAllMocks();
   });
 
+  describe("AudioEngine.arm idempotency", () => {
+    it("reuses the same audio context across repeated arm calls", async () => {
+      const stableContextHarness = createMockWebAudioHarness("suspended");
+      const stableContext = stableContextHarness.createContext();
+      const createContext = vi
+        .fn<() => MockAudioContext>()
+        .mockReturnValue(stableContext);
+      const engine = createAudioEngine({ createContext });
+
+      await engine.arm();
+
+      expect(engine.getStatus()).toBe("ready");
+
+      await engine.arm();
+
+      expect(createContext).toHaveBeenCalledTimes(1);
+      expect(engine.getStatus()).toBe("ready");
+    });
+  });
+
   it("arms a suspended context once and reuses it across repeated arm calls", async () => {
     const engine = createAudioEngine({ createContext: harness.createContext });
 


### PR DESCRIPTION
## Test AudioEngine.arm() is idempotent and reuses the same AudioContext

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #789

### Changes
Add a new test case to src/audio/engine.test.ts that verifies AudioEngine.arm() is idempotent across multiple calls. The test should: (1) create a createContext spy (e.g. vi.fn()) that returns a single, stable AudioContextLike mock instance, (2) pass it to createAudioEngine, (3) await engine.arm() twice in sequence, (4) assert the createContext spy was called exactly once, and (5) assert engine.getStatus() returns "ready" after both calls. This locks down the lazy getOrCreateContext behavior in src/audio/engine.ts so that re-arming (e.g. after a visibility resume) does not recreate the AudioContext and therefore does not blow away internal cooldown bookkeeping like lastScheduledAtByTag. Reuse the existing MockAudioContext / MockGainNode / MockOscillatorNode test helpers already defined at the top of the file rather than introducing new mock factories. Place the new test inside an appropriate describe block (existing arm-related describe if present, or add one named "AudioEngine.arm idempotency").

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*