### PR TITLE
test: Test AudioEngine.now() returns 0 before arm and currentTime after arm

### DIFF
--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -295,6 +295,20 @@ describe("createAudioEngine", () => {
     expect(idleEngine.getStatus()).toBe("idle");
   });
 
+  it("returns 0 before arm and the context currentTime after arm", async () => {
+    const engine = createAudioEngine({ createContext: harness.createContext });
+
+    expect(engine.now()).toBe(0);
+
+    await engine.arm();
+
+    const context = getLastContext(harness);
+
+    context.currentTime = 12.5;
+
+    expect(engine.now()).toBe(12.5);
+  });
+
   describe("AudioEngine.setMuted", () => {
     const toneOptions: ScheduleToneOptions = {
       frequency: 660,


### PR DESCRIPTION
## Test AudioEngine.now() returns 0 before arm and currentTime after arm

**Category:** `test` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #667

### Changes
Add a new test case (or describe block) inside src/audio/engine.test.ts that exercises AudioEngine.now(). Reuse the existing mock AudioContext setup pattern already present in the file. Assert that calling engine.now() before arm() returns 0 (the `context?.currentTime ?? 0` fallback in src/audio/engine.ts when no context exists yet). Then call await engine.arm() with the mock context factory, set the mock context's currentTime to a non-zero value (e.g. 12.5), and assert engine.now() returns that exact value. Make sure the test passes with the current implementation in src/audio/engine.ts — do not modify the engine.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*