### PR TITLE
test: Test AudioEngine.scheduleTone is a no-op before arm() is called

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -274,8 +274,11 @@ describe("createAudioEngine", () => {
     expect(context.createOscillator).toHaveBeenCalledTimes(1);
   });
 
-  it("does not schedule anything while idle", () => {
-    const idleEngine = createAudioEngine({ createContext: harness.createContext });
+  it("does not schedule anything before arm is called", () => {
+    const createContext = vi
+      .fn<() => MockAudioContext>()
+      .mockImplementation(() => harness.createContext());
+    const idleEngine = createAudioEngine({ createContext });
 
     idleEngine.scheduleTone({
       frequency: 440,
@@ -284,9 +287,12 @@ describe("createAudioEngine", () => {
       type: "square"
     });
 
+    expect(createContext).not.toHaveBeenCalled();
+    expect(harness.createContext).not.toHaveBeenCalled();
     expect(harness.contexts).toHaveLength(0);
     expect(harness.oscillators).toHaveLength(0);
     expect(harness.gains).toHaveLength(0);
+    expect(idleEngine.getStatus()).toBe("idle");
   });
 
   describe("AudioEngine.setMuted", () => {


### PR DESCRIPTION
## Test AudioEngine.scheduleTone is a no-op before arm() is called

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #717

### Changes
Add a unit test in src/audio/engine.test.ts that exercises the `status !== "ready"` early return branch of scheduleTone in src/audio/engine.ts. The test must: (1) build a mock AudioContextLike factory using a vi.fn() that, if invoked, would return a mock context (mirroring the existing helpers/types like MockAudioContext, MockOscillatorNode, MockGainNode in this file); (2) call createAudioEngine with that factory but never call arm(); (3) call scheduleTone(...) with valid options (frequency, duration, gain, type); (4) assert the createContext factory mock was never called, AND assert no createOscillator/createGain calls happened (since no context was constructed there are no nodes to inspect — verify by checking the factory itself was not invoked). Also assert engine.getStatus() is still "idle" after the scheduleTone call. Reuse existing mock helper patterns in the file rather than introducing new utilities, and keep the new test inside the existing top-level describe block (or a sibling describe such as `describe("scheduleTone before arm", ...)`) consistent with the file's style. Do not modify src/audio/engine.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*